### PR TITLE
Sa 2670 jc backup error reporting

### DIFF
--- a/PowerShell/ModuleChangelog.md
+++ b/PowerShell/ModuleChangelog.md
@@ -15,6 +15,7 @@ N/A
 #### IMPROVEMENTS:
 
 - Added -Force switch parameter that populates New-JCImportTemplate with all headers when user update or new user CSV is created
+- Additional reporting added to Backup-JCOrganization. If failed tasks are detected, the status of the function should report which tasks failed
 
 #### BUG FIXES:
 


### PR DESCRIPTION
## Issues
* [SA-2670](https://jumpcloud.atlassian.net/browse/SA-2670) - Improved Error Reporting for Get-JCBackup

## What does this solve?

Backup-JCOrganization creates background jobs for each type of backup object requested. If there was a timeout, internet outage or other API error which prevented the job from gathering data from the JumpCloud API an error was not thrown. Now the tasks requested of each job are wrapped in a try/catch loop. Status of each job should be reported at the end of a backup job.

## Is there anything particularly tricky?

## How should this be tested?

- Import the local module and connect to a JumpCloud organization.
- Ensure at least one user is bound to one system

Test that the function still works as expected
- Run `Backup-JCOrganization -Type Organizations, User -Path -Association ./ -debug`
- The Backup Jobs should complete without error

Test that the function throws an error
- Before running the command be prepared to disconnect the network halfway through the command
- Run `Backup-JCOrganization -Type Organizations, User -Path -Association ./ -debug`
- The Backup Jobs tasks should complete but error for at least several jobs. 
- The Jobs that failed should be displayed at the end of the function run


## Screenshots

Successful Job
![Screen Shot 2022-11-07 at 2 41 09 PM](https://user-images.githubusercontent.com/54448601/200421399-03483fcb-cccc-4e78-8cd5-a2d000b89d10.png)

Job with failures
![Screen Shot 2022-11-07 at 2 41 22 PM](https://user-images.githubusercontent.com/54448601/200421444-43039d8b-b40c-4de4-b04c-07e4def2214f.png)


