### PR TITLE
Update Managed Apple ID script when SDKs are released

### DIFF
--- a/scripts/automation/updateManagedAppleId.ps1
+++ b/scripts/automation/updateManagedAppleId.ps1
@@ -16,6 +16,7 @@ if (-not (Get-InstalledModule -Name JumpCloud)) {
 }
 if ([Version](Get-InstalledModule -Name JumpCloud.SDK.V1).Version -lt [Version]"0.0.27") {
     Install-Module JumpCloud.SDK.V1 -Force
+    Install-Module JumpCloud -Force
 }
 Write-Host "Connecting to JumpCloud..."
 Connect-JCOnline -force $JumpCloudApiKey

--- a/scripts/automation/updateManagedAppleId.ps1
+++ b/scripts/automation/updateManagedAppleId.ps1
@@ -14,7 +14,7 @@ if (-not (Get-InstalledModule -Name JumpCloud)) {
     Write-Host "Installing JumpCloud PowerShell Module"
     Install-Module JumpCloud -Force
 }
-if ((Get-InstalledModule -Name JumpCloud.SDK.V1).Version -notmatch 0.0.27) {
+if ((Get-InstalledModule -Name JumpCloud.SDK.V1).Version -lt 0.0.27) {
     Install-Module JumpCloud.SDK.V1 -Force
 }
 Write-Host "Connecting to JumpCloud..."

--- a/scripts/automation/updateManagedAppleId.ps1
+++ b/scripts/automation/updateManagedAppleId.ps1
@@ -16,7 +16,7 @@ if (-not (Get-InstalledModule -Name JumpCloud)) {
 }
 if ([Version](Get-InstalledModule -Name JumpCloud.SDK.V1).Version -lt [Version]"0.0.27") {
     Install-Module JumpCloud.SDK.V1 -Force
-    Install-Module JumpCloud -Force
+    Import-Module JumpCloud.SDK.V1 -Force
 }
 Write-Host "Connecting to JumpCloud..."
 Connect-JCOnline -force $JumpCloudApiKey

--- a/scripts/automation/updateManagedAppleId.ps1
+++ b/scripts/automation/updateManagedAppleId.ps1
@@ -14,7 +14,7 @@ if (-not (Get-InstalledModule -Name JumpCloud)) {
     Write-Host "Installing JumpCloud PowerShell Module"
     Install-Module JumpCloud -Force
 }
-if ((Get-InstalledModule -Name JumpCloud.SDK.V1).Version -lt 0.0.27) {
+if ([Version](Get-InstalledModule -Name JumpCloud.SDK.V1).Version -lt [Version]"0.0.27") {
     Install-Module JumpCloud.SDK.V1 -Force
 }
 Write-Host "Connecting to JumpCloud..."


### PR DESCRIPTION
## Issues
* [SA-2272](https://jumpcloud.atlassian.net/browse/SA-2272) - Update Managed Apple ID script when SDKs are released

## What does this solve?
Removes calling API manually and instead uses PowerShell SDKs

## Is there anything particularly tricky?
No

## How should this be tested?
* Have old version of SDK.V1 installed - ensure that it gets updated
* Don't have SDK.V1 installed - ensure that it gets installed
* Ensure that rows are skipped if they meet the following criteria:
  * Null/Whitespace, Invalid Email Address or ManagedAppleID already matches 
