### PR TITLE
Shell out to agent remove script instead if it exists

### DIFF
--- a/scripts/macos/remove_mac_agent.sh
+++ b/scripts/macos/remove_mac_agent.sh
@@ -4,6 +4,13 @@ if [[ $(id -u) -ne 0 ]]; then
     exit 1
 fi
 
+AGENT_UNINSTALL_SCRIPT="/opt/jc/bin/removeAgent"
+
+if [[ -f $AGENT_UNINSTALL_SCRIPT ]]; then
+    $AGENT_UNINSTALL_SCRIPT
+    exit $?
+fi
+
 launchctl remove com.jumpcloud.darwin-agent
 rm /Library/LaunchDaemons/com.jumpcloud.darwin-agent.plist
 


### PR DESCRIPTION
The mac agent now contains an /opt/jc/bin/removeAgent script that will be versioned with the installed agent.  This change modifies the support script to first check for and run that script if it exists, otherwise perform the previous behavior.  This will allow the agent to add steps needed for uninstallation, without this support script needing to be modified and distributed on every change.