### PR TITLE
Sa 951 jw update major os

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Cache Latest MacOS Installer.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Cache Latest MacOS Installer.md
@@ -1,0 +1,25 @@
+#### Name
+
+Mac - Cache Latest MacOS Installer | v1.0 JCCG
+
+#### commandType
+
+mac
+
+#### Command
+
+```
+softwareupdate --fetch-full-installer
+```
+
+#### Description
+
+This command invokes the MacOS softwareupdate utility. The --fetch-full-installer flag downloads the latest Install MacOS installer available from the App Store. The --fetch-full-installer flag contains a sub-flag to specify which version of the latest Install MacOS installer to download. For example, `softwareupdate --fetch-full-installer --full-installer-version` 10.15.1 would download the 10.15.1 version of Catalina to the target system. The timeout on this command should be changed to accommodate slower networks. A timeout of 30 mins (or 1800 seconds) should suffice if running on a single system.
+
+#### *Import This Command*
+
+To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
+
+```
+Import-JCCommand -URL 'https://git.io/JvLiV'
+```

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Cache Latest MacOS Installer.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Cache Latest MacOS Installer.md
@@ -50,7 +50,7 @@ echo "JumpCloud system: ${systemID} removed from system group: ${systemGroupID}"
 
 #### Description
 
-This command invokes the MacOS softwareupdate utility. The --fetch-full-installer flag downloads the latest Install MacOS installer available from the App Store. The --fetch-full-installer flag contains a sub-flag to specify which version of the latest Install MacOS installer to download. For example, `softwareupdate --fetch-full-installer --full-installer-version` 10.15.1 would download the 10.15.1 version of Catalina to the target system. The timeout on this command should be changed to accommodate slower networks. A timeout of 30 mins (or 1800 seconds) should suffice if running on a single system.
+This command invokes the MacOS softwareupdate utility. The --fetch-full-installer flag downloads the latest Install MacOS installer available from the App Store. The --fetch-full-installer flag contains a sub-flag to specify which version of the latest Install MacOS installer to download. For example, `softwareupdate --fetch-full-installer --full-installer-version` 10.15.1 would download the 10.15.1 version of Catalina to the target system. The timeout on this command should be changed to accommodate slower networks. A timeout of 30 mins (or 1800 seconds) should suffice if running on a single system. Change the systemGroupID to a new group ID in your JumpCloud Organization to track systems which have run this command.
 
 #### *Import This Command*
 

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Install Latest MacOS Installer.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Install Latest MacOS Installer.md
@@ -58,7 +58,7 @@ fi
 
 #### Description
 
-Installs the macOS Installer specified in the first variable declaration. Replace "Install macOS Catalina.app" with the name of the latest cached installer on the target system. The startosinstall program within the latest OS installer is called with the --aggreetolicense and --forcequitapps flags to prevent user interaction. Test that this install method works for for remote users before deploying.
+This command installs the macOS Installer specified in the macosinstaller variable. Replace "Install macOS Catalina.app" with the name of the latest cached installer on the target system. The macosinstaller variable text should include the .app extension. Change the systemGroupID to the same group ID used in the Cache Latest MacOS Installer command. The startosinstall program within the latest OS installer is called with the --agreetolicense and --forcequitapps flags to prevent user interaction. Test that this install method works for for remote users before deploying and consider changing the startosinstall flags if user interaction is required.
 
 #### *Import This Command*
 

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Install Latest MacOS Installer.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Install Latest MacOS Installer.md
@@ -1,0 +1,33 @@
+#### Name
+
+Mac - Install Latest MacOS Installer | v1.0 JCCG
+
+#### commandType
+
+mac
+
+#### Command
+
+```
+# replace the "Install macOS Catalaina.app" text with the version cached on the target system
+macosinstaller="Install macOS Catalina.app"
+
+if [[ -d /Applications/$macosinstaller ]]; then
+    '/Applications/$macosinstaller/Contents/Resources/startosinstall' --agreetolicense --forcequitapps --nointeraction
+else
+    echo "Could not find installer"
+    exit 1
+fi
+```
+
+#### Description
+
+Installs the macOS Installer specified in the first variable declaration. Replace "Install macOS Catalina.app" with the name of the latest cached installer on the target system. The startosinstall program within the latest OS installer is called with the --aggreetolicense, --forcequitapps and --nointeraction flags to prevent user interaction. Test that this install method works for for remote users before deploying.
+
+#### *Import This Command*
+
+To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
+
+```
+Import-JCCommand -URL 'https://git.io/JvLiV'
+```

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Install Latest MacOS Installer.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Install Latest MacOS Installer.md
@@ -11,9 +11,45 @@ mac
 ```
 # replace the "Install macOS Catalaina.app" text with the version cached on the target system
 macosinstaller="Install macOS Catalina.app"
+# change the systemGroupID to match the group used in the cache macOS installer command
+systemGroupID="5e74f14e45886d2939ff2562"
 
-if [[ -d /Applications/$macosinstaller ]]; then
-    '/Applications/$macosinstaller/Contents/Resources/startosinstall' --agreetolicense --forcequitapps --nointeraction
+if [[ -d /Applications/${macosinstaller} ]]; then
+    # Parse the systemKey from the conf file.
+    conf="$(cat /opt/jc/jcagent.conf)"
+    regex='\"systemKey\":\"[a-zA-Z0-9]{24}\"'
+
+    if [[ $conf =~ $regex ]]; then
+        systemKey="${BASH_REMATCH[@]}"
+    fi
+
+    regex='[a-zA-Z0-9]{24}'
+    if [[ $systemKey =~ $regex ]]; then
+        systemID="${BASH_REMATCH[@]}"
+    fi
+
+    # Get the current time.
+    now=$(date -u "+%a, %d %h %Y %H:%M:%S GMT")
+
+    # create the string to sign from the request-line and the date
+    signstr="POST /api/v2/systemgroups/${systemGroupID}/members HTTP/1.1\ndate: ${now}"
+
+    # create the signature
+    signature=$(printf "$signstr" | openssl dgst -sha256 -sign /opt/jc/client.key | openssl enc -e -a | tr -d '\n')
+
+    curl -s \
+        -X 'POST' \
+        -H 'Content-Type: application/json' \
+        -H 'Accept: application/json' \
+        -H "Date: ${now}" \
+        -H "Authorization: Signature keyId=\"system/${systemID}\",headers=\"request-line date\",algorithm=\"rsa-sha256\",signature=\"${signature}\"" \
+        -d '{"op": "remove","type": "system","id": "'${systemID}'"}' \
+        "https://console.jumpcloud.com/api/v2/systemgroups/${systemGroupID}/members"
+
+    echo "JumpCloud system: ${systemID} removed from system group: ${systemGroupID}"
+
+    # Install latest OS Installer
+    '/Applications/${macosinstaller}/Contents/Resources/startosinstall' --agreetolicense --forcequitapps
 else
     echo "Could not find installer"
     exit 1
@@ -22,7 +58,7 @@ fi
 
 #### Description
 
-Installs the macOS Installer specified in the first variable declaration. Replace "Install macOS Catalina.app" with the name of the latest cached installer on the target system. The startosinstall program within the latest OS installer is called with the --aggreetolicense, --forcequitapps and --nointeraction flags to prevent user interaction. Test that this install method works for for remote users before deploying.
+Installs the macOS Installer specified in the first variable declaration. Replace "Install macOS Catalina.app" with the name of the latest cached installer on the target system. The startosinstall program within the latest OS installer is called with the --aggreetolicense and --forcequitapps flags to prevent user interaction. Test that this install method works for for remote users before deploying.
 
 #### *Import This Command*
 


### PR DESCRIPTION
Two Commands:
Mac - Cache Latest MacOS Installer | v1.0 JCCG
This command is used to cache Major OS installers, the softwareupdate command in MacOS Catalina includes the --fetch-full-installer command which will allow admins to remotely cache full OS installers on remote Catalina systems. This command will add systems to a system group to help determine which systems have cached the last OS.
Mac - Install Latest MacOS Installer | v1.0 JCCG
This command will install a full OS installer on remote macos systems. If the specified macOS installer exists on a system the command will run the installer and remove the system from the specified system group in the cache latest os installer command.