### PR TITLE
Remove dependency on `wget`

### DIFF
--- a/scripts/api/v1/radius/dhcpRadiusUpdate.sh
+++ b/scripts/api/v1/radius/dhcpRadiusUpdate.sh
@@ -6,14 +6,14 @@
 #      IP address with the current IP address defined in a JumpCloud radius
 #      server. It is recommended to define radiusId manually, but if not, it
 #      will query the first returned record from the API and check if it needs
-#      to update it. If there's only 1 record, this is fine. 
+#      to update it. If there's only 1 record, this is fine.
 #
-#      *** If there are multiple RADIUS Ids, this is potentially destructive.  
+#      *** If there are multiple RADIUS Ids, this is potentially destructive.
 #      Know which record is being updated.***
 #
-#      REQUIRED: wget, curl, jq, JumpCloud API Key
+#      REQUIRED: curl, jq, JumpCloud API Key
 #      USAGE: This can be set to run as a cron, e.g., every hour at minute 0:
-#      
+#
 #      $ crontab -e
 #      0 * * * * /opt/dhcpRadiusUpdate.sh > /var/log/radupdate.log 2>&1
 #
@@ -23,7 +23,7 @@
 
 apiKey=
 radiusId=
-newIp=$(wget http://ipecho.net/plain -O - -q)
+newIp=$(curl -q http://ipecho.net/plain)
 
 # If newIp can't be defined, bail
 


### PR DESCRIPTION
The script does not need to depend on *both* `curl` and `wget`. Not only is this redundant, but this also allows the script to be run from an EdgeRouter (i.e., vanilla EdgeOS) without installing any additional packages. Not going to lie, this is the primary motivation for this PR :).

Also, `wget` is arguably less common in OOTB/vanilla installs of Linux distros as compared to `curl`, which is _nearly_ guaranteed (except for the tiniest distros).

Tangentially, this also removes some trailing whitespace.