### PR TITLE
Update template for RunAsUser module

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Run As Signed In User Template.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Run As Signed In User Template.md
@@ -8,19 +8,17 @@ windows
 
 #### Command
 
-```
+```powershell
 # If PSModule RunAsUser is not installed, install it
 if ( -not (get-installedModule "RunAsUser" -ErrorAction SilentlyContinue)) {
     install-module RunAsUser -force
 }
-else{
-    $Command = {
 
+$Command = {
     #Powershell Command Goes Here.
-
-    }
-    invoke-ascurrentuser -scriptblock $Command
 }
+
+invoke-ascurrentuser -scriptblock $Command
 ```
 
 #### Description
@@ -35,6 +33,47 @@ An example of this command is if  ```C:\windows\system32\notepad.exe``` is place
 
 To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
 
-```
+```bash
 Import-JCCommand -URL 'https://git.io/Jv5ea'
+```
+
+#### Usage Notes
+
+From the module readme:
+
+> When you execute invoke-ascurrentuser the command will always return the PID of the process it ran/is running in.
+
+Unless output is explicitly redirected, the JumpCloud command_result will simply be a number representing the PID of the spawned process, not the stdout or stderr of the process. Therefore, the module maintainer recommends piping the output to a file and then grabbing the contents. Below is a full example:
+
+```powershell
+# Path to file can be anything you like, but it
+# cannot contain user-scoped variables like $ENV:TEMP,
+# since outside of the invoke-ascurrentuser block we have system scope
+$outfile = "C:\command_results.txt"
+
+# If $outfile does not exist, create it
+if (-not(Test-Path -Path $outfile -PathType Leaf)) {
+     try {
+         $null = New-Item -ItemType File -Path $outfile -Force -ErrorAction Stop
+     }
+     catch {
+         throw $_.Exception.Message
+     }
+ }
+
+# If PSModule RunAsUser is not installed, install it
+if ( -not (get-installedModule "RunAsUser" -ErrorAction SilentlyContinue)) {
+    install-module RunAsUser -force
+}
+
+$Command = {
+    # we have to specify the path here because $outfile is defined outside the command scope
+    get-item HKCU:\Software\Microsoft\Windows\CurrentVersion\Run | out-file "C:\command_results.txt"
+}
+
+# assigning to null to suppress the PID from joining the results
+$null = invoke-ascurrentuser -scriptblock $Command
+
+# return the results to JC
+get-content $outfile
 ```


### PR DESCRIPTION
## What does this solve?
The `%Command` declaration and `invoke-ascurrentuser` statement don’t need to be inside an `else` block. The way it is now…if the `if` condition is true (i.e. the module is not installed)…all the command does is install the module before it exits. You’d have to run the command twice.

Also, some customers are confused by the fact that any command executed using `invoke-ascurrentuser` returns the PID (and not the stdout) of the spawned process. I added a note clarifying this issue, and provided an example of how to retrieve `stdout` if so desired.

## Is there anything particularly tricky?
You may receive the following error if testing on a VM:
```bash
install-module : NuGet provider is required to interact with NuGet-based repositories.
Please ensure that '2.8.5.201' or newer version of NuGet provider is installed.
```

## How should this be tested?
I added a fully testable command in the new section called "Usage Notes" (reproduced below). Save the command in admin portal and associate a Windows device to test. If you receive the error noted above, you must either install the module manually on the target device, or do what is necessary to properly set up NuGet.

```powershell
# Path to file can be anything you like, but it
# cannot contain user-scoped variables like $ENV:TEMP,
# since outside of the invoke-ascurrentuser block we have system scope
$outfile = "C:\command_results.txt"
# If $outfile does not exist, create it
if (-not(Test-Path -Path $outfile -PathType Leaf)) {
     try {
         $null = New-Item -ItemType File -Path $outfile -Force -ErrorAction Stop
     }
     catch {
         throw $_.Exception.Message
     }
 }
# If PSModule RunAsUser is not installed, install it
if ( -not (get-installedModule "RunAsUser" -ErrorAction SilentlyContinue)) {
    install-module RunAsUser -force
}
$Command = {
    # we have to specify the path here because $outfile is defined outside the command scope
    get-item HKCU:\Software\Microsoft\Windows\CurrentVersion\Run | out-file "C:\command_results.txt"
}
# assigning to null to suppress the PID from joining the results
$null = invoke-ascurrentuser -scriptblock $Command
# return the results to JC
get-content $outfile
```