### PR TITLE
Update CheckProgramInstalled to check WOW6432Node

### DIFF
--- a/scripts/windows/InstallWindowsAgent.ps1
+++ b/scripts/windows/InstallWindowsAgent.ps1
@@ -47,7 +47,15 @@ Function CheckProgramInstalled($programName)
     }
     else
     {
-        return $false
+        $installed = (Get-ItemProperty HKLM:SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -match $programName })
+        if (-not [System.String]::IsNullOrEmpty($installed))
+        {
+            return $true
+        }
+        else
+        {
+            return $false
+        }
     }
 }
 


### PR DESCRIPTION
CheckProgramInstalled is checking for the 32bit @HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*. The registry keys for 32 bit uninstaller live in HKLM:SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* 

Without the addition, the script always installs 'prereq Visual C++ 2013 x86'