### PR TITLE
HE-2491 - Use CDN for new agent install for Windows/macOS command line

### DIFF
--- a/scripts/macos/install_agent_and_serviceaccount.sh
+++ b/scripts/macos/install_agent_and_serviceaccount.sh
@@ -216,7 +216,7 @@ else
   # Install Rosetta2 for M1 (Apple Silicon) Macs
   installRosettaForM1
 
-  curl --silent --output /tmp/jumpcloud-agent.pkg "https://s3.amazonaws.com/jumpcloud-windows-agent/production/jumpcloud-agent.pkg" >/dev/null
+  curl --silent --output /tmp/jumpcloud-agent.pkg "https://cdn.jumpcloud.com/production/jumpcloud-agent.pkg" >/dev/null
   mkdir -p /opt/jc
   cat <<-EOF >/opt/jc/agentBootstrap.json
 {

--- a/scripts/windows/InstallWindowsAgent.ps1
+++ b/scripts/windows/InstallWindowsAgent.ps1
@@ -20,7 +20,7 @@ $msvc2013x86Install = "$TempPath$msvc2013x86File /install /quiet /norestart"
 $msvc2013x64Install = "$TempPath$msvc2013x64File /install /quiet /norestart"
 $AGENT_PATH = "${env:ProgramFiles}\JumpCloud"
 $AGENT_BINARY_NAME = "JumpCloud-agent.exe"
-$AGENT_INSTALLER_URL = "https://s3.amazonaws.com/jumpcloud-windows-agent/production/JumpCloudInstaller.exe"
+$AGENT_INSTALLER_URL = "https://cdn.jumpcloud.com/production/JumpCloudInstaller.exe"
 $AGENT_INSTALLER_PATH = "C:\windows\Temp\JumpCloudInstaller.exe"
 
 # JumpCloud Agent Installation Functions


### PR DESCRIPTION
## Issues
* [HE-2491](https://jumpcloud.atlassian.net/browse/HE-2491) - Use CDN for new agent install for Windows/macOS command line

## What does this solve?
Changes the URL for the agent download to the new CDN path.

## Is there anything particularly tricky?
No

## How should this be tested?
Test agent can be installed for macOS/Windows using the scripts.

## Screenshots
