### PR TITLE
Sa 3079 uninstall script changes

### DIFF
--- a/scripts/macos/remove_mac_agent.sh
+++ b/scripts/macos/remove_mac_agent.sh
@@ -6,12 +6,10 @@ fi
 
 # Remove Remote Assist App
 if [[ -d "/Applications/JumpCloud Remote Assist.app" ]];then
-  echo "Removing JumpCloud Remote Assist Application"
   rm -rf "/Applications/JumpCloud Remote Assist.app"
 fi
 # Remove Service Account App
 if [[ -d "/Applications/JumpCloudServiceAccount.app" ]];then
-  echo "Removing JumpCloud Service Account Application"
   rm -rf "/Applications/JumpCloudServiceAccount.app"
 fi
 
@@ -55,7 +53,6 @@ rm -rf /Applications/Jumpcloud.app
 
 # Remove opt/jc_user_ro directory and contents
 if [[ -d "/opt/jc_user_ro" ]];then
-  echo "Removing jc_user_ro directory"
   rm -rf "/opt/jc_user_ro"
 fi
 
@@ -66,13 +63,11 @@ jcAgents=$(find /Library/LaunchAgents -type f -iname "*jumpcloud*")
 # remove each matching daemon file
 for daemon in $jcDaemons
 do
-  echo "Removing $daemon"
   rm -rf $daemon
 done
 # remove each matching agent file
 for agent in $jcAgents
 do
-  echo "Removing $agent"
   rm -rf $agent
 done
 # verify no jumpcloud processes are still running. kill and straglers

--- a/scripts/macos/remove_mac_agent.sh
+++ b/scripts/macos/remove_mac_agent.sh
@@ -4,6 +4,17 @@ if [[ $(id -u) -ne 0 ]]; then
   exit 1
 fi
 
+# Remove Remote Assist App
+if [[ -d "/Applications/JumpCloud Remote Assist.app" ]];then
+  echo "Removing JumpCloud Remote Assist Application"
+  rm -rf "/Applications/JumpCloud Remote Assist.app"
+fi
+# Remove Service Account App
+if [[ -d "/Applications/JumpCloudServiceAccount.app" ]];then
+  echo "Removing JumpCloud Service Account Application"
+  rm -rf "/Applications/JumpCloudServiceAccount.app"
+fi
+
 AGENT_UNINSTALL_SCRIPT="/opt/jc/bin/removeAgent"
 
 if [[ -f $AGENT_UNINSTALL_SCRIPT ]]; then
@@ -42,6 +53,28 @@ done
 rm /Library/LaunchAgents/com.jumpcloud.jcagent-tray.plist
 rm -rf /Applications/Jumpcloud.app
 
+# Remove opt/jc_user_ro directory and contents
+if [[ -d "/opt/jc_user_ro" ]];then
+  echo "Removing jc_user_ro directory"
+  rm -rf "/opt/jc_user_ro"
+fi
+
+# get jumpcloud daemons and agents
+jcDaemons=$(find /Library/LaunchDaemons -type f -iname "*jumpcloud*")
+jcAgents=$(find /Library/LaunchAgents -type f -iname "*jumpcloud*")
+
+# remove each matching daemon file
+for daemon in $jcDaemons
+do
+  echo "Removing $daemon"
+  rm -rf $daemon
+done
+# remove each matching agent file
+for agent in $jcAgents
+do
+  echo "Removing $agent"
+  rm -rf $agent
+done
 # verify no jumpcloud processes are still running. kill and straglers
 # implemented in response to desk case #28825.
 if (pgrep -fi "[j]umpcloud" &> /dev/null); then


### PR DESCRIPTION
## Issues
* [SA-3079](https://jumpcloud.atlassian.net/browse/SA-3079) - Uninstall Mac Agent Changes

## What does this solve?

This script change adds several checks to the `remove_mac_agent.sh` script. Per customer asks, when we remove the JumpCloud agent from a system we should also remove

- Remote Assist & JumpCloudServiceAccount Applications
- Launch Agents, Daemons
- opt/jc_user_ro directories

## Is there anything particularly tricky?

No, the script will check if any of the items listed above are present on the system before attempting to delete them from a system.

## How should this be tested?

On a JumpCloud managed system, install the Remote Assist App & ensure at least one user is bound to the device. 

1. Run this modified `remove_mac_agent.sh` script: `sudo sh /path/to/remove_mac_agent.sh`
2. Validate that the JumpCloud agent was removed
3. Validate that the `opt/jc_user_ro` directory no longer exists
4. Validate that both the `JumpCloud Remote Assist` & `JumpCloudServiceAccount` applications were removed from the /Applications directory
5. Validate the the `*jumpcloud*` files were removed from both `/Library/LaunchDaemons` & `/Library/LaunchAgents` directories.
6. Re-install JumpCloud, validate that you can bind users

## Screenshots


[SA-3079]: https://jumpcloud.atlassian.net/browse/SA-3079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ