### PR TITLE
Fix wrong exit code appearance caused by file downloading function

### DIFF
--- a/scripts/windows/InstallWindowsAgent.ps1
+++ b/scripts/windows/InstallWindowsAgent.ps1
@@ -55,20 +55,7 @@ Function DownloadLink($Link, $Path)
 {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $WebClient = New-Object -TypeName:('System.Net.WebClient')
-    $Global:IsDownloaded = $false
-    $SplatArgs = @{ InputObject = $WebClient
-        EventName               = 'DownloadFileCompleted'
-        Action                  = { $Global:IsDownloaded = $true; }
-    }
-    $DownloadCompletedEventSubscriber = Register-ObjectEvent @SplatArgs
-    $WebClient.DownloadFileAsync("$Link", "$Path")
-    While (-not $Global:IsDownloaded)
-    {
-        Start-Sleep -Seconds 3
-    } # While
-    $DownloadCompletedEventSubscriber.Dispose()
-    $WebClient.Dispose()
-
+    $WebClient.DownloadFile("$Link", "$Path")
 }
 
 


### PR DESCRIPTION
## What does this solve?
* Fixes the problem that current script exits with exit code 5 although it works well, so using it this way
`powershell -command ./InstallWindowsAgent.ps1 -JumpCloudConnectKey "{{ jumpcloud_key }}"`
in, e.g., ansible, will result in error
* Speeds up a bit, since it will not have 3 seconds waiting period

## Is there anything particularly tricky?
I wonder why synchronous file downloading function was implemented using asynchronous function and some workarounds to make it sync

## How should this be tested?
Just try to install agent with script and check exit code after this in cmd
```
powershell -command ./InstallWindowsAgent.ps1 -JumpCloudConnectKey "{{ instant_jumpcloud_key }}"
echo Exit Code is %errorlevel%
```
At least it is reproducible on windows server 2022

## Screenshots
<img width="978" alt="Screenshot 2022-01-13 at 19 07 51" src="https://user-images.githubusercontent.com/22933197/149366393-a727efa8-04d6-4fd2-ad78-7c3c76c3a319.png">

