### PR TITLE
Add_Flush_DNS_Cache

### DIFF
--- a/scripts/windows/FixWindowsAgent.ps1
+++ b/scripts/windows/FixWindowsAgent.ps1
@@ -367,4 +367,8 @@ CheckForAndUninstallExistingAgent
 
 CleanUpAgentLeftovers
 
+#Flush DNS Cache Before Install
+
+ipconfig /FlushDNS
+
 DownloadAndInstallAgent -msvc2013x64link:($msvc2013x64Link) -TempPath:($TempPath) -msvc2013x64file:($msvc2013x64File) -msvc2013x64install:($msvc2013x64Install) -msvc2013x86link:($msvc2013x86Link) -msvc2013x86file:($msvc2013x86File) -msvc2013x86install:($msvc2013x86Install)

--- a/scripts/windows/InstallWindowsAgent.ps1
+++ b/scripts/windows/InstallWindowsAgent.ps1
@@ -117,6 +117,10 @@ Function DownloadAndInstallAgent(
     }
 }
 
+#Flush DNS Cache Before Install
+
+ipconfig /FlushDNS
+
 # JumpCloud Agent Installation Logic
 
 DownloadAndInstallAgent -msvc2013x64link:($msvc2013x64Link) -TempPath:($TempPath) -msvc2013x64file:($msvc2013x64File) -msvc2013x64install:($msvc2013x64Install) -msvc2013x86link:($msvc2013x86Link) -msvc2013x86file:($msvc2013x86File) -msvc2013x86install:($msvc2013x86Install)


### PR DESCRIPTION
Adds flush dns prior to install to account for cases where infrastructure changes occur and windows DNS cache keeps old address leading to failed installed agent.