### PR TITLE
SJ-2472 Update Logging for Password Expiration Prompt Scripts

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Expiring Users To Update Password.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Expiring Users To Update Password.md
@@ -101,7 +101,7 @@ bool bWait);
             'ComputerName'    = $ComputerName;
             'SessionId'       = $SessionId;
             'ResponseId'      = $Response;
-            'ResponseMessage' = $ResponseMessage
+            'ResponseMessage' = $ResponseMessage;
         }
         Return $Responses
     }

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Expiring Users To Update Password.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Expiring Users To Update Password.md
@@ -101,7 +101,7 @@ bool bWait);
             'ComputerName'    = $ComputerName;
             'SessionId'       = $SessionId;
             'ResponseId'      = $Response;
-            'ResponseMessage' = $ResponseMessage;
+            'ResponseMessage' = $ResponseMessage
         }
         Return $Responses
     }
@@ -142,69 +142,70 @@ Function Invoke-PasswordResetNotification
         # Get list of users on machine
         $ActiveUsers = (quser) -Replace ('^>', '') -Replace ('\s{2,}', ',') | ConvertFrom-Csv
         # ForEach user
-        If ($ActiveUsers) {
-        ForEach ($ActiveUser In $ActiveUsers)
+        If ($ActiveUsers) 
         {
-            $UserName = $ActiveUser.UserName
-            $SessionId = $ActiveUser.ID
-            $UserState = $ActiveUser.State
-            If ($UserState -eq 'Active')
+            ForEach ($ActiveUser In $ActiveUsers)
             {
-                # Get user info
-                $SystemUser_URL = 'https://console.jumpcloud.com/api/systemusers?fields=username email password_expiration_date&search[fields]=username&search[searchTerm]=' + $UserName
-                $SystemUser = Invoke-RestMethod -Method:('GET') -Headers:($hdrs) -Uri:($SystemUser_URL)
-                $SystemUser = $SystemUser.results | Where-Object {$_.username -eq $UserName}
-                If ($SystemUser)
+                $UserName = $ActiveUser.UserName
+                $SessionId = $ActiveUser.ID
+                $UserState = $ActiveUser.State
+                If ($UserState -eq 'Active')
                 {
-                    $Id = $SystemUser._id
-                    $UserName = $SystemUser.UserName
-                    $email = $SystemUser.email
-                    $password_expiration_date = $SystemUser.password_expiration_date
-                    #Convert dates to ToUniversalTime
-                    $TodaysDate = (Get-Date).ToUniversalTime()
-                    $password_expiration_date_Universal = Get-Date -Date:($password_expiration_date)
-                    # Get days till users password expires
-                    $TimeSpan = New-TimeSpan -Start:($TodaysDate) -End:($password_expiration_date_Universal)
-                    $DaysUntilPasswordExpire = [math]::ceiling($TimeSpan.TotalDays)
-                    # If days until password expires is less than the alert threshold
-                    If ($DaysUntilPasswordExpire -le $AlertDaysThreshold)
+                    # Get user info
+                    $SystemUser_URL = 'https://console.jumpcloud.com/api/systemusers?fields=username email password_expiration_date&search[fields]=username&search[searchTerm]=' + $UserName
+                    $SystemUser = Invoke-RestMethod -Method:('GET') -Headers:($hdrs) -Uri:($SystemUser_URL)
+                    $SystemUser = $SystemUser.results | Where-Object {$_.username -eq $UserName}
+                    If ($SystemUser)
                     {
-                        # Build confirmation action body
-                        $ConfirmationAction = {
-                            $JsonBody = '{"isSelectAll":false,"models":[{"_id":"' + $Id + '"}]}'
-                            $PasswordReset_URL = 'https://console.jumpcloud.com/api/systemusers/reactivate'
-                            $PasswordReset = Invoke-RestMethod -Method:('POST') -Headers:($hdrs) -Uri:($PasswordReset_URL) -Body:($JsonBody)
+                        $Id = $SystemUser._id
+                        $UserName = $SystemUser.UserName
+                        $email = $SystemUser.email
+                        $password_expiration_date = $SystemUser.password_expiration_date
+                        #Convert dates to ToUniversalTime
+                        $TodaysDate = (Get-Date).ToUniversalTime()
+                        $password_expiration_date_Universal = Get-Date -Date:($password_expiration_date)
+                        # Get days till users password expires
+                        $TimeSpan = New-TimeSpan -Start:($TodaysDate) -End:($password_expiration_date_Universal)
+                        $DaysUntilPasswordExpire = [math]::ceiling($TimeSpan.TotalDays)
+                        # If days until password expires is less than the alert threshold
+                        If ($DaysUntilPasswordExpire -le $AlertDaysThreshold)
+                        {
+                            # Build confirmation action body
+                            $ConfirmationAction = {
+                                $JsonBody = '{"isSelectAll":false,"models":[{"_id":"' + $Id + '"}]}'
+                                $PasswordReset_URL = 'https://console.jumpcloud.com/api/systemusers/reactivate'
+                                $PasswordReset = Invoke-RestMethod -Method:('POST') -Headers:($hdrs) -Uri:($PasswordReset_URL) -Body:($JsonBody)
+                            }
+                            $Response = Invoke-BroadcastMessage -SessionId:($SessionId) -MessageBoxStyle:($MessageBoxStyle) -MessageTitle:($MessageTitle) -MessageBody:($MessageBody -f $DaysUntilPasswordExpire) -ConfirmationAction:($ConfirmationAction) -TimeOutSec:($TimeOutSec)
+                            Return $Response | Where-Object {$_.ComputerName} | Select-Object ComputerName, SessionId, ResponseId, ResponseMessage, @{Name = 'UserName'; Expression = {$UserName}}, @{Name = 'password_expiration_date'; Expression = {$password_expiration_date}}
                         }
-                        $Response = Invoke-BroadcastMessage -SessionId:($SessionId) -MessageBoxStyle:($MessageBoxStyle) -MessageTitle:($MessageTitle) -MessageBody:($MessageBody -f $DaysUntilPasswordExpire) -ConfirmationAction:($ConfirmationAction) -TimeOutSec:($TimeOutSec)
-                        Return $Response | Where-Object {$_.ComputerName} | Select-Object ComputerName, SessionId, ResponseId, ResponseMessage, @{Name = 'UserName'; Expression = {$UserName}}, @{Name = 'password_expiration_date'; Expression = {$password_expiration_date}}
+                        else 
+                        {
+                            Write-Output ("No Active JumpCloud users with expiring passwords found. See details of found users below:")
+                            Return [PSCustomObject]@{
+                                'UserName'                 = $UserName
+                                'password_expiration_date' = $password_expiration_date
+                                'DaysUntilPasswordExpires' = $DaysUntilPasswordExpire
+                                'Notification Triggered'   = 'False'
+                            }
+                        }
                     }
-                    else 
+                    Else
                     {
-                        Write-Output ("No Active JumpCloud users with expiring passwords found. See details of found users below:")
-                        Return [PSCustomObject]@{
-                            'UserName'                 = $UserName
-                            'password_expiration_date' = $password_expiration_date
-                            'DaysUntilPasswordExpires' = $DaysUntilPasswordExpire
-                            'Notification Triggered'   = 'False'
-                        }
+                        Write-Warning ('Unable to find user: "' + $UserName + '". Active user "' + $UserName +  '" is not a JumpCloud user')
                     }
                 }
-                Else
+                else
                 {
-                    Write-Warning ('Unable to find user: "' + $UserName + '". Active user "' + $UserName +  '" is not a JumpCloud user')
+                    Write-Error ('Cannot read the state of the active user: "' + $UserState + '" Is not a valid state')
                 }
-            }
-            else
-            {
-                Write-Error ('Cannot read the state of the active user: "' + $UserState + '" Is not a valid state')
             }
         }
+        Else
+        {
+            Write-Output ("No active users found on system")
+        }
     }
-    Else
-    {
-        Write-Output ("No active users found on system")
-    }
-}
     Catch
     {
         $Exception = $_.Exception

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Expiring Users To Update Password.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Expiring Users To Update Password.md
@@ -142,7 +142,7 @@ Function Invoke-PasswordResetNotification
         # Get list of users on machine
         $ActiveUsers = (quser) -Replace ('^>', '') -Replace ('\s{2,}', ',') | ConvertFrom-Csv
         # ForEach user
-        If ($ActiveUsers) 
+        If ($ActiveUsers)
         {
             ForEach ($ActiveUser In $ActiveUsers)
             {
@@ -167,7 +167,7 @@ Function Invoke-PasswordResetNotification
                         {
                             Write-output ('user: "' + $UserName + '" is set to never expire.')
                         }
-                        else 
+                        else
                         {
                             $password_expiration_date_Universal = Get-Date -Date:($password_expiration_date)
                             # Get days till users password expires
@@ -185,7 +185,7 @@ Function Invoke-PasswordResetNotification
                                 $Response = Invoke-BroadcastMessage -SessionId:($SessionId) -MessageBoxStyle:($MessageBoxStyle) -MessageTitle:($MessageTitle) -MessageBody:($MessageBody -f $DaysUntilPasswordExpire) -ConfirmationAction:($ConfirmationAction) -TimeOutSec:($TimeOutSec)
                                 Return $Response | Where-Object {$_.ComputerName} | Select-Object ComputerName, SessionId, ResponseId, ResponseMessage, @{Name = 'UserName'; Expression = {$UserName}}, @{Name = 'password_expiration_date'; Expression = {$password_expiration_date}}
                             }
-                            else 
+                            else
                             {
                                 Write-Output ("No Active JumpCloud users with expiring passwords found. See details of found users below:")
                                 Return [PSCustomObject]@{

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password With Expiration Date Logic.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password With Expiration Date Logic.md
@@ -16,7 +16,6 @@ $MessageBoxStyle = 4 # Look inside the Invoke-BroadcastMessage function for opti
 $MessageTitle = 'Update Your JumpCloud Password Immediately' # Text to display in the message box title.
 $MessageBody = 'Please update your JumpCloud password immediately. Click "Yes" to send a JumpCloud password reset link to your email.' # Text to display in the message box body.
 $TimeOutSec = 60 # How long you want the message box to display to the user.
-# $AdvancedLogging = true
 
 #------- Do not modify below this line ------
 Function Invoke-BroadcastMessage
@@ -185,22 +184,24 @@ Function Invoke-PasswordResetNotification
                             }
                             else
                             {
+                                Write-Output ("No Active JumpCloud users with expiring passwords found. See details of found users below:")
                                 Return [PSCustomObject]@{
                                     'UserName'                 = $UserName
                                     'password_expiration_date' = $password_expiration_date
                                     'DaysUntilPasswordExpires' = $DaysUntilPasswordExpire
                                     'PasswordUpdate'           = 'Complete'
+                                    'Notification Triggered'   = 'False'
                                 }
                             }
                         }
                         else
                         {
-                            Write-Error ('Unable to find expiration date for user:' + $UserName)
+                            Write-Warning ('Unable to find expiration date for user:' + $UserName)
                         }
                     }
                     Else
                     {
-                        Write-Error ('Unable to find user: "' + $UserName + '". Active user is not a JumpCloud user')
+                        Write-Warning ('Unable to find user: "' + $UserName + '". Active user "' + $UserName +  '" is not a JumpCloud user')
                     }
                 }
                 else 
@@ -211,7 +212,7 @@ Function Invoke-PasswordResetNotification
         }
         Else 
         {
-            Write-Error ("No active users")
+            Write-Output ("No active users")
         }
     }
     Catch
@@ -233,6 +234,7 @@ Invoke-PasswordResetNotification -JCAPIKEY:($JCAPIKEY) -MessageBoxStyle:($Messag
 #### Description
 
 1. Runs "quser" command to get a list of all active sessions on the machine.
+   Note: This script expects an English return of "Active" for the above command in order to complete successfully. If OS isn't default English, the script may return an error.
 2. Query the organizations JumpCloud password expiration policy.
 3. For each user with an active session query the users password expiration date.
 4. If the signed in user has not reset their password on the day the command is run then a notification is sent to the user. **This logic allows the command to be set to run as a repeating on a set of target systems and will only re-prompt users who do not take action and update their passwords.**

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password With Expiration Date Logic.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password With Expiration Date Logic.md
@@ -157,10 +157,11 @@ Function Invoke-PasswordResetNotification
                         $UserName = $SystemUser.UserName
                         $email = $SystemUser.email
                         $password_expiration_date = $SystemUser.password_expiration_date
-                        $passwordExpirationInDays = $Organizations.settings.passwordPolicy.passwordExpirationInDays
-                        $password_set_date = (Get-Date($password_expiration_date)).AddDays(-$passwordExpirationInDays)
+                        
                         If ($password_expiration_date)
                         {
+                            $passwordExpirationInDays = $Organizations.settings.passwordPolicy.passwordExpirationInDays
+                            $password_set_date = (Get-Date($password_expiration_date)).AddDays(-$passwordExpirationInDays)
                             #Convert dates to ToUniversalTime
                             $TodaysDate = (Get-Date).ToUniversalTime()
                             $password_expiration_date_Universal = Get-Date -Date:($password_expiration_date)
@@ -197,7 +198,7 @@ Function Invoke-PasswordResetNotification
                         }
                         else
                         {
-                            Write-Warning ('Unable to find expiration date for user:' + $UserName)
+                            Write-Warning ('Unable to find expiration date for user: "' + $UserName + '" or user password does not expire.')
                         }
                     }
                     Else
@@ -230,7 +231,6 @@ Function Invoke-PasswordResetNotification
 }
 
 Invoke-PasswordResetNotification -JCAPIKEY:($JCAPIKEY) -MessageBoxStyle:($MessageBoxStyle) -MessageTitle:($MessageTitle) -MessageBody:($MessageBody) -TimeOutSec:($TimeOutSec)
-
 ```
 
 #### Description

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password With Expiration Date Logic.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password With Expiration Date Logic.md
@@ -133,7 +133,7 @@ Function Invoke-PasswordResetNotification
         # Get list of users on machine
         $ActiveUsers = (quser) -Replace ('^>', '') -Replace ('\s{2,}', ',') | ConvertFrom-Csv
         # ForEach user
-        If ($ActiveUsers) 
+        If ($ActiveUsers)
         {
             ForEach ($ActiveUser In $ActiveUsers)
             {
@@ -206,13 +206,13 @@ Function Invoke-PasswordResetNotification
                         Write-Warning ('Unable to find user: "' + $UserName + '". Active user "' + $UserName +  '" is not a JumpCloud user')
                     }
                 }
-                else 
+                else
                 {
                     Write-Error ('Cannot read the state of the active user: "' + $UserState + '" Is not a valid state')
                 }
             } 
         }
-        Else 
+        Else
         {
             Write-Output ("No active users found on system")
         }

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password With Expiration Date Logic.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password With Expiration Date Logic.md
@@ -133,7 +133,8 @@ Function Invoke-PasswordResetNotification
         # Get list of users on machine
         $ActiveUsers = (quser) -Replace ('^>', '') -Replace ('\s{2,}', ',') | ConvertFrom-Csv
         # ForEach user
-        If ($ActiveUsers) {
+        If ($ActiveUsers) 
+        {
             ForEach ($ActiveUser In $ActiveUsers)
             {
                 $UserName = $ActiveUser.UserName
@@ -212,7 +213,7 @@ Function Invoke-PasswordResetNotification
         }
         Else 
         {
-            Write-Output ("No active users")
+            Write-Output ("No active users found on system")
         }
     }
     Catch
@@ -229,6 +230,7 @@ Function Invoke-PasswordResetNotification
 }
 
 Invoke-PasswordResetNotification -JCAPIKEY:($JCAPIKEY) -MessageBoxStyle:($MessageBoxStyle) -MessageTitle:($MessageTitle) -MessageBody:($MessageBody) -TimeOutSec:($TimeOutSec)
+
 ```
 
 #### Description

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password.md
@@ -133,53 +133,63 @@ Function Invoke-PasswordResetNotification
         # Get list of users on machine
         $ActiveUsers = (quser) -Replace ('^>', '') -Replace ('\s{2,}', ',') | ConvertFrom-Csv
         # ForEach user
-        ForEach ($ActiveUser In $ActiveUsers)
+        If ($ActiveUsers) 
         {
-            $UserName = $ActiveUser.UserName
-            $SessionId = $ActiveUser.ID
-            $UserState = $ActiveUser.State
-            If ($UserState -eq 'Active')
+            ForEach ($ActiveUser In $ActiveUsers)
             {
-               
-                # Get user info
-                $SystemUser_URL = 'https://console.jumpcloud.com/api/systemusers?fields=username email password_expiration_date&search[fields]=username&search[searchTerm]=' + $UserName
-                $SystemUser = Invoke-RestMethod -Method:('GET') -Headers:($hdrs) -Uri:($SystemUser_URL)
-                $SystemUser = $SystemUser.results | Where-Object {$_.username -eq $UserName}
-                If ($SystemUser)
+                $UserName = $ActiveUser.UserName
+                $SessionId = $ActiveUser.ID
+                $UserState = $ActiveUser.State
+                If ($UserState -eq 'Active')
                 {
-                    $Id = $SystemUser._id
-                    $UserName = $SystemUser.UserName
-                    $email = $SystemUser.email
-                    $password_expiration_date = $SystemUser.password_expiration_date
-                    $passwordExpirationInDays = $Organizations.settings.passwordPolicy.passwordExpirationInDays
-                    $password_set_date = (Get-Date($password_expiration_date)).AddDays(-$passwordExpirationInDays)
+                
+                    # Get user info
+                    $SystemUser_URL = 'https://console.jumpcloud.com/api/systemusers?fields=username email password_expiration_date&search[fields]=username&search[searchTerm]=' + $UserName
+                    $SystemUser = Invoke-RestMethod -Method:('GET') -Headers:($hdrs) -Uri:($SystemUser_URL)
+                    $SystemUser = $SystemUser.results | Where-Object {$_.username -eq $UserName}
+                    If ($SystemUser)
+                    {
+                        $Id = $SystemUser._id
+                        $UserName = $SystemUser.UserName
+                        $email = $SystemUser.email
+                        $password_expiration_date = $SystemUser.password_expiration_date
+                        $passwordExpirationInDays = $Organizations.settings.passwordPolicy.passwordExpirationInDays
+                        $password_set_date = (Get-Date($password_expiration_date)).AddDays(-$passwordExpirationInDays)
 
-                    #Convert dates to ToUniversalTime
-                    $TodaysDate = (Get-Date).ToUniversalTime()
-                    $password_expiration_date_Universal = Get-Date -Date:($password_expiration_date)
-                    # Get days till users password expires
-                    $TimeSpan = New-TimeSpan -Start:($TodaysDate) -End:($password_expiration_date_Universal)
-                    $DaysUntilPasswordExpire = [math]::ceiling($TimeSpan.TotalDays)
-                    # If DaysUntilPasswordExpire is less than passwordExpirationInDays
+                        #Convert dates to ToUniversalTime
+                        $TodaysDate = (Get-Date).ToUniversalTime()
+                        $password_expiration_date_Universal = Get-Date -Date:($password_expiration_date)
+                        # Get days till users password expires
+                        $TimeSpan = New-TimeSpan -Start:($TodaysDate) -End:($password_expiration_date_Universal)
+                        $DaysUntilPasswordExpire = [math]::ceiling($TimeSpan.TotalDays)
 
-                    # Build confirmation action body
-                    $ConfirmationAction = {
-                        $JsonBody = '{"isSelectAll":false,"models":[{"_id":"' + $Id + '"}]}'
-                        $PasswordReset_URL = 'https://console.jumpcloud.com/api/systemusers/reactivate'
-                        $PasswordReset = Invoke-RestMethod -Method:('POST') -Headers:($hdrs) -Uri:($PasswordReset_URL) -Body:($JsonBody)
+                        # Build confirmation action body
+                        $ConfirmationAction = {
+                            $JsonBody = '{"isSelectAll":false,"models":[{"_id":"' + $Id + '"}]}'
+                            $PasswordReset_URL = 'https://console.jumpcloud.com/api/systemusers/reactivate'
+                            $PasswordReset = Invoke-RestMethod -Method:('POST') -Headers:($hdrs) -Uri:($PasswordReset_URL) -Body:($JsonBody)
+                        }
+                        $Response = Invoke-BroadcastMessage -SessionId:($SessionId) -MessageBoxStyle:($MessageBoxStyle) -MessageTitle:($MessageTitle) -MessageBody:($MessageBody -f $DaysUntilPasswordExpire) -ConfirmationAction:($ConfirmationAction) -TimeOutSec:($TimeOutSec)
+                        Return $Response | Where-Object {$_.ComputerName} | Select-Object ComputerName, SessionId, ResponseId, ResponseMessage, `
+                        @{Name = 'UserName'; Expression = {$UserName}}, `
+                        @{Name = 'password_expiration_date'; Expression = {$password_expiration_date}}, `
+                        @{Name = 'DaysUntilPasswordExpiration'; Expression = {$DaysUntilPasswordExpire}}
+
                     }
-                    $Response = Invoke-BroadcastMessage -SessionId:($SessionId) -MessageBoxStyle:($MessageBoxStyle) -MessageTitle:($MessageTitle) -MessageBody:($MessageBody -f $DaysUntilPasswordExpire) -ConfirmationAction:($ConfirmationAction) -TimeOutSec:($TimeOutSec)
-                    Return $Response | Where-Object {$_.ComputerName} | Select-Object ComputerName, SessionId, ResponseId, ResponseMessage, `
-                    @{Name = 'UserName'; Expression = {$UserName}}, `
-                    @{Name = 'password_expiration_date'; Expression = {$password_expiration_date}}, `
-                    @{Name = 'DaysUntilPasswordExpiration'; Expression = {$DaysUntilPasswordExpire}}
-
+                    Else
+                    {
+                        Write-Warning ('Unable to find user: "' + $UserName + '". Active user "' + $UserName +  '" is not a JumpCloud user')
+                    }
                 }
-                Else
+                else
                 {
-                    Write-Error ('Unable to find user:' + $UserName)
+                    Write-Error ('Cannot read the state of the active user: "' + $UserState + '" Is not a valid state')
                 }
             }
+        }
+        Else 
+        {
+            Write-Output ("No active users found on system")
         }
     }
     Catch
@@ -201,7 +211,7 @@ Invoke-PasswordResetNotification -JCAPIKEY:($JCAPIKEY) -MessageBoxStyle:($Messag
 #### Description
 
 1. Runs "quser" command to get a list of all active sessions on the machine.
-2. Sends a notification to the user asking them to reset their password.
+2. Sends a notification to the user asking them to reset their password. This command will prompt all users that are active, regardless if their passwords are expiring or not.
 3. If the user selects "Yes" then the action will trigger a password reset email to be sent to their inbox. If the user selects "No" then no action will occur.
 4. The output will contain the users response to the message box in the ResponseMessage field.
 

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password.md
@@ -208,6 +208,13 @@ Function Invoke-PasswordResetNotification
 Invoke-PasswordResetNotification -JCAPIKEY:($JCAPIKEY) -MessageBoxStyle:($MessageBoxStyle) -MessageTitle:($MessageTitle) -MessageBody:($MessageBody) -TimeOutSec:($TimeOutSec)
 ```
 
+### Deprecation Note
+
+This script is deprecated for:
+ https://github.com/TheJumpCloud/support/blob/master/PowerShell/JumpCloud%20Commands%20Gallery/Windows%20Commands/Windows%20-%20Prompt%20Expiring%20Users%20To%20Update%20Password.md 
+
+This referenced script can be edited to prompt all users by adjusting the $AlertDaysThreshold variable.
+
 #### Description
 
 1. Runs "quser" command to get a list of all active sessions on the machine.

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Prompt Users To Update Password.md
@@ -133,7 +133,7 @@ Function Invoke-PasswordResetNotification
         # Get list of users on machine
         $ActiveUsers = (quser) -Replace ('^>', '') -Replace ('\s{2,}', ',') | ConvertFrom-Csv
         # ForEach user
-        If ($ActiveUsers) 
+        If ($ActiveUsers)
         {
             ForEach ($ActiveUser In $ActiveUsers)
             {
@@ -187,7 +187,7 @@ Function Invoke-PasswordResetNotification
                 }
             }
         }
-        Else 
+        Else
         {
             Write-Output ("No active users found on system")
         }


### PR DESCRIPTION
## Reason
This adds new logging to the 3 Password Expiration Prompt Scripts to catch warnings and better report expected outcomes from the following scenarios to the JumpCloud Admin Console Command Results log output:

1. No active users found on the system
2. No active JumpCloud users found on the system
3. Invalid `state` for any found JumpCloud user other than `Active` (this assists non English OS versions)
4. Any Active JumpCloud users found but without their passwords expiring.


And for the 2 scripts that validate user password expiry as part of the logic to prompt for password reset, we're also outputting:
1. When the Active JumpCloud user has their password set to never expire.