### PR TITLE
Add script to repair failed Windows 64-bit upgrades

### DIFF
--- a/scripts/windows/RepairFailed64BitMigration.bat
+++ b/scripts/windows/RepairFailed64BitMigration.bat
@@ -4,7 +4,6 @@ rem We don't care about the output of this call, we just use it to verify we are
 net session >nul 2>&1
 if %errorlevel% neq 0 (
     echo Error: This script must be run as administrator
-    pause
     exit /B 1
 )
 
@@ -12,7 +11,6 @@ echo Reconfiguring the jumpcloud-agent service binary path
 sc config jumpcloud-agent binPath= "C:\Program Files\JumpCloud\jumpcloud-agent.exe"
 if %errorlevel% neq 0 (
     echo Error reconfiguring jumpcloud-agent service binary path. Cannot continue.
-    pause
     exit /B 1
 )
     
@@ -20,10 +18,8 @@ echo Restarting the jumpcloud-agent service
 sc start jumpcloud-agent
 if %errorlevel% neq 0 (
     echo Error restarting jumpcloud-agent service. Cannot continue.
-    pause
     exit /B 1
 )
 
 echo Successfully reconfigured and restarted the jumpcloud-agent service
-pause
 exit /B 0

--- a/scripts/windows/RepairFailed64BitMigration.bat
+++ b/scripts/windows/RepairFailed64BitMigration.bat
@@ -1,0 +1,29 @@
+rem This script repairs a broken agent install after encountering the 64-bit OS upgrade bug on v0.10.41 
+@echo off
+rem We don't care about the output of this call, we just use it to verify we are administrator
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Error: This script must be run as administrator
+    pause
+    exit /B 1
+)
+
+echo Reconfiguring the jumpcloud-agent service binary path
+sc config jumpcloud-agent binPath= "C:\Program Files\JumpCloud\jumpcloud-agent.exe"
+if %errorlevel% neq 0 (
+    echo Error reconfiguring jumpcloud-agent service binary path. Cannot continue.
+    pause
+    exit /B 1
+)
+    
+echo Restarting the jumpcloud-agent service
+sc start jumpcloud-agent
+if %errorlevel% neq 0 (
+    echo Error restarting jumpcloud-agent service. Cannot continue.
+    pause
+    exit /B 1
+)
+
+echo Successfully reconfigured and restarted the jumpcloud-agent service
+pause
+exit /B 0


### PR DESCRIPTION
This script repairs failed upgrades on 64-bit Windows systems by reconfiguring the service to point to the correct executable and starting the repaired service.