### PR TITLE
UN-888 install crowdstrike falcon agent script

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Install CrowdStrike Falcon Agent.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Install CrowdStrike Falcon Agent.md
@@ -17,36 +17,31 @@ $installerURL="ENTER URL TO FALCON AGENT INSTALLER HERE"
 $installerTempLocation="C:\Windows\Temp\CSFalconAgentInstaller.exe"
 
 if(Get-Service "CSFalconService" -ErrorAction SilentlyContinue) {
-    write-host("Falcon Agent already installed, nothing to do.")
+    Write-Host("Falcon Agent already installed, nothing to do.")
     exit 0
 }
-write-host("Falcon Agent not installed.")
+Write-Host("Falcon Agent not installed.")
 
-write-host("Downloading Falcon Agent installer now.")
+Write-Host("Downloading Falcon Agent installer now.")
 try {
-    $webClient = New-Object System.Net.WebClient 
-    $webClient.DownloadFile($installerURL, $installerTempLocation)
-}
-catch [System.Net.WebException],[System.IO.IOException] {
-    write-host("Unable to download Falcon Agent Installer")
-    exit 1
+    Invoke-WebRequest -Uri $installerURL -OutFile $installerTempLocation
 }
 catch {
-    write-host("An unknown error occurred downloading the Falcon Agent Installer.")
+    Write-Error("Unable to download Falcon Agent Installer".)
     exit 1
 }
-write-host("Finished downloading Falcon Agent installer.")
+Write-Host("Finished downloading Falcon Agent installer.")
 
-write-host("Installing Falcon Agent now, this may take a few minutes.")
+Write-Host("Installing Falcon Agent now, this may take a few minutes.")
 try {
     $args = @("/install","/quiet","/norestart","CID=$CID") 
     $installerProcess = Start-Process -FilePath $installerTempLocation -Wait -PassThru -ArgumentList $args
 }
 catch {
-    write-error("Failed to run Falcon Agent installer.")
+    Write-Error("Failed to run Falcon Agent installer.")
     exit 1
 }
-write-host("Falcon Agent installer returned $($installerProcess.ExitCode).")
+Write-Host("Falcon Agent installer returned $($installerProcess.ExitCode).")
 
 exit $installerProcess.ExitCode
 

--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Install CrowdStrike Falcon Agent.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Install CrowdStrike Falcon Agent.md
@@ -1,0 +1,65 @@
+#### Name
+
+Windows - Install CrowdStrike Falcon Agent | v1.0 JCCG
+
+#### commandType
+
+windows
+
+#### Command
+
+```
+$CID="ENTER CID HERE"
+$installerURL="ENTER URL TO FALCON AGENT INSTALLER HERE"
+
+##### Do Not Edit Below This Line #####
+
+$installerTempLocation="C:\Windows\Temp\CSFalconAgentInstaller.exe"
+
+if(Get-Service "CSFalconService" -ErrorAction SilentlyContinue) {
+    write-host("Falcon Agent already installed, nothing to do.")
+    exit 0
+}
+write-host("Falcon Agent not installed.")
+
+write-host("Downloading Falcon Agent installer now.")
+try {
+    $webClient = New-Object System.Net.WebClient 
+    $webClient.DownloadFile($installerURL, $installerTempLocation)
+}
+catch [System.Net.WebException],[System.IO.IOException] {
+    write-host("Unable to download Falcon Agent Installer")
+    exit 1
+}
+catch {
+    write-host("An unknown error occurred downloading the Falcon Agent Installer.")
+    exit 1
+}
+write-host("Finished downloading Falcon Agent installer.")
+
+write-host("Installing Falcon Agent now, this may take a few minutes.")
+try {
+    $args = @("/install","/quiet","/norestart","CID=$CID") 
+    $installerProcess = Start-Process -FilePath $installerTempLocation -Wait -PassThru -ArgumentList $args
+}
+catch {
+    write-error("Failed to run Falcon Agent installer.")
+    exit 1
+}
+write-host("Falcon Agent installer returned $($installerProcess.ExitCode).")
+
+exit $installerProcess.ExitCode
+
+```
+
+#### Description
+
+This command will download and install the CrowdStrike Falcon Agent to the device if it isn't already installed.  In order to use this command, you must know your Customer ID (CID) and have a valid download URL for the Falcon Agent Installer.
+
+### *Import This Command*
+
+To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
+
+```
+Import-JCCommand -URL 'https://TODO.UPDATE.ONCE.MERGED.INTO.MASTER'
+```


### PR DESCRIPTION
## Issues
* [UN-888](https://jumpcloud.atlassian.net/browse/UN-888) - PowerShell Script to Install CrowdStrike Falcon Added to JumpCloud Command Gallery

## What does this solve?
Adds a command gallery script for downloading and installing the crowdstrike falcon agent

## Is there anything particularly tricky?
No

## How should this be tested?
1. Get access to a CrowdStrike account (You can ask DanM, NickW, or Chase Doeling for access)
2. Login to CrowdStrike
3. Download the falcon agent installer for windows
4. Record the customer ID (CID)
5. Host the installer somewhere - dropbox has been confirmed to work
6. Download the script from the gallery, enter the CID and the URL where the installer is hosted into the script
7. Run the script, make sure it downloads and installs the falcon agent
8. Run the script again, make sure it does not re-download or re-install the falcon agent
9. Get in contact with Ryan Bacon in IT.  He has volunteered/asked to test the script out as well.

## Screenshots
None
