### PR TITLE
Sa 3121 fix windows agent script path

### DIFF
--- a/scripts/windows/FixWindowsAgent.ps1
+++ b/scripts/windows/FixWindowsAgent.ps1
@@ -68,7 +68,9 @@ Function InstallAgent() {
 Function UninstallAgent() {
     # Due to PowerShell's incredible weakness in dealing with paths containing SPACEs, we need to
     # to hard-code this path...
-    $params = ("${env:ProgramFiles}\JumpCloud\unins000.exe", "/VERYSILENT", "/SUPPRESSMSGBOXES")
+    $uninstallPath = Resolve-Path -path "${env:ProgramFiles}\JumpCloud\unins000.exe"
+    $uninstallPath = $uninstallPath -replace " ", "`` "
+    $params = ("$uninstallPath", "/VERYSILENT", "/SUPPRESSMSGBOXES")
     Invoke-Expression "$params"
 }
 

--- a/scripts/windows/FixWindowsAgent.ps1
+++ b/scripts/windows/FixWindowsAgent.ps1
@@ -68,7 +68,7 @@ Function InstallAgent() {
 Function UninstallAgent() {
     # Due to PowerShell's incredible weakness in dealing with paths containing SPACEs, we need to
     # to hard-code this path...
-    $uninstallPath = Resolve-Path -path "${env:ProgramFiles}\JumpCloud\unins000.exe"
+    $uninstallPath = Resolve-Path -Path "${env:ProgramFiles}\JumpCloud\unins000.exe"
     $uninstallPath = $uninstallPath -replace " ", "`` "
     $params = ("$uninstallPath", "/VERYSILENT", "/SUPPRESSMSGBOXES")
     Invoke-Expression "$params"
@@ -160,13 +160,13 @@ Function DownloadAndInstallAgent(
     , [System.String]$msvc2013x86Install
 ) {
     If (!(CheckProgramInstalled("Microsoft Visual C\+\+ 2013 x64"))) {
-        Write-Output "Downloading & Installing JCAgent prereq Visual C++ 2013 x64"
+        Write-Output "Downloading and Installing JCAgent prereq Visual C++ 2013 x64"
         DownloadLink -Link:($msvc2013x64Link) -Path:($TempPath + $msvc2013x64File)
         Invoke-Expression -Command:($msvc2013x64Install)
         Write-Output "JCAgent Visual C++ 2013 x64 prereq installed"
     }
     If (!(CheckProgramInstalled("Microsoft Visual C\+\+ 2013 x86"))) {
-        Write-Output 'Downloading & Installing JCAgent prereq Visual C++ 2013 x86'
+        Write-Output 'Downloading and Installing JCAgent prereq Visual C++ 2013 x86'
         DownloadLink -Link:($msvc2013x86Link) -Path:($TempPath + $msvc2013x86File)
         Invoke-Expression -Command:($msvc2013x86Install)
         Write-Output 'JCAgent prereq installed'


### PR DESCRIPTION
## Issues
* [SA-3121](https://jumpcloud.atlassian.net/browse/SA-3121) - Resolve Path in windows agent script

## What does this solve?

Resolve-path should explicitly inform the OS running the script where the JumpCloud Agent Uninstall script is located.

## Is there anything particularly tricky?

## How should this be tested?

Pull this version of the script and run on a windows intel device. It should reinstall and re-register the JumpCloud agent on a device.

## Screenshots
