### PR TITLE
add check for username and different named home accounts

### DIFF
--- a/scripts/macos/RenameMacUserNameAndHomeDirectory.sh
+++ b/scripts/macos/RenameMacUserNameAndHomeDirectory.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 ###############################################################################
-# Version 1.1
+# Version 1.2
 #
 # RenameMacUserNameAndHomeDirectory.sh - Script to rename the username of a
-#       user account on MacOS. The script updates the users record name (username)
-#		, and home directory.  If the user receiving the name change is signed in
-#		they will be signed out.
+# user account on MacOS. The script updates the users record name (username),
+# and home directory.  If the user receiving the name change is signed in
+# they will be signed out.
 #
 # Example usage: sudo sh RenameMacUserNameAndHomeDirectory.sh cat dog
 #
 # Above example would rename account cat to dog
 #
 # NOTE: SCRIPT MUST BE RUN AS ROOT
+# NOTE: TERMINAL MUST BE GRANTED FULL DISK ACCESS TO RUN SUCCESSFULLY
 # NOTE: SYSTEM WILL RESTART AFTER SCRIPT IS RUN
 #
 # Questions or issues with the operation of the script, please contact
@@ -36,6 +37,14 @@ if [[ "${UID}" != 0 ]]; then
 	exit 1
 fi
 
+# Ensure Terminal has been granted Full Disk Access
+sqlite3 /Library/Application\ Support/com.apple.TCC/TCC.db 'SELECT * from access'
+# accessStatus=(${access} | grep "unable")
+if [[ $? -ne 0 ]]; then
+    echo "${log} Error: Terminal does not appear to have the correct access!" 2>&1 | tee -a JC_RENAME.log
+    echo "${log} Has Terminal been granted Full Disk Access?" 2>&1 | tee -a JC_RENAME.log
+    exit 1
+fi
 # Ensures that the system is not domain bound
 readonly domainBoundCheck=$(dsconfigad -show)
 if [[ "${domainBoundCheck}" ]]; then

--- a/scripts/macos/RenameMacUserNameAndHomeDirectory.sh
+++ b/scripts/macos/RenameMacUserNameAndHomeDirectory.sh
@@ -41,9 +41,9 @@ fi
 sqlite3 /Library/Application\ Support/com.apple.TCC/TCC.db 'SELECT * from access'
 # accessStatus=(${access} | grep "unable")
 if [[ $? -ne 0 ]]; then
-    echo "${log} Error: Terminal does not appear to have the correct access!" 2>&1 | tee -a JC_RENAME.log
-    echo "${log} Has Terminal been granted Full Disk Access?" 2>&1 | tee -a JC_RENAME.log
-    exit 1
+	echo "${log} Error: Terminal does not appear to have the correct access!" 2>&1 | tee -a JC_RENAME.log
+	echo "${log} Grant terminal Full Disk Access and try again." 2>&1 | tee -a JC_RENAME.log
+	exit 1
 fi
 # Ensures that the system is not domain bound
 readonly domainBoundCheck=$(dsconfigad -show)
@@ -107,9 +107,9 @@ fi
 # Check if username differs from home directory name
 actual=$(eval echo "~${oldUser}")
 if [[ "/Users/${oldUser}" != "$actual" ]]; then
-    echo "${log} Error: Username differs from home directory name!" 2>&1 | tee -a JC_RENAME.log
-    echo "${log} Error: home directory: ${actual} should be: /Users/${oldUser}, aborting." 2>&1 | tee -a JC_RENAME.log
-    exit 1
+	echo "${log} Error: Username differs from home directory name!" 2>&1 | tee -a JC_RENAME.log
+	echo "${log} Error: home directory: ${actual} should be: /Users/${oldUser}, aborting." 2>&1 | tee -a JC_RENAME.log
+	exit 1
 fi
 
 # Checks if user is logged in

--- a/scripts/macos/RenameMacUserNameAndHomeDirectory.sh
+++ b/scripts/macos/RenameMacUserNameAndHomeDirectory.sh
@@ -95,6 +95,14 @@ if [[ " ${existingHomeFolders[@]} " =~ " ${newUser} " ]]; then
 	exit 1
 fi
 
+# Check if username differs from home directory name
+actual=$(eval echo "~${oldUser}")
+if [[ "/Users/${oldUser}" != "$actual" ]]; then
+    echo "${log} Error: Username differs from home directory name!" 2>&1 | tee -a JC_RENAME.log
+    echo "${log} Error: home directory: ${actual} should be: /Users/${oldUser}, aborting." 2>&1 | tee -a JC_RENAME.log
+    exit 1
+fi
+
 # Checks if user is logged in
 loginCheck=$(ps -Ajc | grep ${oldUser} | grep loginwindow | awk '{print $2}')
 
@@ -163,7 +171,6 @@ Success ${oldUser} username has been updated to ${newUser}
 Folder "${origHomeDir}" has been renamed to "/Users/${newUser}"
 RecordName: ${newUser}
 NFSHomeDirectory: "/Users/${newUser}"
-
 SYSTEM RESTARTING in 5 seconds to complete username update.
 EOM
 


### PR DESCRIPTION
Add two checks to the macOS rename script:
1) Add a check to see if Terminal has been granted full disk access. Abort if Terminal does not have full disk access.
2) Add a check to see if the account to be renamed differs from the home directory. If the home directory account name differs from the username to be renamed, the script will abort.