### PR TITLE
Create hide_mac_app.sh

### DIFF
--- a/scripts/macos/hide_mac_app.sh
+++ b/scripts/macos/hide_mac_app.sh
@@ -1,0 +1,8 @@
+defaults write /Library/LaunchAgents/com.jumpcloud.jcagent-tray Disabled -bool true
+mkdir -p /opt/jc_user_ro
+touch /opt/jc_user_ro/dont_show_tray_app
+PERMISSIONS="$(ls -l /opt/jc_user_ro/dont_show_tray_app | cut -c -10)"
+if [ "$PERMISSIONS" != "-rw-r--r--" ]; then
+        echo "Permissions not right for file:  $PERMISSIONS"
+        exit 1
+fi

--- a/scripts/macos/hide_mac_app.sh
+++ b/scripts/macos/hide_mac_app.sh
@@ -1,8 +1,8 @@
+#!/bin/bash
+if [ $UID != 0 ]; then
+  (>&2 echo "Error:  $0 must be run as root")
+  exit 1
+fi
 defaults write /Library/LaunchAgents/com.jumpcloud.jcagent-tray Disabled -bool true
 mkdir -p /opt/jc_user_ro
 touch /opt/jc_user_ro/dont_show_tray_app
-PERMISSIONS="$(ls -l /opt/jc_user_ro/dont_show_tray_app | cut -c -10)"
-if [ "$PERMISSIONS" != "-rw-r--r--" ]; then
-        echo "Permissions not right for file:  $PERMISSIONS"
-        exit 1
-fi


### PR DESCRIPTION
This short script hides the Mac App from displaying for JumpCloud managed users. This must be run as root on systems where you would like to hide the Mac App.