### PR TITLE
exit 1 on failed agent install

### DIFF
--- a/scripts/macos/install_agent_and_serviceaccount.sh
+++ b/scripts/macos/install_agent_and_serviceaccount.sh
@@ -203,6 +203,13 @@ EOF
 $SECURETOKEN_ADMIN_USERNAME;$SECURETOKEN_ADMIN_PASSWORD
 EOF
   # The file JumpCloud-SecureToken-Creds.txt IS DELETED during the agent install process
-  installer -pkg /tmp/jumpcloud-agent.pkg -target / &
+installer -pkg /tmp/jumpcloud-agent.pkg -target /
+result=$(echo "$?")
+if [[ $result -eq "0" ]];then
+	echo "JumpCloud Agent Installed Successfully"
+else
+	echo "JumpCloud Agent Install Failed"
+	exit 1
+fi
 fi
 exit 0

--- a/scripts/macos/install_agent_and_serviceaccount.sh
+++ b/scripts/macos/install_agent_and_serviceaccount.sh
@@ -203,13 +203,13 @@ EOF
 $SECURETOKEN_ADMIN_USERNAME;$SECURETOKEN_ADMIN_PASSWORD
 EOF
   # The file JumpCloud-SecureToken-Creds.txt IS DELETED during the agent install process
-installer -pkg /tmp/jumpcloud-agent.pkg -target /
-result=$(echo "$?")
-if [[ $result -eq "0" ]];then
-	echo "JumpCloud Agent Installed Successfully"
-else
-	echo "JumpCloud Agent Install Failed"
-	exit 1
-fi
+  installer -pkg /tmp/jumpcloud-agent.pkg -target /
+  result=$(echo "$?")
+  if [[ $result -eq "0" ]];then
+    echo "JumpCloud Agent Installed Successfully"
+  else
+    echo "JumpCloud Agent Install Failed"
+    exit 1
+  fi
 fi
 exit 0


### PR DESCRIPTION
Add an exit condition to account for scenarios where the installer throws an error.

If installer -pkg /tmp/jumpcloud-agent.pkg -target / returns 1, exit the script with exit code 1, else continue and exit 0