### PR TITLE
Change path separator from / to \

### DIFF
--- a/scripts/windows/InstallWindowsAgent.ps1
+++ b/scripts/windows/InstallWindowsAgent.ps1
@@ -26,7 +26,7 @@ $AGENT_INSTALLER_PATH = "C:\windows\Temp\JumpCloudInstaller.exe"
 # JumpCloud Agent Installation Functions
 Function AgentIsOnFileSystem()
 {
-    Test-Path -Path:(${AGENT_PATH} + '/' + ${AGENT_BINARY_NAME})
+    Test-Path -Path:(${AGENT_PATH} + '\' + ${AGENT_BINARY_NAME})
 }
 Function InstallAgent()
 {


### PR DESCRIPTION
AgentIsOnFileSystem seems to function with '/' or '\', but since your describing a windows filesystem path '\' is the standard.