### PR TITLE
SA-2419 - Increase .main-content max-width on larger resolutions

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -158,3 +158,9 @@ body {
 	}
 	.page_number { position: absolute; left: 50%; top: 50%; font-size: 12px; color: $jcTertiary100; }
 }
+
+@media screen and (min-width: 64em) {
+	.main-content {
+		max-width: 105rem;
+	}
+}


### PR DESCRIPTION
## Issues
* [SA-2419](https://jumpcloud.atlassian.net/browse/SA-2419) - Improve visibility on larger resolutions

## What does this solve?
Increases the size of the margins to allow for easier reading at larger resolutions

## Is there anything particularly tricky?
No

## How should this be tested?
1. `cd` into the theme's directory
2. Install [jekyll](Install this: https://jekyllrb.com)
3. Run `deploy/bootstrap` to install the necessary dependencies
4. Run`bundle add webrick` (potentially already installed)
5. Run `bundle exec jekyll serve` to start the preview server
6. Visit [`localhost:4000`](http://localhost:4000) in your browser to preview the theme
7. Check various posts/pages at different resolutions

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/89030113/156616712-98a94398-fce4-4bad-96c8-e765d53287cb.png)
![image](https://user-images.githubusercontent.com/89030113/156616987-1349e54d-dc23-4c63-9297-3e112039a395.png)



After:
![image](https://user-images.githubusercontent.com/89030113/156616820-a68638dd-072e-4fb4-b7af-e81b99d2d8fe.png)
![image](https://user-images.githubusercontent.com/89030113/156617195-4ed8ced7-8db4-4434-aa7e-4d8f460a6bf0.png)
