### PR TITLE
Async to sync downloads fix/ install windows agent

### DIFF
--- a/scripts/windows/FixWindowsAgent.ps1
+++ b/scripts/windows/FixWindowsAgent.ps1
@@ -150,7 +150,10 @@ Function InstallAgent()
 }
 Function DownloadAgentInstaller()
 {
-    (New-Object System.Net.WebClient).DownloadFile("${AGENT_INSTALLER_URL}", "${AGENT_INSTALLER_PATH}")
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $WebClient = New-Object -TypeName:('System.Net.WebClient')
+    $WebClient.DownloadFile("${AGENT_INSTALLER_URL}", "${AGENT_INSTALLER_PATH}")
+    $WebClient.Dispose()
 }
 
 Function CheckProgramInstalled($programName)
@@ -169,19 +172,9 @@ Function CheckProgramInstalled($programName)
 Function DownloadLink($Link, $Path)
 {
 
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $WebClient = New-Object -TypeName:('System.Net.WebClient')
-    $Global:IsDownloaded = $false
-    $SplatArgs = @{ InputObject = $WebClient
-        EventName               = 'DownloadFileCompleted'
-        Action                  = { $Global:IsDownloaded = $true; }
-    }
-    $DownloadCompletedEventSubscriber = Register-ObjectEvent @SplatArgs
-    $WebClient.DownloadFileAsync("$Link", "$Path")
-    While (-not $Global:IsDownloaded)
-    {
-        Start-Sleep -Seconds 3
-    } # While
-    $DownloadCompletedEventSubscriber.Dispose()
+    $WebClient.DownloadFile("$Link", "$Path")
     $WebClient.Dispose()
 
 }

--- a/scripts/windows/InstallWindowsAgent.ps1
+++ b/scripts/windows/InstallWindowsAgent.ps1
@@ -55,20 +55,8 @@ Function DownloadLink($Link, $Path)
 {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $WebClient = New-Object -TypeName:('System.Net.WebClient')
-    $Global:IsDownloaded = $false
-    $SplatArgs = @{ InputObject = $WebClient
-        EventName               = 'DownloadFileCompleted'
-        Action                  = { $Global:IsDownloaded = $true; }
-    }
-    $DownloadCompletedEventSubscriber = Register-ObjectEvent @SplatArgs
-    $WebClient.DownloadFileAsync("$Link", "$Path")
-    While (-not $Global:IsDownloaded)
-    {
-        Start-Sleep -Seconds 3
-    } # While
-    $DownloadCompletedEventSubscriber.Dispose()
+    $WebClient.DownloadFile("$Link", "$Path")
     $WebClient.Dispose()
-
 }
 
 


### PR DESCRIPTION
## Issues
* [SA-2343](https://jumpcloud.atlassian.net/browse/SA-2343) - Switch Async calls to synchronous in fixWindowsAgent.ps1, InstallWindowsAgent.ps1

## What does this solve?

- Fixes the problem that current script exits with exit code 5 although it works well, so using it this way `powershell -command ./InstallWindowsAgent.ps1 -JumpCloudConnectKey "{{ jumpcloud_key }}"` in, e.g., ansible, will result in error
- Speeds up a bit, since it will not have 3 seconds waiting period

## Is there anything particularly tricky?

NA

## How should this be tested?

Test both functions work and exit 0

## Screenshots
