### PR TITLE
HE-1791 More gracefully handle skipping creating the service account

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Install Agent and Service Account.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Install Agent and Service Account.md
@@ -1,6 +1,6 @@
 #### Name
 
-Mac - Install Agent and Service Account | v1.1 JCCG
+Mac - Install Agent and Service Account | v1.2 JCCG
 
 #### commandType
 
@@ -210,9 +210,15 @@ else
 }
 EOF
 
-  cat <<-EOF >/var/run/JumpCloud-SecureToken-Creds.txt
+  if [ "$SILENT_INSTALL" -eq "0" ]; then
+    cat <<-EOF >/var/run/JumpCloud-SecureToken-Creds.txt
 $SECURETOKEN_ADMIN_USERNAME;$SECURETOKEN_ADMIN_PASSWORD
 EOF
+  else
+    cat <<-EOF >/var/run/JumpCloud-SecureToken-Creds.txt
+=skip
+EOF
+  fi
   # The file JumpCloud-SecureToken-Creds.txt IS DELETED during the agent install process
   installer -pkg /tmp/jumpcloud-agent.pkg -target /
   result=$(echo "$?")

--- a/scripts/macos/install_agent_and_serviceaccount.sh
+++ b/scripts/macos/install_agent_and_serviceaccount.sh
@@ -199,9 +199,15 @@ else
 }
 EOF
 
-  cat <<-EOF >/var/run/JumpCloud-SecureToken-Creds.txt
+  if [ "$SILENT_INSTALL" -eq "0" ]; then
+    cat <<-EOF >/var/run/JumpCloud-SecureToken-Creds.txt
 $SECURETOKEN_ADMIN_USERNAME;$SECURETOKEN_ADMIN_PASSWORD
 EOF
+  else
+    cat <<-EOF >/var/run/JumpCloud-SecureToken-Creds.txt
+=skip
+EOF
+  fi
   # The file JumpCloud-SecureToken-Creds.txt IS DELETED during the agent install process
   installer -pkg /tmp/jumpcloud-agent.pkg -target /
   result=$(echo "$?")


### PR DESCRIPTION
## Issues
* [HE-1791](https://jumpcloud.atlassian.net/browse/HE-1791) - Fail agent install with no ST

## What does this solve?
The agent installer now supports a special value (=skip) in the JumpCloud-SecureToken-Creds.txt file and service account creation will be skipped rather than tried and failed.

## Is there anything particularly tricky?
No.

## How should this be tested?
- Running the `install_agent_and_serviceaccount.sh` script with the `-s` option.
- Using the powershell module `Mac - Install Agent and Service Account` with the `-s` option.
