### PR TITLE
revert Update-JCModule

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -45,11 +45,11 @@ parameters:
   PublishToPSGallery:
     description: 'When `true` and when run against Master branch, this workflow will publish the latest code to PSGallery'
     type: boolean
-    default: false
+    default: true
   ManualModuleVersion:
     description: 'When `true` the pipeline will use the Module Version specified in JumpCloud Module JumpCloud.psd1 file'
     type: boolean
-    default: false
+    default: true
 orbs:
   win: circleci/windows@2.2.0
 executors:
@@ -204,7 +204,7 @@ jobs:
       - invoke-pester:
           JumpCloudApiKey: $env:XAPIKEY_PESTER
           JumpCloudApiKeyMsp: $env:XAPIKEY_PESTER_MTP
-          ExcludeTagList: 'ModuleValidation, JCUsersFromCSV, JCDeployment'
+          ExcludeTagList: 'ModuleValidation, JCUsersFromCSV, JCDeployment, JCModule'
           IncludeTagList: '*'
           RequiredModulesRepo: << pipeline.parameters.RequiredModulesRepo >>
           Shell: 'pwsh.exe'
@@ -215,7 +215,7 @@ jobs:
       - invoke-pester:
           JumpCloudApiKey: $env:XAPIKEY_PESTER_MAC
           JumpCloudApiKeyMsp: $env:XAPIKEY_PESTER_MTP
-          ExcludeTagList: 'ModuleValidation, JCUsersFromCSV, JCDeployment'
+          ExcludeTagList: 'ModuleValidation, JCUsersFromCSV, JCDeployment, JCModule'
           IncludeTagList: '*'
           RequiredModulesRepo: << pipeline.parameters.RequiredModulesRepo >>
           Shell: 'pwsh'
@@ -227,7 +227,7 @@ jobs:
       - invoke-pester:
           JumpCloudApiKey: $env:XAPIKEY_PESTER_LINUX
           JumpCloudApiKeyMsp: $env:XAPIKEY_PESTER_MTP
-          ExcludeTagList: 'ModuleValidation, JCUsersFromCSV, JCDeployment'
+          ExcludeTagList: 'ModuleValidation, JCUsersFromCSV, JCDeployment, JCModule'
           IncludeTagList: '*'
           RequiredModulesRepo: << pipeline.parameters.RequiredModulesRepo >>
           Shell: 'pwsh'

--- a/PowerShell/Deploy/Build-Module.ps1
+++ b/PowerShell/Deploy/Build-Module.ps1
@@ -26,7 +26,9 @@ $PSGalleryInfo = Get-PSGalleryModuleVersion -Name:($ModuleName) -ReleaseType:($R
 # Check to see if ManualModuleVersion parameter is set to true
 if ($ManualModuleVersion) {
     $ManualModuleVersionRetrieval = Get-Content -Path:($FilePath_psd1) | Where-Object {$_ -like '*ModuleVersion*'}
-    $ModuleVersion = $ManualModuleVersionRetrieval[0] | ForEach-Object{$_.split("'")[1]}
+    $SemanticRegex = [Regex]"[0-9]+.[0-9]+.[0-9]+"
+    $SemeanticVersion = Select-String -InputObject $ManualModuleVersionRetrieval -pattern ($SemanticRegex)
+    $ModuleVersion = $SemeanticVersion[0].Matches.Value
 }
 else {
     $ModuleVersion = $PSGalleryInfo.NextVersion

--- a/PowerShell/Deploy/SdkSync/jcapiToSupportSync.ps1
+++ b/PowerShell/Deploy/SdkSync/jcapiToSupportSync.ps1
@@ -77,7 +77,7 @@ $FunctionTemplate = "{0}`nFunction {1}`n{{`n$($IndentChar){2}`n$($IndentChar)Par
 $ScriptAnalyzerResults = @()
 $JumpCloudModulePath = "$PSScriptRoot/../JumpCloud Module"
 Get-Module -Refresh -ListAvailable -All | Out-Null
-$Modules = Get-Module -Name:($Psd1.RequiredModules.ModuleName | Where-Object { $_ -in $ApprovedFunctions.Keys })
+$Modules = Get-Module -Name:($Psd1.RequiredModules | Where-Object { $_ -in $ApprovedFunctions.Keys })
 If (-not [System.String]::IsNullOrEmpty($Modules))
 {
     ForEach ($Module In $Modules)

--- a/PowerShell/Deploy/Setup-Dependencies.ps1
+++ b/PowerShell/Deploy/Setup-Dependencies.ps1
@@ -69,7 +69,7 @@ If (-not [System.String]::IsNullOrEmpty($Psd1))
 {
     # Install required modules
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    ForEach ($RequiredModule In $Psd1.RequiredModules.ModuleName)
+    ForEach ($RequiredModule In $Psd1.RequiredModules)
     {
         # Check to see if the module is installed
         If ([System.String]::IsNullOrEmpty((Get-InstalledModule | Where-Object { $_.Name -eq $RequiredModule })))

--- a/PowerShell/JumpCloud Module/Docs/JumpCloud.md
+++ b/PowerShell/JumpCloud Module/Docs/JumpCloud.md
@@ -2,7 +2,7 @@
 Module Name: JumpCloud
 Module Guid: 31c023d1-a901-48c4-90a3-082f91b31646
 Download Help Link: https://github.com/TheJumpCloud/support/wiki
-Help Version: 1.18.10
+Help Version: 1.18.11
 Locale: en-US
 ---
 

--- a/PowerShell/JumpCloud Module/JumpCloud.psd1
+++ b/PowerShell/JumpCloud Module/JumpCloud.psd1
@@ -12,7 +12,7 @@
 RootModule = 'JumpCloud.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.18.10'
+ModuleVersion = '1.18.11'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -51,9 +51,9 @@ PowerShellVersion = '4.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(@{ModuleName = 'JumpCloud.SDK.DirectoryInsights'; ModuleVersion = '0.0.14'; }, 
-               @{ModuleName = 'JumpCloud.SDK.V2'; ModuleVersion = '0.0.30'; }, 
-               @{ModuleName = 'JumpCloud.SDK.V1'; ModuleVersion = '0.0.26'; })
+RequiredModules = @(@{ModuleName = 'JumpCloud.SDK.DirectoryInsights'}, 
+               @{ModuleName = 'JumpCloud.SDK.V2'}, 
+               @{ModuleName = 'JumpCloud.SDK.V1'})
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/PowerShell/JumpCloud Module/JumpCloud.psd1
+++ b/PowerShell/JumpCloud Module/JumpCloud.psd1
@@ -51,9 +51,9 @@ PowerShellVersion = '4.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(@{ModuleName = 'JumpCloud.SDK.DirectoryInsights'}, 
-               @{ModuleName = 'JumpCloud.SDK.V2'}, 
-               @{ModuleName = 'JumpCloud.SDK.V1'})
+RequiredModules = @('JumpCloud.SDK.DirectoryInsights', 
+               'JumpCloud.SDK.V1', 
+               'JumpCloud.SDK.V2')
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/PowerShell/JumpCloud Module/Public/Authentication/Update-JCModule.ps1
+++ b/PowerShell/JumpCloud Module/Public/Authentication/Update-JCModule.ps1
@@ -8,157 +8,34 @@ Function Update-JCModule
     )
     Begin
     {
-        # Load color scheme
-        $JCColorConfig = Get-JCColorConfig
         $ModuleName = 'JumpCloud'
         # Find the module on the specified repository
-        # Until PowerShellGet is updated to query nuget v3 modules, we need to determine PSGet versions ahead of function process block
-        $PSGetModuleName = 'PowerShellGet'
-        try
+        $FoundModule = If (-not [System.String]::IsNullOrEmpty($RepositoryCredentials))
         {
-            $PSGetLatestVersion = (Find-Module PowerShellGet -AllowPrerelease).Version
-            $PSGet = Get-InstalledModule PowerShellGet
-            $PSGetVersion = (Get-InstalledModule PowerShellGet).Version
-            $PSGetSemanticRegex = [Regex]"[0-9]+.[0-9]+.[0-9]+"
-            $PSGetSemeanticVersion = Select-String -InputObject $PSGet.Version -pattern ($PSGetSemanticRegex)
-            $PSGetVersionMatch = $PSGetSemeanticVersion.Matches[0].Value.ToString()
-        }
-        catch
-        {
-            $PSGetBetaInstalled = $false
-        }
-        # $PSGetSemeanticVersion.Matches[0].Value # This should be the semantic version installed
-        # Prelease regex
-        # $PSGetPrereleaseRegex = [regex]"[0-9]+.[0-9]+.[0-9]+-(.*)"
-        # $PSGetPrereleaseVersion = Select-String -InputObject $PSGet.Version -pattern ($PSGetPrereleaseRegex)
-        # Convert base versions to semantic versioning so we can compare if the beta version of 3.0.11 is installed.
-        # As of October 2021, powershell get 3.0.11 beta is required
-        if ([System.Version]$PSGetVersionMatch -lt [System.Version]"3.0.11")
-        {
-            $PSGetBetaInstalled = $false
-        }
-        else
-        {
-            $PSGetBetaInstalled = $true
-        }
-        # If Repository Credentials are passed in, follow the flow to check for pre-release versions of the Module & SDKs
-        If (-not [System.String]::IsNullOrEmpty($RepositoryCredentials))
-        {
-            if (-not $PSGetBetaInstalled)
-            {
-                If (!($Force))
-                {
-                    Do
-                    {
-                        Write-Host ("$PSGetModuleName ($PSGetVersion) is installed but a newer version is required to interact with V3 nuget feeds. Enter ''Y'' to update the ' + $PSGetModuleName + ' PowerShell module to the latest version or enter ''N'' to cancel:") -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Header)
-                        Write-Host ('Enter ''Y'' to update the ' + $PSGetModuleName + ' module to the latest version ' + "($PSGetLatestVersion)" + ' or enter ''N'' to cancel:') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_UserPrompt)
-                        Write-Host (' ') -NoNewline
-                        $UserInputPSGet = Read-Host
-                    }
-                    Until ($UserInputPSGet.ToUpper() -in ('Y', 'N'))
-                }
-                Else
-                {
-                    $UserInputPSGet = 'Y'
-                }
-                If ($UserInputPSGet.ToUpper() -eq 'N')
-                {
-                    Write-Host ('Exiting the ' + $ModuleName + ' PowerShell module update process.') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action)
-                }
-                Else
-                {
-                    Install-Module -Name $PSGetModuleName -AllowPrerelease -Force
-                    Import-Module $PSGetModuleName -Force
-                }
-            }
-            else
-            {
-                Import-Module $PSGetModuleName
-            }
-            $FoundModule = Find-PSResource -Name:($ModuleName) -Repository:($Repository) -Credential:($RepositoryCredentials) -Prerelease
+            Find-Module -Name:($ModuleName) -Repository:($Repository) -Credential:($RepositoryCredentials) -AllowPrerelease
         }
         Else
         {
-            $FoundModule = Find-Module -Name:($ModuleName) #-Repository:($Repository) -Credential:($RepositoryCredentials) -Prerelease
+            Find-Module -Name:($ModuleName) -Repository:($Repository)
         }
         # Get the version of the module installed locally
         $InstalledModulePreUpdate = Get-InstalledModule -Name:($ModuleName) -AllVersions -ErrorAction:('Ignore')
-        # if null and beta version of PSGet installed:
-        if (($PSGetBetaInstalled) -And [System.String]::IsNullOrEmpty($InstalledModulePreUpdate))
-        {
-            If (!($Force))
-            {
-                Do
-                {
-                    Write-Host ("The $ModuleName PowerShell module was not installed from any PSGallery repositories") -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Header)
-                    Write-Host ("$PSGetModuleName ($PSGetVersion) is installed. Enter 'Y' to search for $ModuleName PowerShell modules in a NugetV3 feed 'N' to cancel:") -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_UserPrompt)
-                    $UserInputSearch = Read-Host
-                }
-                Until ($UserInputSearch.ToUpper() -in ('Y', 'N'))
-            }
-            else
-            {
-                $UserInputSearch = 'Y'
-            }
-            If ($UserInputSearch.ToUpper() -eq 'N')
-            {
-                Write-Host ('Exiting the ' + $ModuleName + ' PowerShell module update process.') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action)
-            }
-            Else
-            {
-                $InstalledModulePreUpdate = Get-InstalledPSResource -Name:($ModuleName) | Where-Object { $_.repository -eq 'codeartifact' } #-AllVersions -ErrorAction:('Ignore')
-            }
-        }
-        If ([System.String]::IsNullOrEmpty($InstalledModulePreUpdate))
-        {
-        }
         # Get module info from GitHub - This should not impact the auto update ability, only the banner message
         $ModuleBanner = Get-ModuleBanner
         $ModuleChangeLog = Get-ModuleChangeLog
         # To change update dependency from PowerShell Gallery to Github flip the commented code below
         ###### $UpdateTrigger = $ModuleBanner.'Latest Version'
-        if ($FoundModule.PrereleaseLabel)
-        {
-            $UpdateTrigger = "$($FoundModule.Version)"
-            $UpdateTriggerWithoutRevision = "$(($($FoundModule.Version)).Major).$(($($FoundModule.Version)).Minor).$(($($FoundModule.Version)).Build)"
-            $UpdateTriggerFull = "$($FoundModule.Version)-$($FoundModule.PrereleaseLabel)"
-            $UpdateTriggerFullRegex = [regex]"^[0-9]+.[0-9]+.[0-9]+.[0-9]+-(.*)"
-            $UpdateTriggerFullDatetime = (Select-String -InputObject $UpdateTriggerFull -pattern ($UpdateTriggerFullRegex)).Matches.Groups[1].value
-        }
-        else
-        {
-            $UpdateTrigger = $FoundModule.Version
-        }
+        $UpdateTrigger = $FoundModule.Version
         # Get the release notes for a specific version
         $ModuleChangeLogLatestVersion = $ModuleChangeLog | Where-Object { $_.Version -eq $UpdateTrigger }
         # To change update dependency from PowerShell Gallery to Github flip the commented code below
         ###### $LatestVersionReleaseDate = $ModuleChangeLogLatestVersion.'RELEASE DATE'
-        If (-not [System.String]::IsNullOrEmpty($RepositoryCredentials))
-        {
-            $LatestVersionReleaseDate = ($FoundModule | ForEach-Object { $_.Version.ToString() + ' (' + $foundModule.PrereleaseLabel + ')' })
-        }
-        Else
-        {
-            $LatestVersionReleaseDate = ($FoundModule | ForEach-Object { ($_.Version).ToString() + ' (' + (Get-Date $_.PublishedDate).ToString('yyyy-MM-dd') + ')' })
-        }
-        # $LatestVersionReleaseDate = ($FoundModule | ForEach-Object { ($_.Version).ToString() + ' (' + [datetime]::parseexact($foundModule.PrereleaseLabel, 'yyyyMMddHHmm', $null) + ')' })
-        # $LatestVersionReleaseDate = [datetime]::parseexact($foundModule.PrereleaseLabel, 'yyyyMMddHHmm', $null)
-        # $LatestVersionReleaseDate = ($FoundModule | ForEach-Object { ($_.Version).ToString() + ' (' + (Get-Date $_.foundModule.PrereleaseLabel).ToString('yyyyMMddHHmm') + ')' })
+        $LatestVersionReleaseDate = ($FoundModule | ForEach-Object { ($_.Version).ToString() + ' (' + (Get-Date $_.PublishedDate).ToString('MMMM dd, yyyy') + ')' })
         # Build welcome page
         $WelcomePage = New-Object -TypeName:('PSCustomObject') | Select-Object `
         @{Name = 'MESSAGE'; Expression = { $ModuleBanner.'Banner Current' } } `
-            , @{Name = 'INSTALLED VERSION(S)'; Expression = { $InstalledModulePreUpdate | ForEach-Object {
-                    if ($InstalledModulePreUpdate.Repository -eq $Repository)
-                    {
-                        ($_.Version).ToString() + ' (' + [datetime]::parseexact($_.PrereleaseLabel, 'yyyyMMddHHmm', $null) + ')'
-                    }
-                    else
-                    {
-                        ($_.Version).ToString() + ' (' + (Get-Date $_.PublishedDate).ToString('yyyy-MM-dd HH:mm') + ')'
-                    }
-                } }
-        } `
-            , @{Name = 'LATEST VERSION'; Expression = { $UpdateTrigger + ' (' + (Get-Date $LatestVersionReleaseDate).ToString('yyyy-MM-dd HH:mm') + ')' } } `
+            , @{Name = 'INSTALLED VERSION(S)'; Expression = { $InstalledModulePreUpdate | ForEach-Object { ($_.Version).ToString() + ' (' + (Get-Date $_.PublishedDate).ToString('MMMM dd, yyyy') + ')' } } } `
+            , @{Name = 'LATEST VERSION'; Expression = { $UpdateTrigger + ' (' + (Get-Date $LatestVersionReleaseDate).ToString('MMMM dd, yyyy') + ')' } } `
             , @{Name = 'RELEASE NOTES'; Expression = { $ModuleChangeLogLatestVersion.'RELEASE NOTES' } } `
             , @{Name = 'FEATURES'; Expression = { $ModuleChangeLogLatestVersion.'FEATURES' } } `
             , @{Name = 'IMPROVEMENTS'; Expression = { $ModuleChangeLogLatestVersion.'IMPROVEMENTS' } } `
@@ -167,7 +44,8 @@ Function Update-JCModule
     }
     Process
     {
-
+        # Load color scheme
+        $JCColorConfig = Get-JCColorConfig
         Try
         {
             # Check to see if module is already installed
@@ -178,12 +56,7 @@ Function Update-JCModule
             Else
             {
                 # Populate status message
-                # [System.Version]($UpdateTrigger.ToString())
-                # ($InstalledModulePreUpdate.Version | Select-Object -First 1)
-                $latestVersionInstalled = ($InstalledModulePreUpdate.Version | Measure-Object -Maximum ).Maximum
-
-                # [System.Version]($InstalledModulePreUpdate.Version.ToString())
-                $Status = If ([System.Version]($UpdateTrigger.ToString()) -gt [System.Version]($latestVersionInstalled))
+                $Status = If ($UpdateTrigger -notin $InstalledModulePreUpdate.Version)
                 {
                     'An update is available for the ' + $ModuleName + ' PowerShell module.'
                 }
@@ -245,137 +118,43 @@ Function Update-JCModule
                     }
                     Else
                     {
-                        if (($InstalledModulePreUpdate.Repository -eq 'PSGallery') -And ($Repository -eq 'CodeArtifact'))
+                        # Update the module to the latest version
+                        Write-Host ('Updating ' + $ModuleName + ' module to version: ') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action) -NoNewline
+                        Write-Host ($UpdateTrigger) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
+                        If (-not [System.String]::IsNullOrEmpty($RepositoryCredentials))
                         {
-                            # Module installed from PSGallery, updating to CodeArtifact Source
-                            Write-Host ('Updating ' + $ModuleName + ' module to version: ') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action) -NoNewline
-                            Write-Host ($UpdateTrigger) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
-                            # install from CodeArtifact
-                            Install-PSResource -Name:($ModuleName) -Repository:('CodeArtifact') -Credential:($RepositoryCredentials) -Prerelease -Reinstall;
-                            # Remove existing module from the session
-                            Get-Module -Name:($ModuleName) -ListAvailable -All | Remove-Module -Force
-                            # Uninstall previous versions
-                            If (!($SkipUninstallOld))
-                            {
-                                $InstalledModulePreUpdate | ForEach-Object {
-                                    Write-Host ('Uninstalling ' + $_.Name + ' module version: ') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action) -NoNewline
-                                    Write-Host (($_.Version).ToString()) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
-                                    $_ | Uninstall-Module -Force
-                                }
-                            }
-                            # Validate install
-                            $InstalledModulePostUpdate = Get-InstalledPSResource -Name:($ModuleName)
-                            # Check to see if the module version on the PowerShell gallery does not match the local module version
-                            If (([System.Version]$UpdateTriggerWithoutRevision -eq [System.Version]($InstalledModulePostUpdate.Version | Measure-Object -Maximum ).Maximum) -And ([System.String]$UpdateTriggerFullDatetime -eq [System.String]($InstalledModulePostUpdate.PrereleaseLabel | Measure-Object -Maximum ).Maximum))
-                            {
-                                # Load new module
-                                Import-Module -Name:($ModuleName) -Scope:('Global') -Force
-                                # Confirm to user module update has been successful
-                                Write-Host ('STATUS:') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Header)
-                                Write-Host ($JCColorConfig.IndentChar) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Indentation) -NoNewline
-                                Write-Host ('The ' + $ModuleName + ' PowerShell module has successfully been updated!') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
-                            }
-                            Else
-                            {
-                                Write-Error ("Failed to update the $($ModuleName) PowerShell module to the latest version. $($UpdateTrigger) is not in $($InstalledModulePostUpdate.Version -join ', ')")
+                            $InstalledModulePreUpdate | Update-Module -Force -Credential:($RepositoryCredentials) -AllowPrerelease
+                        }
+                        Else
+                        {
+                            $InstalledModulePreUpdate | Update-Module -Force
+                        }
+                        # Remove existing module from the session
+                        Get-Module -Name:($ModuleName) -ListAvailable -All | Remove-Module -Force
+                        # Uninstall previous versions
+                        If (!($SkipUninstallOld))
+                        {
+                            $InstalledModulePreUpdate | ForEach-Object {
+                                Write-Host ('Uninstalling ' + $_.Name + ' module version: ') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action) -NoNewline
+                                Write-Host (($_.Version).ToString()) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
+                                $_ | Uninstall-Module -Force
                             }
                         }
-                        elseif (($InstalledModulePreUpdate.Repository -eq 'CodeArtifact') -And ($Repository -eq 'CodeArtifact'))
+                        # Validate install
+                        $InstalledModulePostUpdate = Get-InstalledModule -Name:($ModuleName) -AllVersions
+                        # Check to see if the module version on the PowerShell gallery does not match the local module version
+                        If ($UpdateTrigger -in $InstalledModulePostUpdate.Version)
                         {
-                            Write-Host ('Updating ' + $ModuleName + ' module to version: ') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action) -NoNewline
-                            Write-Host ($UpdateTrigger) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
-                            Install-PSResource -Name $ModuleName -Repository 'CodeArtifact' -Prerelease -Credential $RepositoryCredentials -Reinstall
-                            # Remove existing module from the session
-                            Get-Module -Name:($ModuleName) -ListAvailable -All | Remove-Module -Force
-                            # Uninstall previous versions
-                            If (!($SkipUninstallOld))
-                            {
-                                $InstalledModulePreUpdate | Where-Object { $_.PrereleaseLabel -ne $InstalledModulePreUpdate.PrereleaseLabel } | ForEach-Object {
-                                    Write-Host ('Uninstalling ' + $_.Name + ' module version: ') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action) -NoNewline
-                                    Write-Host (($_.Version).ToString()) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
-                                    $_ | Uninstall-PSResource -Force
-                                }
-                            }
-                            # Validate install
-                            $InstalledModulePostUpdate = Get-InstalledPSResource -Name:($ModuleName)
-                            # Check to see if the module version on the CA match the local module version
-                            If (([System.Version]$UpdateTriggerWithoutRevision -eq [System.Version]($InstalledModulePostUpdate.Version | Measure-Object -Maximum ).Maximum) -And ([System.String]$UpdateTriggerFullDatetime -eq [System.String]($InstalledModulePostUpdate.PrereleaseLabel | Measure-Object -Maximum ).Maximum))
-                            {
-                                # Load new module
-                                Import-Module -Name:($ModuleName) -Scope:('Global') -Force
-                                # Confirm to user module update has been successful
-                                Write-Host ('STATUS:') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Header)
-                                Write-Host ($JCColorConfig.IndentChar) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Indentation) -NoNewline
-                                Write-Host ('The ' + $ModuleName + ' PowerShell module has successfully been updated!') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
-                            }
-                            Else
-                            {
-                                Write-Error ("Failed to update the $($ModuleName) PowerShell module to the latest version. $($UpdateTrigger) is not in $($InstalledModulePostUpdate.Version -join ', ')")
-                            }
+                            # Load new module
+                            Import-Module -Name:($ModuleName) -Scope:('Global') -Force
+                            # Confirm to user module update has been successful
+                            Write-Host ('STATUS:') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Header)
+                            Write-Host ($JCColorConfig.IndentChar) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Indentation) -NoNewline
+                            Write-Host ('The ' + $ModuleName + ' PowerShell module has successfully been updated!') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
                         }
-                        else
+                        Else
                         {
-                            Write-Host ('Updating ' + $ModuleName + ' module to version: ') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action) -NoNewline
-                            Write-Host ($UpdateTrigger) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
-                            If ($InstalledModulePreUpdate.Repository -eq 'CodeArtifact')
-                            {
-                                # Install-PSResource here if InstalledModulePreUpdate.repository is codeartifact
-                                # Install-PSResource -Name:($ModuleName) -Repository:('CodeArtifact') -Credential:($RepositoryCredentials) -Prerelease
-                                Install-Module -Name:($ModuleName) -Force -Repository:('PSGallery')
-                            }
-                            else
-                            {
-
-                                $InstalledModulePreUpdate | Update-Module -Force
-                            }
-                            # Remove existing module from the session
-                            Get-Module -Name:($ModuleName) -ListAvailable -All | Remove-Module -Force
-                            # Uninstall previous versions
-                            If (!($SkipUninstallOld))
-                            {
-                                If ($InstalledModulePreUpdate.Repository -eq 'CodeArtifact')
-                                {
-                                    # Uninstall Code Artifact Version of JumpCloud Module
-                                    $InstalledModulePreUpdate | ForEach-Object {
-                                        Write-Host ('Uninstalling ' + $_.Name + ' module version: ') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action) -NoNewline
-                                        Write-Host (($_.Version).ToString()) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
-                                        # Get just the version number if a build number is associated
-                                        $VersionWithoutBuild = "$(($($_.Version)).Major).$(($($_.Version)).Minor).$(($($_.Version)).Build)"
-                                        # Specify the version, Uninstall-PSResource will remove all versions of a module if not specified
-                                        Uninstall-PSResource -Name 'JumpCloud' -Version $VersionWithoutBuild -Force
-                                    }
-                                    # Uninstall Code Artifact Versions of JumpCloud SDK Modules
-                                    Get-InstalledPSResource | Where-Object { ($_.Name -match 'JumpCloud.SDK') -and ($_.Repository -match 'CodeArtifact') } | ForEach-Object {
-                                        Write-Host ('Uninstalling ' + $_.Name + ' module version: ') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action) -NoNewline
-                                        Write-Host (($_.Version).ToString()) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
-                                        Uninstall-PSResource $_.Name -Version $_.Version -Force
-                                    }
-                                }
-                                else
-                                {
-                                    $InstalledModulePreUpdate | ForEach-Object {
-                                        Write-Host ('Uninstalling ' + $_.Name + ' module version: ') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Action) -NoNewline
-                                        Write-Host (($_.Version).ToString()) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
-                                        $_ | Uninstall-Module -Force
-                                    }
-                                }
-                            }
-                            # Validate install
-                            $InstalledModulePostUpdate = Get-InstalledModule -Name:($ModuleName) -AllVersions
-                            # Check to see if the module version on the PowerShell gallery does not match the local module version
-                            If ([System.Version]$UpdateTrigger -eq [System.Version]($InstalledModulePostUpdate.Version | Measure-Object -Maximum).Maximum)
-                            {
-                                # Load new module
-                                Import-Module -Name:($ModuleName) -Scope:('Global') -Force
-                                # Confirm to user module update has been successful
-                                Write-Host ('STATUS:') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Header)
-                                Write-Host ($JCColorConfig.IndentChar) -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Indentation) -NoNewline
-                                Write-Host ('The ' + $ModuleName + ' PowerShell module has successfully been updated!') -BackgroundColor:($JCColorConfig.BackgroundColor) -ForegroundColor:($JCColorConfig.ForegroundColor_Body)
-                            }
-                            Else
-                            {
-                                Write-Error ("Failed to update the $($ModuleName) PowerShell module to the latest version. $($UpdateTrigger) is not in $($InstalledModulePostUpdate.Version -join ', ')")
-                            }
+                            Write-Error ("Failed to update the $($ModuleName) PowerShell module to the latest version. $($UpdateTrigger) is not in $($InstalledModulePostUpdate.Version -join ', ')")
                         }
                     }
                 }

--- a/PowerShell/ModuleBanner.md
+++ b/PowerShell/ModuleBanner.md
@@ -1,7 +1,7 @@
 #### Latest Version
 
 ```
-1.18.10
+1.18.11
 ```
 
 #### Banner Current

--- a/PowerShell/ModuleChangelog.md
+++ b/PowerShell/ModuleChangelog.md
@@ -1,3 +1,19 @@
+## 1.18.11
+
+Release Date: December 16, 2021
+
+#### RELEASE NOTES
+
+```
+This release reverts a change to the Update-JCModule function which displayed erroneous error messages and includes a roll up bug fixes from the 1.18.9 release.
+```
+
+#### BUG FIXES:
+
+SA-2258 - Fix Set-JCUser function where it would error when setting a user's enrollment windows anywhere between 4-7 days.
+
+SA-2271 - Fix the Regex Pattern used in Import-JCCommand to address change in GitHub.
+
 ## 1.18.10
 
 Release Date: December 5, 2021


### PR DESCRIPTION
## Issues
* [SA-2284](https://jumpcloud.atlassian.net/browse/SA-2284) - Revert changes to Update-JCModule

## What does this solve?
Reverts changes made to the Update-JCModule function to add CodeArtifact repository support. 

## Is there anything particularly tricky?

No this is a reversion, this worked previously

## How should this be tested?

Update 1.18.8 -1.18.11 should work without issue regardless of PowerShellGet version. 
Update 1.18.8 -1.18.11 should work without issue regardless of PowerShellGet version & SDK Version

## Screenshots
