### PR TITLE
Sa 2351 manual build check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,6 @@ workflows:
     jobs:
     - path-filtering/filter:
         mapping: |
-          Powershell\/(?!JumpCloud\sCommands\sGallery|JumpCloud\sOffice365\sSSO).* PowerShellModified true
+          PowerShell\/(?!JumpCloud\sCommands\sGallery|JumpCloud\sOffice365\sSSO).* PowerShellModified true
         base-revision: master
         config-path: .circleci/workflows.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  path-filtering: circleci/path-filtering@0.0.2
+  path-filtering: circleci/path-filtering@0.1.1
 workflows:
   version: 2
   check-updated-files:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,6 @@ workflows:
     jobs:
     - path-filtering/filter:
         mapping: |
-          Powershell\/(?!JumpCloud\sCommands\sGallery|JumpCloud\.Office365\.SSO).* PowerShellModified true
+          Powershell\/(?!JumpCloud\sCommands\sGallery|JumpCloud\sOffice365\sSSO).* PowerShellModified true
         base-revision: master
         config-path: .circleci/workflows.yml

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -3,7 +3,7 @@ parameters:
   ManualBuild:
     description: 'When `true`, pipeline will continue to build even if its been filtered out by config.yml (Will Not Run on Master Branch)'
     type: boolean
-    default: true
+    default: false
   EnableDebugging:
     description: 'When `true`, debugging commands will run and output to terminal.'
     type: boolean

--- a/PowerShell/JumpCloud Module/LICENSE
+++ b/PowerShell/JumpCloud Module/LICENSE
@@ -1,5 +1,5 @@
 JumpCloud
-Copyright (c) 2019-2020 JumpCloud
+Copyright (c) 2019-2022 JumpCloud
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PowerShell/LICENSE
+++ b/PowerShell/LICENSE
@@ -1,5 +1,5 @@
 JumpCloud
-Copyright (c) 2019-2020 JumpCloud
+Copyright (c) 2019-2022 JumpCloud
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PowerShell/LICENSE
+++ b/PowerShell/LICENSE
@@ -1,5 +1,5 @@
 JumpCloud
-Copyright (c) 2019-2022 JumpCloud
+Copyright (c) 2019-2020 JumpCloud
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Issues
* [SA-2351](https://jumpcloud.atlassian.net/browse/SA-2351) - Fix Circle-CI Path-Filtering Mapping

## What does this solve?

Path filtering has never worked as intended. This updates a regex pattern to search the /support repository and only kick off the PowerShell Build Process if files in that repository have been changed. 

## How should this be tested?

Commit a "test" file to any directory outside Support/PowerShell/ - the PS Pipeline should not build
Commit a "test" file to a directory like Support/PowerShell/JumpCloud Command Gallery - the PS Pipeline should not build. 
Commit a "test" file to the Support/PowerShell/PowerShell Module directory - the PS Pipeline should build.

