### PR TITLE
Sa 3171 replace expiring cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,5 @@
 /scripts/automation/Radius/*/*.pfx
 /scripts/automation/Radius/*/*.zip
 /scripts/automation/Radius/*/*.srl
-/scripts/automation/Radius/commands.json
-scripts/automation/Radius/Config.ps1
-scripts/automation/Radius/users.json
+/scripts/automation/Radius/Config.ps1
+/scripts/automation/Radius/users.json

--- a/scripts/automation/Radius/Functions/Private/Generate-UserCert.ps1
+++ b/scripts/automation/Radius/Functions/Private/Generate-UserCert.ps1
@@ -50,7 +50,7 @@ function Generate-UserCert {
                 # Get CSR & Key
                 Write-Host "[status] Get CSR & Key"
                 Invoke-Expression "$opensslBinary req -newkey rsa:2048 -nodes -keyout $userKey -subj `"/C=$($subj.countryCode)/ST=$($subj.stateCode)/L=$($subj.Locality)/O=$($JCORGID)/OU=$($subj.OrganizationUnit)`" -out $userCSR"
-                # take signing request, make cert # specify extensions requets
+                # take signing request, make cert # specify extensions requests
                 Write-Host "[status] take signing request, make cert # specify extensions requets"
                 Invoke-Expression "$opensslBinary x509 -req -extfile $ExtensionPath -days $JCUSERCERTVALIDITY -in $userCSR -CA $rootCA -CAkey $rootCAKey -passin pass:$($JCORGID) -CAcreateserial -out $userCert -extensions v3_req"
                 # validate the cert we cant see it once it goes to pfx
@@ -62,11 +62,11 @@ function Generate-UserCert {
             }
             'EmailDn' {
                 # Create Client cert with email in the subject distinguished name
-                Invoke-Expression "$opensslBinary genrsa -out $userKey 2048 -noout"
+                Invoke-Expression "$opensslBinary genrsa -out $userKey 2048"
                 # Generate User CSR
                 Invoke-Expression "$opensslBinary req -nodes -new -key $rootCAKey -passin pass:$($JCORGID) -out $($userCSR) -subj /C=$($subj.countryCode)/ST=$($subj.stateCode)/L=$($subj.Locality)/O=$($JCORGID)/OU=$($subj.OrganizationUnit)/CN=$($subj.CommonName)"
                 Invoke-Expression "$opensslBinary req -new -key $userKey -out $userCsr -config $ExtensionPath -subj `"/C=$($subj.countryCode)/ST=$($subj.stateCode)/L=$($subj.Locality)/O=$($JCORGID)/OU=$($subj.OrganizationUnit)/CN=/emailAddress=$($user.email)`""
-                # Gennerate User Cert
+                # Generate User Cert
                 Invoke-Expression "$opensslBinary x509 -req -in $userCsr -CA $rootCA -CAkey $rootCAKey -days $JCUSERCERTVALIDITY -passin pass:$($JCORGID) -CAcreateserial -out $userCert -extfile $ExtensionPath"
                 # Combine key and cert to create pfx file
                 Invoke-Expression "$opensslBinary pkcs12 -export -out $userPfx -inkey $userKey -in $userCert -passout pass:$($JCUSERCERTPASS) -legacy"
@@ -80,7 +80,7 @@ function Generate-UserCert {
                 # Generate User CSR
                 Invoke-Expression "$opensslBinary req -nodes -new -key $rootCAKey -passin pass:$($JCORGID) -out $($userCSR) -subj /C=$($subj.countryCode)/ST=$($subj.stateCode)/L=$($subj.Locality)/O=$($JCORGID)/OU=$($subj.OrganizationUnit)/CN=$($subj.CommonName)"
                 Invoke-Expression "$opensslBinary req -new -key $userKey -out $userCSR -config $ExtensionPath -subj `"/C=$($subj.countryCode)/ST=$($subj.stateCode)/L=$($subj.Locality)/O=$($JCORGID)/OU=$($subj.OrganizationUnit)/CN=$($user.username)`""
-                # Gennerate User Cert
+                # Generate User Cert
                 Invoke-Expression "$opensslBinary x509 -req -in $userCSR -CA $rootCA -CAkey $rootCAKey -days $JCUSERCERTVALIDITY -CAcreateserial -passin pass:$($JCORGID) -out $userCert -extfile $ExtensionPath"
                 # Combine key and cert to create pfx file
                 Invoke-Expression "$opensslBinary pkcs12 -export -out $userPfx -inkey $userKey -in $userCert -inkey $userKey -passout pass:$($JCUSERCERTPASS) -legacy"

--- a/scripts/automation/Radius/Functions/Private/Generate-UserCert.ps1
+++ b/scripts/automation/Radius/Functions/Private/Generate-UserCert.ps1
@@ -51,7 +51,7 @@ function Generate-UserCert {
                 Write-Host "[status] Get CSR & Key"
                 Invoke-Expression "$opensslBinary req -newkey rsa:2048 -nodes -keyout $userKey -subj `"/C=$($subj.countryCode)/ST=$($subj.stateCode)/L=$($subj.Locality)/O=$($JCORGID)/OU=$($subj.OrganizationUnit)`" -out $userCSR"
                 # take signing request, make cert # specify extensions requests
-                Write-Host "[status] take signing request, make cert # specify extensions requets"
+                Write-Host "[status] take signing request, make cert # specify extensions requests"
                 Invoke-Expression "$opensslBinary x509 -req -extfile $ExtensionPath -days $JCUSERCERTVALIDITY -in $userCSR -CA $rootCA -CAkey $rootCAKey -passin pass:$($JCORGID) -CAcreateserial -out $userCert -extensions v3_req"
                 # validate the cert we cant see it once it goes to pfx
                 Write-Host "[status] validate the cert we cant see it once it goes to pfx"

--- a/scripts/automation/Radius/Functions/Private/Get-CertInfo.ps1
+++ b/scripts/automation/Radius/Functions/Private/Get-CertInfo.ps1
@@ -1,0 +1,81 @@
+function Get-CertInfo {
+    param (
+        [switch]$RootCA,
+        [switch]$UserCerts
+    )
+    begin {
+        # Import the Config.ps1 variables
+        . "$JCScriptRoot/Config.ps1"
+
+        if ($RootCA) {
+            # Find the RootCA Path
+            $foundCerts = Resolve-Path -Path "$JCScriptRoot/Cert/*cert*.pem" -ErrorAction SilentlyContinue
+        }
+
+        if ($UserCerts) {
+            # Find all userCert paths
+            $foundCerts = Resolve-Path -Path "$JCScriptRoot/UserCerts/*.crt" -ErrorAction SilentlyContinue
+        }
+
+        $certObj = @()
+    }
+    process {
+        # If no cert is found, return null
+        if (!$foundCerts) {
+            $certHash = $null
+        } else {
+            if ($RootCA) {
+                # Create hashtable to contain cert info
+                $certHash = @{}
+                # Use openssl to gather serial, subject, issuer, and enddate information
+                $certInfo = Invoke-Expression "$opensslBinary x509 -in $($foundCerts.Path) -enddate -serial -subject -issuer -noout"
+
+                # Convert string data into a key/value pair
+                $certInfo | ForEach-Object {
+                    $property = $_ | ConvertFrom-StringData
+
+                    # Convert notAfter property into datetime format
+                    if ($property.notAfter) {
+                        $date = $property.notAfter
+                        $date = $date.replace('GMT', '').Trim()
+                        $date = $date -replace '\s+', ' '
+                        $property.notAfter = [datetime]::ParseExact($date , "MMM d HH:mm:ss yyyy", $null)
+                    }
+
+                    $certHash += $property
+                }
+
+                # Add hash to certObj array
+                $certObj += $certHash
+            } elseif ($UserCerts) {
+                foreach ($cert in $foundCerts) {
+                    # Create hashtable to contain cert info
+                    $certHash = @{}
+                    # Use openssl to gather serial, subject, issuer and enddate information
+                    $certInfo = Invoke-Expression "$opensslBinary x509 -in $($cert.Path) -enddate -serial -subject -issuer -noout"
+
+                    # Convert string data into a key/value pair
+                    $certInfo | ForEach-Object {
+                        $property = $_ | ConvertFrom-StringData
+
+                        # Convert notAfter property into datetime format
+                        if ($property.notAfter) {
+                            $date = $property.notAfter
+                            $date = $date.replace('GMT', '').Trim()
+                            $date = $date -replace '\s+', ' '
+                            $property.notAfter = [datetime]::ParseExact($date , "MMM d HH:mm:ss yyyy", $null)
+                        }
+
+                        $certHash += $property
+                    }
+
+                    # Add hash to certObj array
+                    $certObj += $certHash
+                }
+            }
+        }
+    }
+    end {
+        return $certObj
+    }
+}

--- a/scripts/automation/Radius/Functions/Private/Get-ExpiringCertInfo.ps1
+++ b/scripts/automation/Radius/Functions/Private/Get-ExpiringCertInfo.ps1
@@ -1,0 +1,12 @@
+function Get-ExpiringCertInfo {
+    param (
+        $certInfo,
+        $cutoffDate
+    )
+    process {
+        $expiringCerts = $certInfo | Where-Object -Property notAfter -LT $cutoffDate
+    }
+    end {
+        return $expiringCerts
+    }
+}

--- a/scripts/automation/Radius/Functions/Private/Show-RadiusMainMenu.ps1
+++ b/scripts/automation/Radius/Functions/Private/Show-RadiusMainMenu.ps1
@@ -23,7 +23,7 @@ function Show-RadiusMainMenu {
         Write-Host "$([char]0x1b)[32mRoot CA Expiration: $($rootCAInfo.notAfter)`n"
     }
     if ($expiringCerts) {
-        Write-Host "$([char]0x1b)[91m$($expiringCerts.Count) user certs will expire in 15 days `n"
+        Write-Host "$([char]0x1b)[91m$($($expiringCerts.subject).Count) user certs will expire in 15 days `n"
     }
 
     Write-Host "1: Press '1' to generate your Root Certificate."

--- a/scripts/automation/Radius/Functions/Private/Show-RadiusMainMenu.ps1
+++ b/scripts/automation/Radius/Functions/Private/Show-RadiusMainMenu.ps1
@@ -2,9 +2,29 @@ function Show-RadiusMainMenu {
     param (
         [string]$Title = 'JumpCloud Radius Cert Deployment'
     )
+    # Get cert information
+    $rootCAInfo = Get-CertInfo -rootCa
+    $userCertInfo = Get-CertInfo -UserCerts
+
+    # Determine cut off date for expiring certs
+    $cutoffDate = (Get-Date).AddDays(15).Date
+
+    # Find all certs that will expire between current date and cut off date
+    $expiringCerts = Get-ExpiringCertInfo -certInfo $userCertInfo -cutoffDate $cutoffDate
+
+    # Output for Users
     Clear-Host
     Write-Host "================ $Title ================"
-    Write-Host "$([char]0x1b)[96mEdit the variables in Config.ps1 before continuing this script"
+    Write-Host "$([char]0x1b)[33mEdit the variables in Config.ps1 before continuing this script `n"
+    if ($rootCAInfo -eq $null) {
+        Write-Host "$([char]0x1b)[33mNo Root CA detected`n"
+    } else {
+        Write-Host "$([char]0x1b)[32mRoot CA Serial Number: $($rootCAInfo.serial)"
+        Write-Host "$([char]0x1b)[32mRoot CA Expiration: $($rootCAInfo.notAfter)`n"
+    }
+    if ($expiringCerts) {
+        Write-Host "$([char]0x1b)[91m$($expiringCerts.Count) user certs will expire in 15 days `n"
+    }
 
     Write-Host "1: Press '1' to generate your Root Certificate."
     Write-Host "2: Press '2' to generate/update your User Certificate(s)."

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -259,13 +259,20 @@ if (`$CurrentUser -eq "$($user.userName)") {
         Write-Host "RunAsUser Module installed, importing into session..."
         Import-Module RunAsUser -Force
     }
-
-    Expand-Archive -LiteralPath C:\Windows\Temp\$($user.userName)-client-signed.zip -DestinationPath C:\Windows\Temp -Force
+    # create temp new radius directory
+    If (Test-Path "C:\RadiusCert"){
+        Write-Host "Radius Temp Cert Directory Exists"
+    } else {
+        New-Item "C:\RadiusCert" -itemType Directory
+    }
+    # expand archive as root
+    Expand-Archive -LiteralPath C:\Windows\Temp\$($user.userName)-client-signed.zip -DestinationPath C:\RadiusCert -Force
+    # copy to a temp location
     `$password = ConvertTo-SecureString -String $JCUSERCERTPASS -AsPlainText -Force
     `$ScriptBlockInstall = { `$password = ConvertTo-SecureString -String "secret1234!" -AsPlainText -Force
-    Import-PfxCertificate -Password `$password -FilePath "C:\Windows\Temp\$($user.userName)-client-signed.pfx" -CertStoreLocation Cert:\CurrentUser\My
+    Import-PfxCertificate -Password `$password -FilePath "C:\RadiusCert\$($user.userName)-client-signed.pfx" -CertStoreLocation Cert:\CurrentUser\My
     }
-    `$imported = Get-PfxData -Password `$password -FilePath "C:\Windows\Temp\$($user.userName)-client-signed.pfx"
+    `$imported = Get-PfxData -Password `$password -FilePath "C:\RadiusCert\$($user.userName)-client-signed.pfx"
     # Get Current Certs As User
     `$ScriptBlockCleanup = {
         `$certs = Get-ChildItem Cert:\CurrentUser\My\
@@ -302,8 +309,8 @@ if (`$CurrentUser -eq "$($user.userName)") {
     If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.zip"){
         Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.zip"
     }
-    If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.pfx"){
-        Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.pfx"
+    If (Test-Path "C:\RadiusCert\$($user.userName)-client-signed.pfx"){
+        Remove-Item "C:\RadiusCert\$($user.userName)-client-signed.pfx"
     }
 
     # Lastly validate if the cert was installed
@@ -318,8 +325,8 @@ if (`$CurrentUser -eq "$($user.userName)") {
     If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.zip"){
         Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.zip"
     }
-    If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.pfx"){
-        Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.pfx"
+    If (Test-Path "C:\RadiusCert\$($user.userName)-client-signed.pfx"){
+        Remove-Item "C:\RadiusCert\$($user.userName)-client-signed.pfx"
     }
     exit 4
 }

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -52,7 +52,7 @@ if ($RadiusCertCommands.Count -ge 1) {
 # Create commands for each user
 foreach ($user in $userArray) {
     # Get certificate and zip to upload to Commands
-    $userCertFiles = Get-ChildItem -path "$JCScriptRoot/UserCerts" -Filter "$($user.userName)*"
+    $userCertFiles = Get-ChildItem -Path "$JCScriptRoot/UserCerts" -Filter "$($user.userName)*"
     # set crt and pfx filepaths
     $userCrt = ($userCertFiles | Where-Object { $_.Name -match "crt" }).FullName
     $userPfx = ($userCertFiles | Where-Object { $_.Name -match "pfx" }).FullName
@@ -357,6 +357,7 @@ while ($confirmation -ne 'y') {
         Write-Host "[status] Returning to main menu"
         exit
     }
+    $confirmation = Read-Host "Would you like to invoke commands? [y/n]"
 }
 
 $invokeCommands = Invoke-CommandsRetry -jsonFile "$JCScriptRoot\users.json"

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -265,9 +265,8 @@ if (`$CurrentUser -eq "$($user.userName)") {
     } else {
         New-Item "C:\RadiusCert" -itemType Directory
     }
-    # expand archive as root
+    # expand archive as root and copy to temp location
     Expand-Archive -LiteralPath C:\Windows\Temp\$($user.userName)-client-signed.zip -DestinationPath C:\RadiusCert -Force
-    # copy to a temp location
     `$password = ConvertTo-SecureString -String $JCUSERCERTPASS -AsPlainText -Force
     `$ScriptBlockInstall = { `$password = ConvertTo-SecureString -String "secret1234!" -AsPlainText -Force
     Import-PfxCertificate -Password `$password -FilePath "C:\RadiusCert\$($user.userName)-client-signed.pfx" -CertStoreLocation Cert:\CurrentUser\My

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -281,6 +281,13 @@ if (`$CurrentUser -eq "$($user.userName)") {
             }
         }
     }
+    `$scriptBlockValidate = {
+        if (Get-ChildItem Cert:\CurrentUser\My\`$(`$imported.thumbrprint)){
+            return `$true
+        } else {
+            return `$false
+        }
+    }
     Write-Host "Importing Pfx Certificate for $($user.userName)"
     `$certInstall = Invoke-AsCurrentUser -ScriptBlock `$ScriptBlockInstall -CaptureOutput
     `$certInstall
@@ -298,12 +305,12 @@ if (`$CurrentUser -eq "$($user.userName)") {
     If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.pfx"){
         Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.pfx"
     }
-    `$scriptBlockValidate = {
-        if (Get-ChildItem Cert:\CurrentUser\My\`$(`$imported.thumbrprint)){
-            return `$true
-        } else {
-            return `$false
-        }
+
+    # Lastly validate if the cert was installed
+    if (`$certValidate){
+        Write-Host "Cert was installed"
+    } else {
+        Throw "Cert was not installed"
     }
 } else {
     Write-Host "Current logged in user, `$CurrentUser, does not match expected certificate user. Please ensure $($user.userName) is signed in and retry."

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -183,6 +183,15 @@ if [[ `$currentUser ==  $($user.userName) ]]; then
     fi
 else
     echo "Current logged in user, `$currentUser, does not match expected certificate user. Please ensure $($user.userName) is signed in and retry"
+    # Finally clean up files
+    if [[ -f "/tmp/$($user.userName)-client-signed.zip" ]]; then
+        echo "Removing Temp Zip"
+        rm "/tmp/$($user.userName)-client-signed.zip"
+    fi
+    if [[ -f "/tmp/$($user.userName)-client-signed.pfx" ]]; then
+        echo "Removing Temp Pfx"
+        rm "/tmp/$($user.userName)-client-signed.pfx"
+    fi
     exit 4
 fi
 
@@ -277,8 +286,22 @@ if (`$CurrentUser -eq "$($user.userName)") {
     Write-Host "Cleaning Up Previously Installed Certs for $($user.userName)"
     `$certCleanup = Invoke-AsCurrentUser -ScriptBlock `$ScriptBlockCleanup -CaptureOutput
     `$certCleanup
+    # finally clean up temp files:
+    If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.zip"){
+        Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.zip"
+    }
+    If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.pfx"){
+        Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.pfx"
+    }
 } else {
     Write-Host "Current logged in user, `$CurrentUser, does not match expected certificate user. Please ensure $($user.userName) is signed in and retry."
+    # finally clean up temp files:
+    If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.zip"){
+        Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.zip"
+    }
+    If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.pfx"){
+        Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.pfx"
+    }
     exit 4
 }
 "@

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -80,6 +80,7 @@ foreach ($user in $userArray) {
             $property = $_ | ConvertFrom-StringData
             $certHash += $property
         }
+        # TODO: is common name the same depending on the CertType?
         # Create new Command and upload the signed pfx
         try {
             $CommandBody = @{
@@ -124,7 +125,7 @@ if [[ `$currentUser ==  $($user.userName) ]]; then
                 # if cert is installed, no need to update
                 import=false
             else
-                echo "Deleteing Old Radius Cert:"
+                echo "Removing previously installed radius cert:"
                 echo "SN: `${arraySN[`$i]} SHA: `${arraySHA[`$i]}"
                 security delete-certificate -Z "`${arraySHA[`$i]}" /Users/$($user.userName)/Library/Keychains/login.keychain
             fi
@@ -144,6 +145,16 @@ if [[ `$currentUser ==  $($user.userName) ]]; then
         fi
     else
         echo "cert already imported"
+    fi
+
+    # Finally clean up files
+    if [[ -f "/tmp/$($user.userName)-client-signed.zip" ]]; then
+        echo "Removing Temp Zip"
+        rm "/tmp/$($user.userName)-client-signed.zip"
+    fi
+    if [[ -f "/tmp/$($user.userName)-client-signed.pfx" ]]; then
+        echo "Removing Temp Pfx"
+        rm "/tmp/$($user.userName)-client-signed.pfx"
     fi
 else
     echo "Current logged in user, `$currentUser, does not match expected certificate user. Please ensure $($user.userName) is signed in and retry"

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -77,7 +77,7 @@ foreach ($user in $userArray) {
         }
         'EmailDN' {
             # Else set cert identifier to email of cert subject
-            $regex = 'emailAddress = (.*?),'
+            $regex = 'emailAddress = (.*?)$'
             $subjMatch = Select-String -InputObject "$($certHash.Subject)" -Pattern $regex
             $certIdentifier = $subjMatch.matches.Groups[1].value
             # in macOS search user certs by email
@@ -286,6 +286,12 @@ if (`$CurrentUser -eq "$($user.userName)") {
     Write-Host "Cleaning Up Previously Installed Certs for $($user.userName)"
     `$certCleanup = Invoke-AsCurrentUser -ScriptBlock `$ScriptBlockCleanup -CaptureOutput
     `$certCleanup
+
+    if (`$certCleanup -notMatch "$($certHash.serial)"){
+        throw "cert was not installed"
+    } else {
+        Write-Host "Cert was installed"
+    }
     # finally clean up temp files:
     If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.zip"){
         Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.zip"

--- a/scripts/automation/Radius/Functions/Public/Generate-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Generate-UserCerts.ps1
@@ -14,6 +14,13 @@ $SystemHash = Get-JCSystem -returnProperties displayName, os
 if (Test-Path -Path "$JCScriptRoot/users.json" -PathType Leaf) {
     Write-Host "[status] Found user.json file"
     $userArray = Get-Content -Raw -Path "$JCScriptRoot/users.json" | ConvertFrom-Json -Depth 6
+    # If the json is a single item, explicitly make it a list so we can add to it
+    If ($userArray.count -eq 1) {
+        $array = New-Object System.Collections.ArrayList
+        $array.add($userArray)
+        $userArray = $array
+    }
+
 } else {
     Write-Host "[status] users.json file not found"
     $userArray = @()

--- a/scripts/automation/Radius/Functions/Public/Generate-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Generate-UserCerts.ps1
@@ -44,7 +44,7 @@ foreach ($user in $groupMembers) {
         if (Test-Path -Path "$JCScriptRoot/UserCerts/$($MatchedUser.username)-client-signed.pfx") {
             Write-Host "[status] $($MatchedUser.username) already has certs generated... skipping"
         } else {
-            Generate-UserCert -JCORGID $JCORGID -JCUSERCERTVALIDITY $JCUSERCERTVALIDITY -CertType $CertType -user $MatchedUser -rootCAKey "$JCScriptRoot/Cert/selfsigned-ca-key.pem" -rootCA "$JCScriptRoot/Cert/selfsigned-ca-cert.pem"
+            Generate-UserCert -CertType $CertType -user $MatchedUser -rootCAKey "$JCScriptRoot/Cert/selfsigned-ca-key.pem" -rootCA "$JCScriptRoot/Cert/selfsigned-ca-cert.pem"
         }
     } else {
         Write-Host "[status] $($MatchedUser.username) not found in users.json"


### PR DESCRIPTION
## Issues
* [SA-3171](https://jumpcloud.atlassian.net/browse/SA-3171) - Re-Issue Expiring User Certificates

## What does this solve?

This release enables admins to re-generate Radius user certificates and re-deploy them to systems without creating duplicate certificates. Generated user certificates in the `userCerts` directory are checked against their current expiration date. If local user certificates are set to expire within 15 days, the admin running the PowerShell automation will receive a notification that a number of certificates are due to expire soon. 

Admins can then go and regenerate user certificates to address the soon-to-expire certificates.

## Is there anything particularly tricky?

## How should this be tested?

**User Certificate Expiration Notification**

- In `config.ps1` update the `$JCUSERCERTVALIDITY` variable to be 90 days
- Generate user certificates for a group of users.
- The notification regarding expiring user certificate should NOT show
- manually delete the user certificates in the `userCerts` directory
- In `config.ps1` update the `$JCUSERCERTVALIDITY` variable to be 10 days
- Generate user certificates for a group of users.
- The notification regarding expiring user certificate SHOULD show

**Device User Certificate Expiration Tests**

**Windows**

- `UsernameCN`/ `EmailDN`/ `EmailSAN` Test Cases (test each type)
- In `config.ps1` update the `$CertType` variable to be: `UsernameCN`/ `EmailDN`/ `EmailSAN`
- Generate User Certs
- Issue commands to devices and wait until at least one cert is deployed to a windows device
- Either delete the commands or re-run the specific command on the device
- The existing Cert should NOT be deleted from the device, it’s SerialNO should be matched, reinstalled but not deleted from the device
- Delete the User Certs from the UserCerts directory. 
- Re-Generate the User Certificates
- Issues Commands to Devices and wait until the certificate is deployed to the same windows device
- The new certificate should be deployed and any old certificate should be deleted from the user cert store.
- The .pfx/.zip files should not exist in "C:\Windows\Temp\" if the command was run, if the command failed/ was successful

**macOS**

- `UsernameCN`/ `EmailDN`/ `EmailSAN` Test Cases (test each type)
- In `config.ps1` update the `$CertType` variable to be: `UsernameCN`/ `EmailDN`/ `EmailSAN`
- Generate User Certs
- Issue commands to devices and wait until at least one cert is deployed to a macOS device
- Either delete the commands or re-run the specific command on the device
- The existing Cert should NOT be deleted from the device, it’s SerialNO should be matched, reinstalled but not deleted from the device
- Delete the User Certs from the UserCerts directory. 
- Re-Generate the User Certificates
- Issues Commands to Devices and wait until the certificate is deployed to the same macOS device
- The new certificate should be deployed and any old certificate should be deleted from the user cert store.
- The .pfx/.zip files should not exist in "/tmp/" if the command was run, if the command failed/ was successful

## Screenshots


[SA-3171]: https://jumpcloud.atlassian.net/browse/SA-3171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ