### PR TITLE
Sa 1939 disable local users scripts

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Linux Commands/Linux - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Linux Commands/Linux - Disable Local User.md
@@ -1,0 +1,103 @@
+#### Name
+
+Linux - Disable Local User | v1.0 JCCG
+
+#### commandType
+
+linux
+
+#### Command
+
+```
+#!/bin/bash
+################################################################################
+# This script will disable the *matched* username patterns in the usersToMatch
+# list variable. For Example:
+# Users on the system: administrator, steve, it-staff
+# usersToMatch=(admin it)
+# both the administrator and it-staff would be disabled
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Test how this command will run by setting the disable variable to false. When
+# set to false the script will identify users to disable and print out a list
+# without disabling the accounts
+################################################################################
+
+# Settings, set true or false
+disable=true
+reboot=false
+
+# Enter user(s) patterns you want to match against (user admin bobsAccount)
+usersToMatch=(userToDisable anotherUserToDisable)
+
+# Do not modify below this line
+################################################################################
+
+# regexMatchregexPattern
+regexPattern=""
+
+# build regex matching regexPattern
+pos=$(( ${#usersToMatch[*]} - 1 ))
+last=${usersToMatch[$pos]}
+for user in ${usersToMatch[@]}; do
+    # add to regexPattern
+    if [[ $user == $last ]]; then
+        regexPattern+="${user}[^\s]*"
+    else
+        regexPattern+="${user}[^\s]*|"
+    fi
+done
+
+echo "Searching System for the following users: ${usersToMatch[@]}"
+echo "Regex Pattern: $regexPattern"
+
+# Get usernames on system:
+allUsers=$(cut -d : -f 1 /etc/passwd)
+
+
+# Try to find match:
+# Case insensitive search:
+# set nocasematch option
+shopt -s nocasematch
+
+foundUsers=()
+for value in ${allUsers[@]}; do
+    if [[ $value =~ $regexPattern ]]; then
+        echo "matched $value user"
+        foundUsers+=($value)
+    fi
+done
+
+# unset nocasematch option
+shopt -u nocasematch
+
+echo "The Following users will be disabled: ${foundUsers[@]}"
+for user in ${foundUsers[@]}; do
+    echo "Disabling $user's login shell..."
+    if [[ $disable = true ]]; then
+        sudo usermod --expiredate 1 $user
+    fi
+done
+
+if [[ $reboot = true ]]; then
+    reboot
+fi
+
+```
+
+#### Description
+
+This command will disable the local users that match the regex pattern supplied in the 'usersToMatch' list variable. If for example, a system contains the following users:
+
+Steve, Administrator, IT-Admin
+
+And the usersToMatch variable is set to (admin it), both the 'Administrator' and 'IT-Admin' Account would be disabled. The Regex pattern searches usernames for partial matches.
+
+Run this script with disable=false to test what accounts would be disabled before running disable=true. Set the reboot=true variable to reboot the system, upon next restart the disabled users will be unable to login.
+
+#### *Import This Command*
+
+To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
+
+```
+Import-JCCommand -URL 'https://git.io/jccg-Linux-Pulljcagent.log'
+```

--- a/PowerShell/JumpCloud Commands Gallery/Linux Commands/Linux - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Linux Commands/Linux - Disable Local User.md
@@ -24,7 +24,7 @@ linux
 
 # Settings, set true or false
 disable=true
-reboot=false
+reboot=true
 
 # Enter user(s) patterns you want to match against (user admin bobsAccount)
 usersToMatch=(userToDisable anotherUserToDisable)

--- a/PowerShell/JumpCloud Commands Gallery/Linux Commands/Linux - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Linux Commands/Linux - Disable Local User.md
@@ -72,9 +72,16 @@ shopt -u nocasematch
 
 echo "The Following users will be disabled: ${foundUsers[@]}"
 for user in ${foundUsers[@]}; do
-    echo "Disabling $user's login shell..."
     if [[ $disable = true ]]; then
+        echo "[status] Attempting to disable $user's login shell..."
         sudo usermod --expiredate 1 $user
+        if [ $? -eq 0 ]; then
+            echo "[success] $user's login shell was disabled"
+        else
+            echo "[failure] $user's login shell could not be disabled"
+        fi
+    else
+        echo "[status] $user's account would have been disabled"
     fi
 done
 

--- a/PowerShell/JumpCloud Commands Gallery/Linux Commands/Linux - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Linux Commands/Linux - Disable Local User.md
@@ -14,7 +14,7 @@ linux
 # This script will disable the *matched* username patterns in the usersToMatch
 # list variable. For Example:
 # Users on the system: administrator, steve, it-staff
-# usersToMatch=(admin it)
+# export usersToMatch="admin it"
 # both the administrator and it-staff would be disabled
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Test how this command will run by setting the disable variable to false. When
@@ -26,12 +26,12 @@ linux
 disable=true
 
 # Enter user(s) patterns you want to match against (user admin bobsAccount)
-export usersToMatch="Inflad supercool"
-LAST_ITEM="${usersToMatch##* }"
+export usersToMatch="admin it"
 
 # Do not modify below this line
 ################################################################################
-
+# last item in matched user list
+LAST_ITEM="${usersToMatch##* }"
 # regexMatchregexPattern
 regexPattern=""
 

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Disable Local User.md
@@ -1,0 +1,105 @@
+#### Name
+
+Mac - Disable Local User | v1.0 JCCG
+
+#### commandType
+
+mac
+
+#### Command
+
+```
+#!/bin/bash
+################################################################################
+# This script will disable the *matched* username patterns in the usersToMatch
+# list variable. For Example:
+# Users on the system: administrator, steve, it-staff
+# usersToMatch=(admin it)
+# both the administrator and it-staff would be disabled
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Test how this command will run by setting the disable variable to false. When
+# set to false the script will identify users to disable and print out a list
+# without disabling the accounts
+################################################################################
+
+# Settings, set true or false
+disable=true
+reboot=false
+
+# Enter user(s) patterns you want to match against (user admin bobsAccount)
+usersToMatch=(userToDisable anotherUserToDisable)
+
+# Do not modify below this line
+################################################################################
+
+# regexMatchregexPattern
+regexPattern=""
+# build regex matching regexPattern
+pos=$(( ${#usersToMatch[*]} - 1 ))
+last=${usersToMatch[$pos]}
+for user in ${usersToMatch[@]}; do
+    # add to regexPattern
+    if [[ $user == $last ]]; then
+        regexPattern+="${user}[^\s]*"
+    else
+        regexPattern+="${user}[^\s]*|"
+    fi
+done
+
+echo "Searching System for the following users: ${usersToMatch[@]}"
+echo "Regex Pattern: $regexPattern"
+
+# Get usernames on system:
+allUsers=$(dscl . list /Users UniqueID | awk '$2>500{print $1}' | grep -v super.admin | grep -v _jumpcloudserviceaccount)
+echo "-------------------------------------------------------------------------"
+echo "Accounts on the system:"
+echo "$allUsers"
+echo "-------------------------------------------------------------------------"
+
+# Try to find match:
+# Case insensitive search:
+# set nocasematch option
+shopt -s nocasematch
+
+foundUsers=()
+for value in ${allUsers[@]}; do
+    if [[ $value =~ $regexPattern ]]; then
+        echo "matched $value user"
+        foundUsers+=($value)
+    fi
+done
+
+# unset nocasematch option
+shopt -u nocasematch
+
+echo "The Following users will be disabled: ${foundUsers[@]}"
+for user in ${foundUsers[@]}; do
+    echo "Disabling $user's login shell..."
+    if [[ $disable = true ]]; then
+        chsh -s /usr/bin/false $user
+    fi
+done
+
+if [[ $reboot = true ]]; then
+    shutdown -r now
+fi
+
+```
+
+#### Description
+
+This command will disable the local users that match the regex pattern supplied in the 'usersToMatch' list variable. If for example, a system contains the following users:
+
+Steve, Administrator, IT-Admin
+
+And the usersToMatch variable is set to (admin it), both the 'Administrator' and 'IT-Admin' Account would be disabled. The Regex pattern searches usernames for partial matches.
+
+Run this script with disable=false to test what accounts would be disabled before running disable=true. Set the reboot=true variable to reboot the system, upon next restart the disabled users will be unable to login.
+
+#### *Import This Command*
+
+To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
+
+```
+Import-JCCommand -URL 'https://git.io/JvSeX'
+```

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Disable Local User.md
@@ -24,7 +24,7 @@ mac
 
 # Settings, set true or false
 disable=true
-reboot=false
+reboot=true
 
 # Enter user(s) patterns you want to match against (user admin bobsAccount)
 usersToMatch=(userToDisable anotherUserToDisable)

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Disable Local User.md
@@ -24,10 +24,9 @@ mac
 
 # Settings, set true or false
 disable=true
-reboot=true
 
 # Enter user(s) patterns you want to match against (user admin bobsAccount)
-usersToMatch=(userToDisable anotherUserToDisable)
+usersToMatch=(inflad)
 
 # Do not modify below this line
 ################################################################################
@@ -71,26 +70,18 @@ done
 
 # unset nocasematch option
 shopt -u nocasematch
-
+loggedInUsers=$(who -u)
 echo "The Following users will be disabled: ${foundUsers[@]}"
 for user in ${foundUsers[@]}; do
+    echo "Disabling $user's login shell..."
     if [[ $disable = true ]]; then
-    echo "[status] Attempting to disable $user's login shell..."
-        chsh -s /usr/bin/false $user
-        if [ $? -eq 0 ]; then
-            echo "[success] $user's login shell was disabled"
-        else
-            echo "[failure] $user's login shell could not be disabled"
+        if echo "$loggedInUsers" | grep -iqE "$user"; then
+            echo "logging $user out of system"
+            sudo launchctl bootout user/$(id -u "${user}")
         fi
-    else
-        echo "[status] $user's account would have been disabled"
+        chsh -s /usr/bin/false $user
     fi
 done
-
-if [[ $reboot = true ]]; then
-    shutdown -r now
-fi
-
 ```
 
 #### Description

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Disable Local User.md
@@ -74,9 +74,16 @@ shopt -u nocasematch
 
 echo "The Following users will be disabled: ${foundUsers[@]}"
 for user in ${foundUsers[@]}; do
-    echo "Disabling $user's login shell..."
     if [[ $disable = true ]]; then
+    echo "[status] Attempting to disable $user's login shell..."
         chsh -s /usr/bin/false $user
+        if [ $? -eq 0 ]; then
+            echo "[success] $user's login shell was disabled"
+        else
+            echo "[failure] $user's login shell could not be disabled"
+        fi
+    else
+        echo "[status] $user's account would have been disabled"
     fi
 done
 

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Disable Local User.md
@@ -26,7 +26,7 @@ mac
 disable=true
 
 # Enter user(s) patterns you want to match against (user admin bobsAccount)
-usersToMatch=(inflad)
+usersToMatch=(admin it)
 
 # Do not modify below this line
 ################################################################################

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Disable Local User.md
@@ -13,7 +13,7 @@ windows
 # This script will disable the *matched* username patterns in the usersToMatch
 # list variable. For Example:
 # Users on the system: administrator, steve, it-staff
-# $usersToMatch=(admin it)
+# $usersToMatch = @("admin", "it")
 # both the administrator and it-staff would be disabled
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Test how this command will run by setting the disable variable to false. When
@@ -25,7 +25,7 @@ windows
 $disable = $true
 
 # Enter user(s) patterns you want to match against (user admin bobsAccount)
-$usersToMatch = @("inflad", "boogie")
+$usersToMatch = @("admin", "it")
 
 # Do not modify below this line
 ################################################################################

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Disable Local User.md
@@ -1,0 +1,89 @@
+#### Name
+
+Windows - Disable Local User | v1.0 JCCG
+
+#### commandType
+
+windows
+
+#### Command
+
+```
+################################################################################
+# This script will disable the *matched* username patterns in the usersToMatch
+# list variable. For Example:
+# Users on the system: administrator, steve, it-staff
+# $usersToMatch=(admin it)
+# both the administrator and it-staff would be disabled
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Test how this command will run by setting the disable variable to false. When
+# set to false the script will identify users to disable and print out a list
+# without disabling the accounts
+################################################################################
+
+# Settings, set $true or $false
+$disable = $true
+$reboot = $false
+
+# Enter user(s) patterns you want to match against (user admin bobsAccount)
+$usersToMatch = @("userToDisable", "anotherUserToDisable")
+
+# Do not modify below this line
+################################################################################
+
+$regexPattern=""
+$last = [int]($usersToMatch.Length) - 1
+foreach ($user in $usersToMatch) {
+    Write-Host $user
+    if ($user -eq $usersToMatch[$last]){
+        $regexpattern += "$($user)[^\s]*"
+    }
+    else{
+        $regexpattern += "$($user)[^\s]*|"
+    }
+}
+Write-Host "Searching System for the following users: $usersToMatch"
+Write-Host "Regex Pattern: $regexPattern"
+
+$localUsers = Get-LocalUser
+$foundUsers = @()
+foreach ($username in $localUsers.name)
+{
+    if ($username -match $regexPattern)
+    {
+        # Set Selected Username Variable
+        write-host "Matched $username user found"
+        $foundUsers += $username
+    }
+}
+
+Write-Host "The Following users will be disabled: $foundUsers"
+
+foreach ($username in $foundUsers){
+    if ($disable){
+        Disable-LocalUser -Name $username
+    }
+}
+
+if ($reboot){
+    shutdown /r
+}
+```
+
+#### Description
+
+This command will disable the local users that match the regex pattern supplied in the 'usersToMatch' list variable. If for example, a system contains the following users:
+
+Steve, Administrator, IT-Admin
+
+And the $usersToMatch variable is set to ("admin", "it"), both the 'Administrator' and 'IT-Admin' Account would be disabled. The Regex pattern searches usernames for partial matches.
+
+Run this script with disable=false to test what accounts would be disabled before running disable=true. Set the reboot=true variable to reboot the system, upon next restart the disabled users will be unable to login.
+
+#### *Import This Command*
+
+To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
+
+```
+Import-JCCommand -URL 'https://git.io/jccg-windows-64-bitmultilinecommand'
+```

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Disable Local User.md
@@ -23,10 +23,9 @@ windows
 
 # Settings, set $true or $false
 $disable = $true
-$reboot = $true
 
 # Enter user(s) patterns you want to match against (user admin bobsAccount)
-$usersToMatch = @("userToDisable", "anotherUserToDisable")
+$usersToMatch = @("inflad", "boogie")
 
 # Do not modify below this line
 ################################################################################
@@ -58,15 +57,23 @@ foreach ($username in $localUsers.name)
 }
 
 Write-Host "The Following users will be disabled: $foundUsers"
-
+$loggedInUsers=query user
 foreach ($username in $foundUsers){
     if ($disable){
+        if ($loggedInUsers -match $username) {
+            Write-Host "Logging $username out of system"
+            $session = quser | Where-Object { $_ -match $username }
+            ## Parse the session IDs from the output
+            $sessionIds = ($session -split ' +')[2]
+            Write-Host "Found $sessionIds for $username on system."
+            ## Loop through each session ID and pass each to the logoff command
+            $sessionIds | ForEach-Object {
+                Write-Host "Logging off session id [$($_)]..."
+                logoff $_
+            }
+        }
         Disable-LocalUser -Name $username
     }
-}
-
-if ($reboot){
-    shutdown /r
 }
 ```
 

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Disable Local User.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Disable Local User.md
@@ -23,7 +23,7 @@ windows
 
 # Settings, set $true or $false
 $disable = $true
-$reboot = $false
+$reboot = $true
 
 # Enter user(s) patterns you want to match against (user admin bobsAccount)
 $usersToMatch = @("userToDisable", "anotherUserToDisable")


### PR DESCRIPTION
## Issues
* [SA-1939](https://jumpcloud.atlassian.net/browse/SA-1939) - Disable Local Users Scripts

## What does this solve?
Scripts to disable & logoff local users by username.

## Is there anything particularly tricky?
Not particularly tricky but usernames are disabled by a regex match pattern. If multiple users match the pattern it's best to run the script with the disable variable set off to see which users would be disabled first. 

## How should this be tested?
Add a local user to a system, import the command, test that the user can me disabled by running the commands, and that the user is kicked off the system.

## Screenshots