### PR TITLE
API changed - now requires "name" + "sharedSecret"

### DIFF
--- a/scripts/api/v1/radius/dhcpRadiusUpdate.sh
+++ b/scripts/api/v1/radius/dhcpRadiusUpdate.sh
@@ -60,7 +60,7 @@ curl \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H "x-api-key: ${apiKey}" \
-  -d '{"networkSourceIp":"'"${newIp}"'"}' \
+  -d '{"networkSourceIp":"'"${newIp}"'", "name": "<YOUR RADIUS NAME>", "sharedSecret": "<YOUR SHARED SECRET"}' \
   "https://console.jumpcloud.com/api/radiusservers/${radiusId}"
 
 }


### PR DESCRIPTION
The script was no longer working, the API now requiring "name" and "sharedSecret" keys for each update