### PR TITLE
Fixed broken redirect in process check.

### DIFF
--- a/scripts/macos/remove_mac_agent.sh
+++ b/scripts/macos/remove_mac_agent.sh
@@ -45,7 +45,7 @@ rm -rf /Applications/Jumpcloud.app
 # verify no jumpcloud processes are still running. kill and straglers
 # implemented in response to desk case #28825.
 if (pgrep -fi "[j]umpcloud" &> /dev/null); then
-  for proc in $(pgrep -fi "[j]umpcloud" &> /dev/null); do
+  for proc in $(pgrep -fi "[j]umpcloud" 2> /dev/null); do
     kill -9 "${proc}"
   done
 fi


### PR DESCRIPTION
the recently added process check had an improper redirect to /dev/null, rendering it useless in actually killing processes left running after agent uninstall.