### PR TITLE
update mac rename hostname script [skip ci]

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Rename System HostName LocalHostName and ComputerName from JumpCloud.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Mac - Rename System HostName LocalHostName and ComputerName from JumpCloud.md
@@ -12,7 +12,7 @@ mac
 #!/bin/bash
 ################################################################################
 # This script will update the system hostname, localHostname & computerName to
-# match the value of the this systems displayName in the JumpCloud console.
+# match the value of this systems displayName in the JumpCloud console.
 # An API Key with read access is required to run this script.
 ################################################################################
 


### PR DESCRIPTION
## Issues
* [SA-2607](https://jumpcloud.atlassian.net/browse/SA-2607) - MacOS Rename Hostname script

## What does this solve?

Mostly customer confusion surrounding the [System Context API](https://support.jumpcloud.com/support/s/article/System-Context-API-KB-Information). The previous iteration of this script would only run on systems enrolled in JumpCloud with an admin connect key. Systems enrolled with MDM / User portal installation were ineligible to use the system context api. 

This script was updated to make use of the read only API Key. In addition, before setting the LocalHostName, the script will validate that the desired name matches the [bonjour requirements](https://apple.lib.utah.edu/bonjour-naming-guidelines/). Namely LocalHostName strings must be: 

* Be a maximum 63 characters in length
* Contain no whitespace characters
* Contain only alphanumeric characters and hyphens '-'
* Hyphens must not exist at the beginning or end of the string ex. '-system-1-' is not allowed

## How should this be tested?

[Import this command](https://github.com/TheJumpCloud/support/blob/110224a9b029d64ebaaf03b0f746a9d0d82ea663/PowerShell/JumpCloud%20Commands%20Gallery/Mac%20Commands/Mac%20-%20Rename%20System%20HostName%20LocalHostName%20and%20ComputerName%20from%20JumpCloud.md) in JumpCloud and run the following test cases where each test requires setting a DisplayName on a system in JumpCloud and running the command. 

| System DisplayName                                               	| Test Expected Result 	| Expected LocalHostname                                          	|
|------------------------------------------------------------------	|----------------------	|-----------------------------------------------------------------	|
| Test-System                                                      	| PASS                 	| Test-system                                                     	|
| Test-System-                                                     	| FAIL                 	|                                                                 	|
| Test-System One                                                  	| PASS                 	| Test-SystemOne                                                  	|
| Test System                                                      	| PASS                 	| TestSystem                                                      	|
| Test:System                                                      	| PASS                 	| TestSystem                                                      	|
| 305834779501752846042702407133145361458676974994438073944751439  	| PASS                 	| 305834779501752846042702407133145361458676974994438073944751439 	|
| 3058347795017528460427024071331453614586769749944380739447514391 	| FAIL                 	|                                                                 	|


## Screenshots
