### PR TITLE
Sa 2866 set jc command include command type

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -32,7 +32,7 @@ parameters:
     description: "Release Type. Accepted values [ Major, Minor, Patch ]"
     type: enum
     enum: ["Major", "Minor", "Patch"]
-    default: "Major"
+    default: "Patch"
   RequiredModulesRepo:
     description: "PowerShell Repository for JumpCloud SDKs"
     type: enum

--- a/PowerShell/JumpCloud Module/JumpCloud.psd1
+++ b/PowerShell/JumpCloud Module/JumpCloud.psd1
@@ -12,7 +12,7 @@
 RootModule = 'JumpCloud.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0.1'
+ModuleVersion = '2.0.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/PowerShell/JumpCloud Module/Public/Commands/Set-JCCommand.ps1
+++ b/PowerShell/JumpCloud Module/Public/Commands/Set-JCCommand.ps1
@@ -83,31 +83,40 @@ The CommandID will be the 24 character string populated for the _id field.')]
 
         Write-Verbose 'Initilizing NewCommandsArray'
         $NewCommandsArray = @()
-
     }
-
     process
     {
 
         $body = @{}
 
+        $getCommand = Get-JCCommand -commandId $CommandId
+
         foreach ($param in $PSBoundParameters.GetEnumerator())
         {
-
             if ([System.Management.Automation.PSCmdlet]::CommonParameters -contains $param.key) { continue }
 
             if ($param.key -eq 'CommandID', 'JCAPIKey') { continue }
-
+            
+            
             $body.add($param.Key, $param.Value)
-
         }
 
-        $jsonbody = $body | ConvertTo-Json
+        if (!$PSBoundParameters.ContainsKey('timeout')) {
+            $body.Add("timeout", $getCommand.timeout)        
+        }
 
+        if (!$PSBoundParameters.ContainsKey('launchType')) {
+            $body.Add("launchType",$getCommand.launchType)
+            $body.Add("trigger",$getCommand.trigger)
+        }
+        $body.add("commandType", $getCommand.commandType)
+        # Include commandType to body
+
+        $jsonbody = $body | ConvertTo-Json
+        Write-Debug "Json  = $($jsonbody)"
         $NewCommand = Invoke-RestMethod -Uri $URL -Method PUT -Body $jsonbody -Headers $hdrs -UserAgent:(Get-JCUserAgent)
 
         $NewCommandsArray += $NewCommand
-
     }
 
     end

--- a/PowerShell/JumpCloud Module/Tests/Public/Commands/Set-JCCommand.tests.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Commands/Set-JCCommand.tests.ps1
@@ -33,3 +33,13 @@ Describe -Tag:('JCCommand') "Set-JCCommand 1.7" {
         $SetBack = Set-JCCommand -CommandID $PesterParams_Command3.id -timeout $CmdQuery.timeout
     }
 }
+Describe -Tag:('JCCommand') "Set-JCCommand 2.0.2" {
+    It "Updates the name of a command but not the timeout/ trigger" {
+        $CmdQuery = Get-JCCommand -CommandID $PesterParams_Command3.id
+        $CmdUpdate = Set-JCCommand -CommandID $PesterParams_Command3.id -name "update Test"
+        $CmdUpdate.timeout | Should -Be $CmdQuery.timeout
+        $CmdUpdate.launchType | Should -Be $CmdQuery.launchType
+        $SetBack = Set-JCCommand -CommandID $PesterParams_Command3.id -name $CmdQuery.Name
+    }
+}
+

--- a/PowerShell/ModuleBanner.md
+++ b/PowerShell/ModuleBanner.md
@@ -1,17 +1,17 @@
 #### Latest Version
 
 ```
-2.0.1
+2.0.2
 ```
 
 #### Banner Current
 
 ```
-This release introduces Parallel processing functionality to several functions (Get-JCUser, Get-JCSystem, Get-JCSystemUser, Get-JCGroup, Get-JCSystemGroupMember, Get-JCUserGroupMember, Get-JCCommand, Get-JCCommandResult, Get-JCCommandTarget). This release modifies New-JCImportTemplate, Update and Import-JCUsersFromCSV to allow imports or updates with LDAP bind and MFA + EnrollmentDays to users
+Bug fix for Set-JCCommand where commandType, launchType, and timeout gets changed to default values.
 ```
 
 #### Banner Old
 
 ```
-* New-JCCommandURL converts Import-JCCommand command url (https://github.com/) to raw github content (https://raw.githubusercontent.com/)
+* This release introduces Parallel processing functionality to several functions (Get-JCUser, Get-JCSystem, Get-JCSystemUser, Get-JCGroup, Get-JCSystemGroupMember, Get-JCUserGroupMember, Get-JCCommand, Get-JCCommandResult, Get-JCCommandTarget). This release modifies New-JCImportTemplate, Update and Import-JCUsersFromCSV to allow imports or updates with LDAP bind and MFA + EnrollmentDays to users
 ```

--- a/PowerShell/ModuleChangelog.md
+++ b/PowerShell/ModuleChangelog.md
@@ -1,3 +1,24 @@
+## 2.0.2
+
+Release Date: October 12, 2022
+
+#### RELEASE NOTES
+
+```
+This release fixes an issue to Set-JCCommand where commandType, launchType, and timeout goes back to default values
+```
+
+#### FEATURES:
+
+N/A
+
+#### IMPROVEMENTS:
+
+N/A
+
+#### BUG FIXES:
+
+Bug fix for Set-JCCommand where commandType, launchType, and timeout gets changed to default values
 ## 2.0.1
 
 Release Date: September 1, 2022


### PR DESCRIPTION
## Issues
* [SA-2866](https://jumpcloud.atlassian.net/browse/SA-2866) - SA-2866-Set-JCCommand-include-commandtype

## What does this solve?
Fixes issue with commandType, timeout, and launchType get set to default when updating a command. Updating parameter(s) should not change other variables/objects that are not being updated.
## Is there anything particularly tricky?
N/A
## How should this be tested?
1. Update name of a command or any of the parameters 
2. Validate commandType, launchType, and timeout are not changed

