### PR TITLE
Sa 646 jw remove first enrollment accounts

### DIFF
--- a/zero-touch/prestage_user_enrollment/CHANGELOG.md
+++ b/zero-touch/prestage_user_enrollment/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 1.1
+
+#### RELEASE DATE
+
+September 19, 2019
+
+#### RELEASE NOTES
+
+The jumpcloud_bootstrap_template.sh has been updated with logic to delete the `DECRYPT_USER` and the `ENROLLMENT_USER` accounts from the macOS system. This logic has been added to the end of the jumpcloud_bootstrap_template.sh.Removing the `ENROLLMENT_USER` is an important step as this user has a valid Secure Token and while they are disabled via the JumpCloud agent (In Version 1.0) their account will be present at the macOS FileVault decryption screen. By removing this account from the system the Secure Token is invalided and the account does not display at the FileVault decrypt screen.

--- a/zero-touch/prestage_user_enrollment/README.md
+++ b/zero-touch/prestage_user_enrollment/README.md
@@ -11,28 +11,28 @@ The JumpCloud Service Account is required to manage users on FileVault protected
 ![configuration_steps](https://github.com/TheJumpCloud/support/blob/master/zero-touch/prestage_user_enrollment/diagrams/configuration_steps.png?raw=true)
 
 **Table Of Contents**
-- [Prerequisites](#Prerequisites)
-  - [An Apple Device Enrollment (DEP) Account](#An-Apple-Device-Enrollment-DEP-Account)
-  - [An MDM server integrated with Apple DEP](#An-MDM-server-integrated-with-Apple-DEP)
-  - [An Apple Developer Account](#An-Apple-Developer-Account)
-  - [munkipkg or an alternative macOS PKG building tool or application](#munkipkg-or-an-alternative-macOS-PKG-building-tool-or-application)
-  - [Users who you wish to enroll using this zero-touch workflow added to the JumpCloud directory.](#Users-who-you-wish-to-enroll-using-this-zero-touch-workflow-added-to-the-JumpCloud-directory)
-- [Zero-Touch Enrollment Workflow Diagram](#Zero-Touch-Enrollment-Workflow-Diagram)
-- [Component Definitions](#Component-Definitions)
-- [Configuration Steps](#Configuration-Steps)
-  - [Step 1 - Download the JumpCloud Bootstrap template script](#Step-1---Download-the-JumpCloud-Bootstrap-template-script)
-  - [Step 2 - Configuring the JumpCloud Tenant For DEP Zero-Touch](#Step-2---Configuring-the-JumpCloud-Tenant-For-DEP-Zero-Touch)
-  - [Step 3 - Populating the Bootstrap template script variables](#Step-3---Populating-the-Bootstrap-template-script-variables)
-    - [Variable Definitions](#Variable-Definitions)
-  - [Step 4 - Selecting a User Configuration Module](#Step-4---Selecting-a-User-Configuration-Module)
-    - [Pending User Configuration Modules](#Pending-User-Configuration-Modules)
-    - [Pending or Active User Configuration Modules](#Pending-or-Active-User-Configuration-Modules)
-  - [Step 5 - Populating the Bootstrap template script with a User Configuration Module](#Step-5---Populating-the-Bootstrap-template-script-with-a-User-Configuration-Module)
-  - [Step 6 - Creaking a PKG from the Bootstrap template script using munkiPKG](#Step-6---Creaking-a-PKG-from-the-Bootstrap-template-script-using-munkiPKG)
-  - [Step 7 - Configuring MDM PreStage Settings](#Step-7---Configuring-MDM-PreStage-Settings)
-  - [Step 8 - Configuring the PKG for MDM deployment](#Step-8---Configuring-the-PKG-for-MDM-deployment)
-  - [Step 9 - Creating a Privacy Preference Policy](#Step-9---Creating-a-Privacy-Preference-Policy)
-- [Testing the workflow](#Testing-the-workflow)
+- [Prerequisites](#prerequisites)
+  - [An Apple Device Enrollment (DEP) Account](#an-apple-device-enrollment-dep-account)
+  - [An MDM server integrated with Apple DEP](#an-mdm-server-integrated-with-apple-dep)
+  - [An Apple Developer Account](#an-apple-developer-account)
+  - [munkipkg or an alternative macOS PKG building tool or application](#munkipkg-or-an-alternative-macos-pkg-building-tool-or-application)
+  - [Users who you wish to enroll using this zero-touch workflow added to the JumpCloud directory.](#users-who-you-wish-to-enroll-using-this-zero-touch-workflow-added-to-the-jumpcloud-directory)
+- [Zero-Touch Enrollment Workflow Diagram](#zero-touch-enrollment-workflow-diagram)
+- [Component Definitions](#component-definitions)
+- [Configuration Steps](#configuration-steps)
+  - [Step 1 - Download the JumpCloud Bootstrap template script](#step-1---download-the-jumpcloud-bootstrap-template-script)
+  - [Step 2 - Configuring the JumpCloud Tenant For DEP Zero-Touch](#step-2---configuring-the-jumpcloud-tenant-for-dep-zero-touch)
+  - [Step 3 - Populating the Bootstrap template script variables](#step-3---populating-the-bootstrap-template-script-variables)
+    - [Variable Definitions](#variable-definitions)
+  - [Step 4 - Selecting a User Configuration Module](#step-4---selecting-a-user-configuration-module)
+    - [Pending User Configuration Modules](#pending-user-configuration-modules)
+    - [Pending or Active User Configuration Modules](#pending-or-active-user-configuration-modules)
+  - [Step 5 - Populating the Bootstrap template script with a User Configuration Module](#step-5---populating-the-bootstrap-template-script-with-a-user-configuration-module)
+  - [Step 6 - Creaking a PKG from the Bootstrap template script using munkiPKG](#step-6---creaking-a-pkg-from-the-bootstrap-template-script-using-munkipkg)
+  - [Step 7 - Configuring MDM PreStage Settings](#step-7---configuring-mdm-prestage-settings)
+  - [Step 8 - Configuring the PKG for MDM deployment](#step-8---configuring-the-pkg-for-mdm-deployment)
+  - [Step 9 - Creating a Privacy Preference Policy](#step-9---creating-a-privacy-preference-policy)
+- [Testing the workflow](#testing-the-workflow)
 
 ## Prerequisites
 
@@ -254,6 +254,13 @@ WELCOME_TITLE=""
 ### DEPNotify Welcome Window Text use //n for line breaks ###
 WELCOME_TEXT=''
 
+### Boolean to delete the enrollment user set through MDM ###
+DELETE_ENROLLMENT_USERS=true
+
+### Username of the enrollment user account configured in the MDM.
+### This account will be deleted if the above boolean is set to true.
+ENROLLMENT_USER=""
+
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # END General Settings                                                         ~
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -362,6 +369,15 @@ Enter welcome text that will load when DEPNotify launches.
 
 Use \\n for line breaks.
 
+- `DELETE_ENROLLMENT_USERS=true`
+
+A Boolean variable that by default is set to true. This variable controls if the `DECRYPT_USER` and `ENROLLMENT_USER` accounts are deleted from the system at the end of the flow. It is recommend to leave this variable set to True to ensure that these users are removed.
+
+
+- `ENROLLMENT_USER=""`
+
+The username of the MDM enrollment user pushed down to the machine.
+
 Example of populated variables:
 
 ```SH
@@ -398,6 +414,14 @@ WELCOME_TITLE="Welcome to Azzipa.\\n Where we make backwards pizzas."
 
 ### DEPNotify Welcome Window Text use \\n for line breaks ###
 WELCOME_TEXT='Sit back and relax as your computer configures itself for you. \\n\\n After configuration settings download you will be asked to activate your account and set a password!'
+
+### Boolean to delete the enrollment user set through MDM ###
+DELETE_ENROLLMENT_USERS=true
+
+### Username of the enrollment user account configured in the MDM.
+### This account will be deleted if the above boolean is set to true.
+ENROLLMENT_USER="Welcome"
+
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # END General Settings                                                         ~

--- a/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
+++ b/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
@@ -73,6 +73,13 @@ WELCOME_TEXT=''
 ### NTP server, set to time.apple.com by default, Ensure time is correct ### 
 NTP_SERVER="time.apple.com"
 
+### Boolean to delete the enrollment user set through MDM ###
+DELETE_ENROLLMENT_USERS=true
+
+### short name of the inital user account, this account will be deleted is the 
+### above boolean is set to true. 
+FIRST_ENROLLMENT_USER="Welcome"
+
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # END General Settings                                                         ~
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -458,6 +465,18 @@ while [[ -z "${groupTakeOverCheck}" ]]; do
 done
 
 FINISH_TITLE="All Done"
+
+if [[ $DELETE_ENROLLMENT_USERS = true ]]
+then
+    # delete the first logged in user 
+    Sleep 10
+    echo "$(date "+%Y-%m-%dT%H:%M:%S") Deleting the first enrollment user: $FIRST_ENROLLMENT_USER" >>"$DEP_N_DEBUG"
+    dscl . -delete /Users/$FIRST_ENROLLMENT_USER
+    rm -rf /Users/$FIRST_ENROLLMENT_USER
+    echo "$(date "+%Y-%m-%dT%H:%M:%S") Deleting the decrypt user: $DECRYPT_USER" >>"$DEP_N_DEBUG"
+    dscl . -delete /Users/$DECRYPT_USER
+    rm -rf /Users/$DECRYPT_USER
+fi
 
 echo "Command: MainTitle: $FINISH_TITLE" >>"$DEP_N_LOG"
 echo "Status: Enrollment Complete" >>"$DEP_N_LOG"

--- a/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
+++ b/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
@@ -70,7 +70,7 @@ WELCOME_TITLE=""
 ### DEPNotify Welcome Window Text use //n for line breaks ###
 WELCOME_TEXT=''
 
-### NTP server, set to time.apple.com by default used to ensure system time is correct ### 
+### NTP server, set to time.apple.com by default, Ensure time is correct ### 
 NTP_SERVER="time.apple.com"
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
+++ b/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
@@ -2,6 +2,8 @@
 
 #*******************************************************************************
 #
+#       Version 1.1 | See the CHANGELOG.md for version information
+#
 #       See the ReadMe file for detailed configuration steps.
 #
 #       The "jumpcloud_bootstrap_template.sh" is a template file. Populate the
@@ -32,7 +34,8 @@
 #       Questions or feedback on the JumpCloud bootstrap workflow? Please
 #       contact support@jumpcloud.com
 #
-#       Author: Scott Reed | scott.reed@jumpcloud.com
+#       Authors: Scott Reed | scott.reed@jumpcloud.com
+#               Joe Workman | joe.workman@jumpcloud.com
 #
 #*******************************************************************************
 
@@ -73,9 +76,9 @@ WELCOME_TEXT=''
 ### Boolean to delete the enrollment user set through MDM ###
 DELETE_ENROLLMENT_USERS=true
 
-### short name of the inital user account, this account will be deleted is the 
-### above boolean is set to true. 
-FIRST_ENROLLMENT_USER="Welcome"
+### Username of the enrollment user account configured in the MDM.
+### This account will be deleted if the above boolean is set to true.
+ENROLLMENT_USER=""
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # END General Settings                                                         ~
@@ -455,18 +458,16 @@ done
 
 FINISH_TITLE="All Done"
 
-if [[ $DELETE_ENROLLMENT_USERS = true ]]
-then
-    # delete the first logged in user 
+if [[ $DELETE_ENROLLMENT_USERS == true ]]; then
+    # delete the first logged in user
     Sleep 10
-    echo "$(date "+%Y-%m-%dT%H:%M:%S") Deleting the first enrollment user: $FIRST_ENROLLMENT_USER" >>"$DEP_N_DEBUG"
-    dscl . -delete /Users/$FIRST_ENROLLMENT_USER
-    rm -rf /Users/$FIRST_ENROLLMENT_USER
+    echo "$(date "+%Y-%m-%dT%H:%M:%S") Deleting the first enrollment user: $ENROLLMENT_USER" >>"$DEP_N_DEBUG"
+    dscl . -delete /Users/$ENROLLMENT_USER
+    rm -rf /Users/$ENROLLMENT_USER
     echo "$(date "+%Y-%m-%dT%H:%M:%S") Deleting the decrypt user: $DECRYPT_USER" >>"$DEP_N_DEBUG"
     dscl . -delete /Users/$DECRYPT_USER
     rm -rf /Users/$DECRYPT_USER
 fi
-
 
 echo "Command: MainTitle: $FINISH_TITLE" >>"$DEP_N_LOG"
 echo "Status: Enrollment Complete" >>"$DEP_N_LOG"

--- a/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
+++ b/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
@@ -73,13 +73,6 @@ WELCOME_TEXT=''
 ### NTP server, set to time.apple.com by default, Ensure time is correct ### 
 NTP_SERVER="time.apple.com"
 
-### Boolean to delete the enrollment user set through MDM ###
-DELETE_ENROLLMENT_USERS=true
-
-### short name of the inital user account, this account will be deleted is the 
-### above boolean is set to true. 
-FIRST_ENROLLMENT_USER="Welcome"
-
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # END General Settings                                                         ~
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -465,18 +458,6 @@ while [[ -z "${groupTakeOverCheck}" ]]; do
 done
 
 FINISH_TITLE="All Done"
-
-if [[ $DELETE_ENROLLMENT_USERS = true ]]
-then
-    # delete the first logged in user 
-    Sleep 10
-    echo "$(date "+%Y-%m-%dT%H:%M:%S") Deleting the first enrollment user: $FIRST_ENROLLMENT_USER" >>"$DEP_N_DEBUG"
-    dscl . -delete /Users/$FIRST_ENROLLMENT_USER
-    rm -rf /Users/$FIRST_ENROLLMENT_USER
-    echo "$(date "+%Y-%m-%dT%H:%M:%S") Deleting the decrypt user: $DECRYPT_USER" >>"$DEP_N_DEBUG"
-    dscl . -delete /Users/$DECRYPT_USER
-    rm -rf /Users/$DECRYPT_USER
-fi
 
 echo "Command: MainTitle: $FINISH_TITLE" >>"$DEP_N_LOG"
 echo "Status: Enrollment Complete" >>"$DEP_N_LOG"

--- a/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
+++ b/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
@@ -70,6 +70,9 @@ WELCOME_TITLE=""
 ### DEPNotify Welcome Window Text use //n for line breaks ###
 WELCOME_TEXT=''
 
+### NTP server, set to time.apple.com by default used to ensure system time is correct ### 
+NTP_SERVER="time.apple.com"
+
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # END General Settings                                                         ~
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -234,6 +237,13 @@ Sleep 1
 echo "Status: Pulling configuration settings from JumpCloud" >>"$DEP_N_LOG"
 
 # Add system to DEP_ENROLLMENT_GROUP_ID using System Context API Authentication
+
+# Ensure system time is set correctly Sierra-Mojave compatible
+MacOSMinorVersion=$(sw_vers -productVersion | cut -d '.' -f 2)
+if [[ MacOSMinorVersion -ge 12 ]]
+then
+    sntp -sS $NTP_SERVER
+fi
 
 conf="$(cat /opt/jc/jcagent.conf)"
 regex='\"systemKey\":\"[a-zA-Z0-9]{24}\"'


### PR DESCRIPTION
Reverted changes from previous branch/ kept issue with time sync in other branch. 

Added variable for the short name of the welcome (first user) account to be deleted at the end of the flow. if the DELETE_ENROLLMENT_USERS bool is switched to false, the script will not delete the first users. It could be useful for admins who opt to run through the prestage before distribution to the end user. 