### PR TITLE
Update dhcpRadiusUpdate.sh

### DIFF
--- a/scripts/api/v1/radius/dhcpRadiusUpdate.sh
+++ b/scripts/api/v1/radius/dhcpRadiusUpdate.sh
@@ -83,11 +83,11 @@ if [ -z ${sharedSecret} ]; then
 fi
 
 if [ -z ${radiusId} ]; then # Use the radiusId and currentIp of the first record returned
-  current=($(getRadiusId | jq '.results[0]._id, .results[0].networkSourceIp' | sed s/\"//g))
+  current=$(getRadiusId | jq '.results[0]._id, .results[0].networkSourceIp' | sed s/\"//g)
   radiusId=$(echo ${current[0]})
   currentIp=$(echo ${current[1]})
 else # call the predefined radiusId and define currentIP
-  currentIp=($(getCurrentIp | jq '.networkSourceIp' | sed s/\"//g))
+  currentIp=$(getCurrentIp | jq '.networkSourceIp' | sed s/\"//g)
 fi
 
 # Compare currentIp to newIp, bail if nothing's chainged


### PR DESCRIPTION
Unneeded parenthesis cause script execution failure while running on Unifi Dream Machine Pro.

./jumpcloudupdate.sh: line 81: syntax error: unexpected "(" (expecting "fi")

Removing them allows for code to function as intended.

This should resolve: https://github.com/TheJumpCloud/support/issues/184