### PR TITLE
TX-397 - Uninstall legacy Remote Assist before installation

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Install Remote Assist.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Install Remote Assist.md
@@ -9,6 +9,7 @@ windows
 #### Command
 
 ```
+$uninstallerPath="C:\Program Files\JumpCloud\Jumpcloud Assist App\Uninstall Jumpcloud Assist App.exe"
 $installerURL="https://cdn.jumpcloud.com/TheJumpCloud/jumpcloud-remote-assist-agent/latest/jumpcloud-assist-app.exe"
 $JumpCloudThumbprint="7A4844FBF481047BEDBB7A8054069C50E449D355"
 $installerTempLocation=Join-Path $([System.IO.Path]::GetTempPath()) JumpCloudRemoteAssistInstaller.exe
@@ -32,6 +33,19 @@ catch {
     exit 1
 }
 Write-Host "Download complete"
+
+if ( Test-Path $uninstallerPath ) {
+    Write-Host "Uninstalling legacy JumpCloud Remote Assist at " $uninstallerPath
+    try {
+        $uninstallerProcess = Start-Process -FilePath $uninstallerPath -Wait -PassThru -ArgumentList "/S"
+    }
+    catch {
+        Write-Error "Unable to uninstall legacy JumpCloud Remote Assist"
+        Write-Error $_
+        exit 1
+    }
+    Write-Host "Legacy JumpCloud Remote Assist uninstaller completed with exit code $($uninstallerProcess.ExitCode)"
+}
 
 try {
     Write-Host "Verifying installer signature"


### PR DESCRIPTION
## Issues
* [TX-397](https://jumpcloud.atlassian.net/browse/TX-397) - RAS EA Uninstall on Windows for Permission fix

## What does this solve?
Uninstall any versions of RAA in `C:\Program Files\JumpCloud` before installing the new version. Permissions on that folder are restrictive, and subsequent packages will be installed to a different location. The explicit uninstallation prevents having two versions installed simultaneously which could be most confusing.

## Is there anything particularly tricky?
The uninstaller path is hardcoded because the installed versions don't have support for PowerShell cmdlets such as `Uninstall-Package`

## How should this be tested?
Run the command without RAA installed, and run the command with RAA installed

## Screenshots
