### PR TITLE
MDM group example

### DIFF
--- a/_posts/2022-02-10-Group-Systems-By-MDM-Status.md
+++ b/_posts/2022-02-10-Group-Systems-By-MDM-Status.md
@@ -1,0 +1,133 @@
+---
+layout: post
+title: Group Systems by MDM Enrollment Status
+description: Automatically group systems by MDM Enrollment status
+tags:
+  - powershell
+  - groups
+  - mdm
+---
+
+This script will create two device groups: MacOS-MDM-Pending & MacOS-MDM-Approved. It can be run multiple times to update the membership of the two system groups. If systems are waiting on MDM user approval they will be added to the MacOS-MDM-Pending group. Systems enrolled in JumpCloud MDM and user approved are added to the MacOS-MDM-Approved group.
+
+### Basic Usage
+
+* The PowerShell Module is required to run this script
+* Save the script to a location
+* Run `Connect-JCOnline` before executing this script
+* In a PowerShell terminal window, run the script `~/Path/To/Scrpt/filename.ps1`
+
+### Additional Information
+
+This script will create two system groups (if they do not already exist). (Optionally) Modify The `$mdmApproved` & `$mdmPending` variables to change the two system group names the script will create/update. It can be run multiple times to add new systems to groups.
+
+### Expected Output
+
+The terminal window in which this script is run should display systemsNames, SystemGroups and the UserApprovedMDM status in a table like the example below:
+
+| SystemName                      | SystemGroup        | UserApprovedMDM |
+|---------------------------------|--------------------|-----------------|
+| mdm-system                      | MacOS-MDM-Approved | true            |
+| defaultadmins-MacBook-Air       | MacOS-MDM-Approved | true            |
+| Farmer367-MacBook-Air           | MacOS-MDM-Approved | true            |
+| TamirD-ISR-PRO-Mac              | MacOS-MDM-Approved | true            |
+| Farmer345-MacBook               | MacOS-MDM-Approved | true            |
+| Farmer345-MacBookPro            | MacOS-MDM-Pending  | false           |
+| BobFays-BigSur-VM               | MacOS-MDM-Pending  | false           |
+| mdm-testing                     | MacOS-MDM-Pending  | false           |
+| Farmer121-MacBookPro            | MacOS-MDM-Pending  | false           |
+
+### Script
+
+```powershell
+################################################################################
+# This script requires the JumpCloud PowerShell Module to run. Specifically, the
+# JumpCloud PowerShell SDK Modules are required to run the system queries. To
+# install the PowerShell Modules, enter the following line in a PWSH terminal:
+# Install-Module JumpCloud
+#
+# This script will search for systems and add them to system groups if they are
+# not currently members of that group. It is intended to group systems by MDM
+# enrollment status.
+#
+# This script can be run multiple times. As systems are added to JumpCloud, they
+# will then be added to the defined system groups.
+################################################################################
+# Get all mac systems
+$allMacSystems = Get-JCSystem | Where-Object { $_.osFamily -eq "darwin" }
+# system groups
+$mdmApproved = "MacOS-MDM-Approved"
+$mdmPending = "MacOS-MDM-Pending"
+# IF the group names do not exist, create them...
+if (-Not (Get-JCGroup -Type System -Name $mdmApproved)){
+    New-JcSdkSystemGroup -name $mdmApproved
+}
+if (-Not (Get-JCGroup -Type System -Name $mdmPending)) {
+    New-JcSdkSystemGroup -name $mdmPending
+}
+# Get id of the two system groups
+$mdmApprovedId = Get-JCGroup -Type System -Name $mdmApproved | select-object id
+$mdmPendingId = Get-JCGroup -Type System -Name $mdmPending | select-object id
+# Create an empty list to track the systems with User Approved MDM (UAMDM)
+$userApprovedMdm = @()
+# Get the ids of the systems already in the system groups
+$userApprovedMdmSystems = Get-JCSystemGroupMember -GroupName $mdmApproved | select-object SystemID
+$pendingMdmApprovalSystems = Get-JCSystemGroupMember -GroupName $mdmPending | select-object SystemID
+
+# For each mac system:
+$trackingList = @()
+foreach ($system in $allMacSystems)
+{
+    # If that system is user approved and using JumpCloud MDM
+    if ($system.mdm.userApproved -eq $True -and $system.mdm.vendor -eq "internal")
+    {
+        if ($system._id -notin $userApprovedMdmSystems.SystemID) {
+        # if system is not in the mdm approved group, add it
+            Set-JcSdkSystemGroupMember -GroupId:$mdmApprovedId.id -Op:add -Id:$system._id
+            $TrackingList += [PSCustomObject]@{
+                SystemName      = $($system.hostname)
+                SystemGroup     = $mdmApproved
+                UserApprovedMDM = $True
+            }
+        }
+        else {
+            # Else just track it
+            $TrackingList += [PSCustomObject]@{
+                SystemName      = $($system.hostname)
+                SystemGroup     = $mdmApproved
+                UserApprovedMDM = $True
+            }
+        }
+        # If system is in the pending group, remove it from that group
+        if ($system._id -in $pendingMdmApprovalSystems.SystemID) {
+            Set-JcSdkSystemGroupMember -GroupId:$mdmPendingId.id -Op:remove -Id:$system._id
+        }
+    }
+    else{
+        # If the system is no user approved and using JumpCloud MDM
+        if ( $system._id -notin $pendingMdmApprovalSystems.SystemID) {
+            # if system is not in the mdm pending group, add it
+            Set-JcSdkSystemGroupMember -GroupId:$mdmPendingId.id -Op:add -Id:$system._id
+            $TrackingList += [PSCustomObject]@{
+                SystemName      = $($system.hostname)
+                SystemGroup     = $mdmPending
+                UserApprovedMDM = $False
+            }
+        }
+        else {
+            # Else just track it
+            $TrackingList += [PSCustomObject]@{
+                SystemName      = $($system.hostname)
+                SystemGroup     = $mdmPending
+                UserApprovedMDM = $False
+            }
+        }
+        # If the system is in the approved MDM group, but it shouldn't be, remove it
+        if ( $system._id -in $userApprovedMdmSystems.SystemID) {
+            Set-JcSdkSystemGroupMember -GroupId:$mdmApprovedId.id -Op:remove -Id:$system._id
+        }
+    }
+}
+# Print Results
+$trackingList | Sort-Object UserApprovedMDM -Descending | Format-Table | Out-Host
+```

--- a/tag/mdm.md
+++ b/tag/mdm.md
@@ -1,0 +1,7 @@
+---
+layout: tagpage
+title: "Tag: mdm"
+tag: mdm
+description: "Script examples related to: mdm"
+robots: noindex
+---


### PR DESCRIPTION
## Issues
* [SA-2395](https://jumpcloud.atlassian.net/browse/SA-2395) - Group mac systems by MDM approval status

## What does this solve?

Gathering MDM approval status is tricky in the UI, maintaining system groups membership is impossible without the API. This script groups systems by the `system.mdm.userapproved` attribute. User Approved MDM is required for specific MDM workflows .

Two groups will be created while running this script: 
`MacOS-MDM-Approved`
`MacOS-MDM-Pending`

Mac systems are queried while running this script. If they have their user approval attribute set (and are managed by JumpCloud MDM) those systems are added to the `MacOS-MDM-Approved` group. Systems without this attribute are placed in the `MacOS-MDM-Pending` group. Membership is updated each time the script is run. 

## Is there anything particularly tricky?

No but systems enrolled in MDM are needed to test this.

## How should this be tested?

In an org with MDM, User Approved systems, non User approved systems run the script and verify that systems are added/ removed from the correct groups. 

## Screenshots
Script output:
![Screen Shot 2022-02-10 at 2 45 09 PM](https://user-images.githubusercontent.com/54448601/153501670-2ad803d9-734c-48be-8b81-801caa10a357.png)
Approved MDM System Group:
![Screen Shot 2022-02-10 at 2 46 33 PM](https://user-images.githubusercontent.com/54448601/153501891-4b44aed7-28f3-4a91-b40e-c65939f00f1a.png)
Pending MDM Approval System Group:
![Screen Shot 2022-02-10 at 2 47 13 PM](https://user-images.githubusercontent.com/54448601/153502104-c43c9c01-fc70-4763-9cbb-42e6e1ae53d4.png)

