### PR TITLE
Sa 736 jw delay welcome user files deletion

### DIFF
--- a/zero-touch/prestage_user_enrollment/CHANGELOG.md
+++ b/zero-touch/prestage_user_enrollment/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### RELEASE DATE
 
-December 3, 2019
+December 5, 2019
 
 #### RELEASE NOTES
 

--- a/zero-touch/prestage_user_enrollment/CHANGELOG.md
+++ b/zero-touch/prestage_user_enrollment/CHANGELOG.md
@@ -12,6 +12,10 @@ Slight change to the logic at the end of the script for deleting the enrollment 
 
 The user deletion step now occurs in the last stage. Deletion should only occur when either a different user other than the enrollment user is logged in or at the login window. This solves the potential issue where remnant files of the enrollment user and decrypt user account remain after deletion. Running the `sysadminctl` command to delete users absolves the need to run `rm -rf /User/EnrollmentUser` to clean up the user files.
 
+The bootstrap script is now caffeinated to prevent systems from falling asleep during the enrollment process. `caffeinate` code blocks the first three gates prevent the system from sleeping. That caffeinate process is killed at the end of each code block. the caffeinate process is not called during the last code block where the launch daemon is deleted.
+
+The user module password prompt should now timeout after thirty minutes rather than the default two minutes. In previous versions of the bootstrap script, the dialogue box would open a new password prompt every two mins if the enrollment user did not enter their password. This is generally avoidable since the enrollment user must click continue before proceeding to the password prompt. If an enrollment user walked away at this stage, the script should wait thirty minutes before timing out and checking for a password.
+
 ## 2.0
 
 ### RELEASE DATE

--- a/zero-touch/prestage_user_enrollment/CHANGELOG.md
+++ b/zero-touch/prestage_user_enrollment/CHANGELOG.md
@@ -8,9 +8,9 @@ December 3, 2019
 
 #### RELEASE NOTES
 
-Slight change to the logic at the end of the script for deleting the enrollment and decrypt users. Switch to using sysadminctl instead of dscl to delete enrollment and decrypt users. The sysadminctl command was introduced in 10.13 macOS High Sierra. Thus, High Sierra is the minimum required version of macOS required to run this workflow.
+Slight change to the logic at the end of the script for deleting the enrollment and decrypt users. Switch to using `sysadminctl` instead of `dscl` commands to delete enrollment and decrypt users. The sysadminctl command was introduced in 10.13 macOS High Sierra. Thus, High Sierra is the minimum required version of macOS required to run this workflow.
 
-The user deletion step now occurs in the last stage. Deletion should only occur when either a different user other than the enrollment user is logged in or at the login window. This solves the potential issue where remnant files of the enrollment user and decrypt user account remain after deletion. Running the sysadminctl command to delete users absolves the need to run rm -rf /User/EnrollmentUser to clean up the user files.
+The user deletion step now occurs in the last stage. Deletion should only occur when either a different user other than the enrollment user is logged in or at the login window. This solves the potential issue where remnant files of the enrollment user and decrypt user account remain after deletion. Running the `sysadminctl` command to delete users absolves the need to run `rm -rf /User/EnrollmentUser` to clean up the user files.
 
 ## 2.0
 

--- a/zero-touch/prestage_user_enrollment/CHANGELOG.md
+++ b/zero-touch/prestage_user_enrollment/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.1
+
+### RELEASE DATE
+
+December 3, 2019
+
+#### RELEASE NOTES
+
+Slight change to the logic at the end of the script for deleting the enrollment and decrypt users. Switch to using sysadminctl instead of dscl to delete enrollment and decrypt users. The sysadminctl command was introduced in 10.13 macOS High Sierra. Thus, High Sierra is the minimum required version of macOS required to run this workflow.
+
+The user deletion step now occurs in the last stage. Deletion should only occur when either a different user other than the enrollment user is logged in or at the login window. This solves the potential issue where remnant files of the enrollment user and decrypt user account remain after deletion. Running the sysadminctl command to delete users absolves the need to run rm -rf /User/EnrollmentUser to clean up the user files.
+
 ## 2.0
 
 ### RELEASE DATE

--- a/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
+++ b/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
@@ -2,7 +2,7 @@
 
 #*******************************************************************************
 #
-#       Version 2.0 | See the CHANGELOG.md for version information
+#       Version 2.1 | See the CHANGELOG.md for version information
 #
 #       See the ReadMe file for detailed configuration steps.
 #

--- a/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
+++ b/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
@@ -146,6 +146,9 @@ DEP_N_GATE_DONE="/var/tmp/com.jumpcloud.gate.done"
 #*******************************************************************************
 # First condition - is JC installed
 if [[ ! -f $DEP_N_GATE_INSTALLJC ]]; then
+    # Caffeinate this script
+    caffeinate -d -i -m -u &
+    caffeinatePID=$!
 
     # Install DEPNotify
     curl --silent --output /tmp/DEPNotify-1.1.5.pkg "https://s3.amazonaws.com/nomadbetas/DEPNotify-1.1.5.pkg" >/dev/null
@@ -255,11 +258,16 @@ EOF
     echo "Status: JumpCloud agent installed!" >>"$DEP_N_LOG"
 
     # JumpCloud installed - add gate file
+    kill $caffeinatePID
     touch $DEP_N_GATE_INSTALLJC
 fi
 # Check if the system has yet to be added to JumpCloud
 if [[ ! -f $DEP_N_GATE_SYSADD ]]; then
-    Sleep 1
+    # Caffeinate this script
+    caffeinate -d -i -m -u &
+    caffeinatePID=$!
+
+    sleep 1
 
     echo "Status: Pulling configuration settings from JumpCloud" >>"$DEP_N_LOG"
 
@@ -377,12 +385,16 @@ if [[ ! -f $DEP_N_GATE_SYSADD ]]; then
     done
 
     # Set the receipt for the system add gate. The system was added to JumpCloud at this stage
+    kill $caffeinatePID
     touch $DEP_N_GATE_SYSADD
     echo "System added to JumpCloud Enrollment Group" >>"$DEP_N_LOG"
 fi
 
 # User interaction steps - check if user has completed these steps.
 if [[ ! -f $DEP_N_GATE_UI ]]; then
+    # Caffeinate this script
+    caffeinate -d -i -m -u &
+    caffeinatePID=$!
     # reboot check
     FINDER_PROCESS=$(pgrep -l "Finder")
     until [ "$FINDER_PROCESS" != "" ]; do
@@ -452,10 +464,14 @@ if [[ ! -f $DEP_N_GATE_UI ]]; then
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     # user interaction complete - add gate file
+    kill $caffeinatePID
     touch $DEP_N_GATE_UI
 fi
 # Final steps to complete the install
 if [[ ! -f $DEP_N_GATE_DONE ]]; then
+    # Caffeinate this script
+    caffeinate -d -i -m -u &
+    caffeinatePID=$!
     ## Get the JumpCloud SystemID
     conf="$(cat /opt/jc/jcagent.conf)"
     regex='\"systemKey\":\"[a-zA-Z0-9]{24}\"'
@@ -606,6 +622,7 @@ if [[ ! -f $DEP_N_GATE_DONE ]]; then
     done
 
     # add gate file here, user interaction complete
+    kill $caffeinatePID
     touch $DEP_N_GATE_DONE
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # END Post login active session workflow                                       ~

--- a/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
+++ b/zero-touch/prestage_user_enrollment/jumpcloud_bootstrap_template.sh
@@ -467,9 +467,9 @@ if [[ ! -f $DEP_N_GATE_DONE ]]; then
     regex='[a-zA-Z0-9]{24}'
     if [[ $systemKey =~ $regex ]]; then
         systemID="${BASH_REMATCH[@]}"
-        echo "$(date "+%Y-%m-%dT%H:%M:%S") JumpCloud systemID found SystemID: "$systemID >>"$DEP_N_DEBUG"
+        echo "$(date "+%Y-%m-%dT%H:%M:%S"): JumpCloud systemID found SystemID: "$systemID >>"$DEP_N_DEBUG"
     else
-        echo "$(date "+%Y-%m-%dT%H:%M:%S") No systemID found" >>"$DEP_N_DEBUG"
+        echo "$(date "+%Y-%m-%dT%H:%M:%S"): No systemID found" >>"$DEP_N_DEBUG"
         exit 1
     fi
 
@@ -505,9 +505,9 @@ if [[ ! -f $DEP_N_GATE_DONE ]]; then
 
     if [[ $userBindCheck =~ $regex ]]; then
         userID="${BASH_REMATCH[@]}"
-        echo "$(date "+%Y-%m-%dT%H:%M:%S") JumpCloud user "$loggedInUser "bound to systemID: "$systemID >>"$DEP_N_DEBUG"
+        echo "$(date "+%Y-%m-%dT%H:%M:%S"): JumpCloud user "$loggedInUser "bound to systemID: "$systemID >>"$DEP_N_DEBUG"
     else
-        echo "$(date "+%Y-%m-%dT%H:%M:%S") error JumpCloud user not bound to system" >>"$DEP_N_DEBUG"
+        echo "$(date "+%Y-%m-%dT%H:%M:%S"): error JumpCloud user not bound to system" >>"$DEP_N_DEBUG"
         exit 1
     fi
 
@@ -529,15 +529,15 @@ if [[ ! -f $DEP_N_GATE_DONE ]]; then
         accountTakeOverCheck=$(echo ${updateLog} | grep "User updates complete")
         logoutTimeoutCounter=$((${logoutTimeoutCounter} + 1))
         if [[ ${logoutTimeoutCounter} -eq 10 ]]; then
-            echo "$(date "+%Y-%m-%dT%H:%M:%S") Error during JumpCloud agent local account takeover" >>"$DEP_N_DEBUG"
-            echo "$(date "+%Y-%m-%dT%H:%M:%S") JCAgent.log: ${updateLog}" >>"$DEP_N_DEBUG"
+            echo "$(date "+%Y-%m-%dT%H:%M:%S"): Error during JumpCloud agent local account takeover" >>"$DEP_N_DEBUG"
+            echo "$(date "+%Y-%m-%dT%H:%M:%S"): JCAgent.log: ${updateLog}" >>"$DEP_N_DEBUG"
             exit 1
         fi
     done
 
     echo "Status: System Account Configured" >>"$DEP_N_LOG"
 
-    echo "$(date "+%Y-%m-%dT%H:%M:%S") JumpCloud agent local account takeover complete" >>"$DEP_N_DEBUG"
+    echo "$(date "+%Y-%m-%dT%H:%M:%S"): JumpCloud agent local account takeover complete" >>"$DEP_N_DEBUG"
 
     # Remove from DEP_ENROLLMENT_GROUP and add to DEP_POST_ENROLLMENT_GROUP
 
@@ -549,7 +549,7 @@ if [[ ! -f $DEP_N_GATE_DONE ]]; then
         -d '{"op": "remove","type": "system","id": "'${systemID}'"}' \
         "https://console.jumpcloud.com/api/v2/systemgroups/${DEP_ENROLLMENT_GROUP_ID}/members"
 
-    echo "$(date "+%Y-%m-%dT%H:%M:%S") Removed from DEP_ENROLLMENT_GROUP_ID: $DEP_ENROLLMENT_GROUP_ID" >>"$DEP_N_DEBUG"
+    echo "$(date "+%Y-%m-%dT%H:%M:%S"): Removed from DEP_ENROLLMENT_GROUP_ID: $DEP_ENROLLMENT_GROUP_ID" >>"$DEP_N_DEBUG"
 
     curl \
         -X 'POST' \
@@ -559,7 +559,7 @@ if [[ ! -f $DEP_N_GATE_DONE ]]; then
         -d '{"op": "add","type": "system","id": "'${systemID}'"}' \
         "https://console.jumpcloud.com/api/v2/systemgroups/${DEP_POST_ENROLLMENT_GROUP_ID}/members"
 
-    echo "$(date "+%Y-%m-%dT%H:%M:%S") Added to from DEP_POST_ENROLLMENT_GROUP_ID: $DEP_POST_ENROLLMENT_GROUP_ID" >>"$DEP_N_DEBUG"
+    echo "$(date "+%Y-%m-%dT%H:%M:%S"): Added to from DEP_POST_ENROLLMENT_GROUP_ID: $DEP_POST_ENROLLMENT_GROUP_ID" >>"$DEP_N_DEBUG"
 
     echo "Status: Applying Finishing Touches" >>"$DEP_N_LOG"
 
@@ -583,33 +583,29 @@ if [[ ! -f $DEP_N_GATE_DONE ]]; then
         groupTakeOverCheck=$(echo ${groupSwitchCheck} | grep "Processing user updates")
         groupTimeoutCounter=$((${groupTimeoutCounter} + 1))
         if [[ ${groupTimeoutCounter} -eq 90 ]]; then
-            echo "$(date "+%Y-%m-%dT%H:%M:%S") Error during JumpCloud agent local account takeover" >>"$DEP_N_DEBUG"
-            echo "$(date "+%Y-%m-%dT%H:%M:%S") JCAgent.log: ${groupSwitchCheck}" >>"$DEP_N_DEBUG"
+            echo "$(date "+%Y-%m-%dT%H:%M:%S"): Error during JumpCloud agent local account takeover" >>"$DEP_N_DEBUG"
+            echo "$(date "+%Y-%m-%dT%H:%M:%S"): JCAgent.log: ${groupSwitchCheck}" >>"$DEP_N_DEBUG"
             exit 1
         fi
-        echo "$(date "+%Y-%m-%dT%H:%M:%S") Waiting for group switch :${groupTimeoutCounter} of 90" >>"$DEP_N_DEBUG"
+        echo "$(date "+%Y-%m-%dT%H:%M:%S"): Waiting for group switch :${groupTimeoutCounter} of 90" >>"$DEP_N_DEBUG"
     done
 
     FINISH_TITLE="All Done"
 
-    # add gate file here before we remove the user potentially running the script
-    touch $DEP_N_GATE_DONE
-
-    if [[ $DELETE_ENROLLMENT_USERS == true ]]; then
-        # delete the first logged in user
-        Sleep 10
-        echo "$(date "+%Y-%m-%dT%H:%M:%S") Deleting the first enrollment user: $ENROLLMENT_USER" >>"$DEP_N_DEBUG"
-        dscl . -delete /Users/$ENROLLMENT_USER
-        rm -rf /Users/$ENROLLMENT_USER
-        echo "$(date "+%Y-%m-%dT%H:%M:%S") Deleting the decrypt user: $DECRYPT_USER" >>"$DEP_N_DEBUG"
-        dscl . -delete /Users/$DECRYPT_USER
-        rm -rf /Users/$DECRYPT_USER
-    fi
-
     echo "Command: MainTitle: $FINISH_TITLE" >>"$DEP_N_LOG"
     echo "Status: Enrollment Complete" >>"$DEP_N_LOG"
-    echo "$(date "+%Y-%m-%dT%H:%M:%S") Status: Enrollment Complete" >>"$DEP_N_DEBUG"
+    echo "$(date "+%Y-%m-%dT%H:%M:%S"): Status: Enrollment Complete" >>"$DEP_N_DEBUG"
 
+    ACTIVE_USER=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+    echo "$(date "+%Y-%m-%dT%H:%M:%S"): Waiting for ${ACTIVE_USER} user to logout... " >>"$DEP_N_DEBUG"
+    FINDER_PROCESS=$(pgrep -l "Finder")
+    while [ "$FINDER_PROCESS" != "" ]; do
+        echo "$(date "+%Y-%m-%dT%H:%M:%S"): Finder process found. Waiting until session end" >>"$DEP_N_DEBUG"
+        sleep 1
+        FINDER_PROCESS=$(pgrep -l "Finder")
+    done
+    # add gate file here before we remove the user potentially running the script
+    touch $DEP_N_GATE_DONE
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # END Post login active session workflow                                       ~
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -621,11 +617,36 @@ fi
 # this script. The launchdaemon with status 127 will remain on the system until
 # reboot, it will be not be called again after reboot.
 if [[ -f $DEP_N_GATE_DONE ]]; then
-    sleep 10
+    if [[ $DELETE_ENROLLMENT_USERS == true ]]; then
+        # wait until welcome user is logged out
+        echo "$(date "+%Y-%m-%dT%H:%M:%S"): Testing if ${ENROLLMENT_USER} user is logged out" >>"$DEP_N_DEBUG"
+        ACTIVE_USER=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+        if [[ "${ACTIVE_USER}" == "${ENROLLMENT_USER}" ]]; then
+            echo "$(date "+%Y-%m-%dT%H:%M:%S"): Logged in user is: ${ACTIVE_USER}, waiting until logout to continue" >> "$DEP_N_DEBUG"
+            FINDER_PROCESS=$(pgrep -l "Finder")
+            echo "$(date "+%Y-%m-%dT%H:%M:%S"): $FINDER_PROCESS" >>"$DEP_N_DEBUG"
+            while [ "$FINDER_PROCESS" != "" ]; do
+                echo "$(date "+%Y-%m-%dT%H:%M:%S"): Finder process found. Waiting until session end" >>"$DEP_N_DEBUG"
+                sleep 1
+                FINDER_PROCESS=$(pgrep -l "Finder")
+            done
+        fi
+        # given the case that the enrollment user was logged in previously, recheck the active user        
+        ACTIVE_USER=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+        echo "$(date "+%Y-%m-%dT%H:%M:%S"): Logged in user is: ${ACTIVE_USER}" >> "$DEP_N_DEBUG"
+        if [[ "${ACTIVE_USER}" == "" || "${ACTIVE_USER}" != "${ENROLLMENT_USER}" ]]; then
+            # delete the enrollment and decrypt user
+            echo "$(date "+%Y-%m-%dT%H:%M:%S"): Deleting the first enrollment user: $ENROLLMENT_USER" >>"$DEP_N_DEBUG"
+            sysadminctl -deleteUser $ENROLLMENT_USER >>"$DEP_N_DEBUG" 2>&1
+            echo "$(date "+%Y-%m-%dT%H:%M:%S"): Deleting the decrypt user: $DECRYPT_USER" >>"$DEP_N_DEBUG"
+            sysadminctl -deleteUser $DECRYPT_USER >>"$DEP_N_DEBUG" 2>&1
+        fi
+        
+    fi
     # ACTIVE_USER=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
-    # echo "$(date "+%Y-%m-%dT%H:%M:%S") User: $ACTIVE_USER is Unloading LaunchDaemon" >>"$DEP_N_DEBUG"
+    # echo "$(date "+%Y-%m-%dT%H:%M:%S"): User: $ACTIVE_USER is Unloading LaunchDaemon" >>"$DEP_N_DEBUG"
     # launchctl unload /Library/LaunchDaemons/com.jumpcloud.prestage.plist # this step is taken care of by deleting the daemon in the next step
-    echo "$(date "+%Y-%m-%dT%H:%M:%S") Status: Removing LaunchDaemon" >>"$DEP_N_DEBUG"
+    echo "$(date "+%Y-%m-%dT%H:%M:%S"): Status: Removing LaunchDaemon" >>"$DEP_N_DEBUG"
     rm -rf "/Library/LaunchDaemons/${daemon}"
     # Clean up receipts
     rm /var/tmp/com.jumpcloud*

--- a/zero-touch/prestage_user_enrollment/user_configuration_modules/pending_or_active_user_company_email_and_secret.sh
+++ b/zero-touch/prestage_user_enrollment/user_configuration_modules/pending_or_active_user_company_email_and_secret.sh
@@ -150,8 +150,12 @@ while [ "$VALID_PASSWORD" == "False" ]; do
 
     VALID_PASSWORD='True'
 
-    password=$(launchctl asuser "$uid" /usr/bin/osascript -e 'Tell application "System Events" to display dialog "PASSWORD COMPLEXITY REQUIREMENTS:\n--------------------------------------------------------------\n * At least 8 characters long \n * Have at least 1 lowercase character \n * Have at least 1 uppercase character \n * Have at least 1 number \n * Have at least 1 special character'"$COMPLEXITY"'" with title "CREATE A SECURE PASSWORD"  buttons {"Continue"} default button "Continue" with hidden answer default answer ""' -e 'text returned of result' 2>/dev/null)
-
+    password=$(launchctl asuser "$uid" /usr/bin/osascript -e '
+        Tell application "System Events" 
+            with timeout of 1800 seconds 
+                display dialog "PASSWORD COMPLEXITY REQUIREMENTS:\n--------------------------------------------------------------\n * At least 8 characters long \n * Have at least 1 lowercase character \n * Have at least 1 uppercase character \n * Have at least 1 number \n * Have at least 1 special character'"$COMPLEXITY"'" with title "CREATE A SECURE PASSWORD"  buttons {"Continue"} default button "Continue" with hidden answer default answer ""' -e 'text returned of result 
+            end timeout
+        end tell' 2>/dev/null)
     # Length check
     lengthCheck='.{'$minlength',100}'
     if [[ $password =~ $lengthCheck ]]; then

--- a/zero-touch/prestage_user_enrollment/user_configuration_modules/pending_or_active_user_last_name_and_secret.sh
+++ b/zero-touch/prestage_user_enrollment/user_configuration_modules/pending_or_active_user_last_name_and_secret.sh
@@ -150,8 +150,12 @@ while [ "$VALID_PASSWORD" == "False" ]; do
 
     VALID_PASSWORD='True'
 
-    password=$(launchctl asuser "$uid" /usr/bin/osascript -e 'Tell application "System Events" to display dialog "PASSWORD COMPLEXITY REQUIREMENTS:\n--------------------------------------------------------------\n * At least 8 characters long \n * Have at least 1 lowercase character \n * Have at least 1 uppercase character \n * Have at least 1 number \n * Have at least 1 special character'"$COMPLEXITY"'" with title "CREATE A SECURE PASSWORD"  buttons {"Continue"} default button "Continue" with hidden answer default answer ""' -e 'text returned of result' 2>/dev/null)
-
+    password=$(launchctl asuser "$uid" /usr/bin/osascript -e '
+        Tell application "System Events" 
+            with timeout of 1800 seconds 
+                display dialog "PASSWORD COMPLEXITY REQUIREMENTS:\n--------------------------------------------------------------\n * At least 8 characters long \n * Have at least 1 lowercase character \n * Have at least 1 uppercase character \n * Have at least 1 number \n * Have at least 1 special character'"$COMPLEXITY"'" with title "CREATE A SECURE PASSWORD"  buttons {"Continue"} default button "Continue" with hidden answer default answer ""' -e 'text returned of result 
+            end timeout
+        end tell' 2>/dev/null)
     # Length check
     lengthCheck='.{'$minlength',100}'
     if [[ $password =~ $lengthCheck ]]; then

--- a/zero-touch/prestage_user_enrollment/user_configuration_modules/pending_or_active_user_personal_email_and_secret.sh
+++ b/zero-touch/prestage_user_enrollment/user_configuration_modules/pending_or_active_user_personal_email_and_secret.sh
@@ -150,8 +150,12 @@ while [ "$VALID_PASSWORD" == "False" ]; do
 
     VALID_PASSWORD='True'
 
-    password=$(launchctl asuser "$uid" /usr/bin/osascript -e 'Tell application "System Events" to display dialog "PASSWORD COMPLEXITY REQUIREMENTS:\n--------------------------------------------------------------\n * At least 8 characters long \n * Have at least 1 lowercase character \n * Have at least 1 uppercase character \n * Have at least 1 number \n * Have at least 1 special character'"$COMPLEXITY"'" with title "CREATE A SECURE PASSWORD"  buttons {"Continue"} default button "Continue" with hidden answer default answer ""' -e 'text returned of result' 2>/dev/null)
-
+    password=$(launchctl asuser "$uid" /usr/bin/osascript -e '
+        Tell application "System Events" 
+            with timeout of 1800 seconds 
+                display dialog "PASSWORD COMPLEXITY REQUIREMENTS:\n--------------------------------------------------------------\n * At least 8 characters long \n * Have at least 1 lowercase character \n * Have at least 1 uppercase character \n * Have at least 1 number \n * Have at least 1 special character'"$COMPLEXITY"'" with title "CREATE A SECURE PASSWORD"  buttons {"Continue"} default button "Continue" with hidden answer default answer ""' -e 'text returned of result 
+            end timeout
+        end tell' 2>/dev/null)
     # Length check
     lengthCheck='.{'$minlength',100}'
     if [[ $password =~ $lengthCheck ]]; then

--- a/zero-touch/prestage_user_enrollment/user_configuration_modules/pending_user_company_email.sh
+++ b/zero-touch/prestage_user_enrollment/user_configuration_modules/pending_user_company_email.sh
@@ -145,8 +145,12 @@ while [ "$VALID_PASSWORD" == "False" ]; do
 
     VALID_PASSWORD='True'
 
-    password=$(launchctl asuser "$uid" /usr/bin/osascript -e 'Tell application "System Events" to display dialog "PASSWORD COMPLEXITY REQUIREMENTS:\n--------------------------------------------------------------\n * At least 8 characters long \n * Have at least 1 lowercase character \n * Have at least 1 uppercase character \n * Have at least 1 number \n * Have at least 1 special character'"$COMPLEXITY"'" with title "CREATE A SECURE PASSWORD"  buttons {"Continue"} default button "Continue" with hidden answer default answer ""' -e 'text returned of result' 2>/dev/null)
-
+    password=$(launchctl asuser "$uid" /usr/bin/osascript -e '
+        Tell application "System Events" 
+            with timeout of 1800 seconds 
+                display dialog "PASSWORD COMPLEXITY REQUIREMENTS:\n--------------------------------------------------------------\n * At least 8 characters long \n * Have at least 1 lowercase character \n * Have at least 1 uppercase character \n * Have at least 1 number \n * Have at least 1 special character'"$COMPLEXITY"'" with title "CREATE A SECURE PASSWORD"  buttons {"Continue"} default button "Continue" with hidden answer default answer ""' -e 'text returned of result 
+            end timeout
+        end tell' 2>/dev/null)
     # Length check
     lengthCheck='.{'$minlength',100}'
     if [[ $password =~ $lengthCheck ]]; then

--- a/zero-touch/prestage_user_enrollment/user_configuration_modules/pending_user_personal_email.sh
+++ b/zero-touch/prestage_user_enrollment/user_configuration_modules/pending_user_personal_email.sh
@@ -146,8 +146,12 @@ while [ "$VALID_PASSWORD" == "False" ]; do
 
     VALID_PASSWORD='True'
 
-    password=$(launchctl asuser "$uid" /usr/bin/osascript -e 'Tell application "System Events" to display dialog "PASSWORD COMPLEXITY REQUIREMENTS:\n--------------------------------------------------------------\n * At least 8 characters long \n * Have at least 1 lowercase character \n * Have at least 1 uppercase character \n * Have at least 1 number \n * Have at least 1 special character'"$COMPLEXITY"'" with title "CREATE A SECURE PASSWORD"  buttons {"Continue"} default button "Continue" with hidden answer default answer ""' -e 'text returned of result' 2>/dev/null)
-
+    password=$(launchctl asuser "$uid" /usr/bin/osascript -e '
+        Tell application "System Events" 
+            with timeout of 1800 seconds 
+                display dialog "PASSWORD COMPLEXITY REQUIREMENTS:\n--------------------------------------------------------------\n * At least 8 characters long \n * Have at least 1 lowercase character \n * Have at least 1 uppercase character \n * Have at least 1 number \n * Have at least 1 special character'"$COMPLEXITY"'" with title "CREATE A SECURE PASSWORD"  buttons {"Continue"} default button "Continue" with hidden answer default answer ""' -e 'text returned of result 
+            end timeout
+        end tell' 2>/dev/null)
     # Length check
     lengthCheck='.{'$minlength',100}'
     if [[ $password =~ $lengthCheck ]]; then


### PR DESCRIPTION
Fix for the remnant files which are left over if dscl is used to delete the enrollment user and the decrypt user. The use of Sysadminctl -deleteuser has a few additional checks built in to ensure the last SecureToken user on a system is not removed. The script now waits until no users are logged in or if the enrollment user is not logged in before processing the delete users block of code. 

This user deletion block of code was moved to the last gate check in the script. Admins who wish to restart their systems as part of the process can do so at the end of the last gate. Deleting users with sysadminctl is a more elegant way of removing users in 10.13+ and seems to resolve some of the delay at first user login.

The script is now caffeinated to account for enrollment users who walk away from their systems. Each code gate before the last gate contains a caffeinate code snippet to ensure the system will not sleep during the enrollment process. The last code gate is not caffeinated, since the code block contains no user interaction and should complete shortly after the previous block. 

The user configuration modules which request user passwords had an osascript with a timeout period of two minutes. Given the case that an enrollment user walks away from their system, the timeout period was extended to thirty mins to prevent multiple popup windows from displaying.