### PR TITLE
Sa 646 jw update time before syscontextapi

### DIFF
--- a/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
+++ b/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
@@ -70,7 +70,7 @@ WELCOME_TITLE=""
 ### DEPNotify Welcome Window Text use //n for line breaks ###
 WELCOME_TEXT=''
 
-### NTP server, set to time.apple.com by default used to ensure system time is correct ### 
+### NTP server, set to time.apple.com by default, Ensure time is correct ### 
 NTP_SERVER="time.apple.com"
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
+++ b/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
@@ -70,6 +70,9 @@ WELCOME_TITLE=""
 ### DEPNotify Welcome Window Text use //n for line breaks ###
 WELCOME_TEXT=''
 
+### NTP server, set to time.apple.com by default used to ensure system time is correct ### 
+NTP_SERVER="time.apple.com"
+
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # END General Settings                                                         ~
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -234,6 +237,13 @@ Sleep 1
 echo "Status: Pulling configuration settings from JumpCloud" >>"$DEP_N_LOG"
 
 # Add system to DEP_ENROLLMENT_GROUP_ID using System Context API Authentication
+
+# Ensure system time is set correctly Sierra-Mojave compatible
+MacOSMinorVersion=$(sw_vers -productVersion | cut -d '.' -f 2)
+if [[ MacOSMinorVersion -ge 12 ]]
+then
+    sntp -sS $NTP_SERVER
+fi
 
 conf="$(cat /opt/jc/jcagent.conf)"
 regex='\"systemKey\":\"[a-zA-Z0-9]{24}\"'


### PR DESCRIPTION
System Context API call will fail for systems with skewed time. Proposed change to compare the system time with a NTP server. If the system clock is out of sync, the sntp command will set the clock to the correct time based on the provided NTP server. 