### PR TITLE
SA-3199 Specify macOS SSID when importing user certificate

### DIFF
--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -8,6 +8,8 @@ $JCUSERGROUP = 'YOURJCUSERGROUP'
 $JCUSERCERTPASS = 'secret1234!'
 # USER CERT Validity Length (days)
 $JCUSERCERTVALIDITY = 90
+# NETWORK SSID (optional)
+$NETWORKSSID = 'YOUR_SSID'
 # OpenSSLBinary by default this is (openssl)
 # NOTE: If openssl does not work, try using the full path to the openssl file
 # MacOS HomeBrew Example: '/usr/local/Cellar/openssl@3/3.0.7/bin/openssl'

--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -8,8 +8,10 @@ $JCUSERGROUP = 'YOURJCUSERGROUP'
 $JCUSERCERTPASS = 'secret1234!'
 # USER CERT Validity Length (days)
 $JCUSERCERTVALIDITY = 90
-# NETWORK SSID (optional)
-$NETWORKSSID = 'YOUR_SSID'
+# List Of Radius Network SSID(s)
+# For Multiple SSIDs enter as a single string seperated by spaces ex:
+# "CorpNetwork_Denver CorpNetwork_Boulder"
+$NETWORKSSID = "YOUR_SSID"
 # OpenSSLBinary by default this is (openssl)
 # NOTE: If openssl does not work, try using the full path to the openssl file
 # MacOS HomeBrew Example: '/usr/local/Cellar/openssl@3/3.0.7/bin/openssl'

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -116,6 +116,7 @@ unzip -o /tmp/$($user.userName)-client-signed.zip -d /tmp
 currentUser=`$(/usr/bin/stat -f%Su /dev/console)
 currentUserUID=`$(id -u "`$currentUser")
 currentCertSN="$($certHash.serial)"
+networkSsid="$($NETWORKSSID)"
 if [[ `$currentUser ==  $($user.userName) ]]; then
     certs=`$(security find-certificate -a -$($macCertSearch) "$($certIdentifier)" -Z /Users/$($user.userName)/Library/Keychains/login.keychain)
     regexSHA='SHA-1 hash: ([0-9A-F]{5,40})'
@@ -161,12 +162,19 @@ if [[ `$currentUser ==  $($user.userName) ]]; then
     fi
 
     if [[ `$import == true ]]; then
-        /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security import /tmp/$($user.userName)-client-signed.pfx -k /Users/$($user.userName)/Library/Keychains/login.keychain -P $JCUSERCERTPASS
+        /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security import /tmp/$($user.userName)-client-signed.pfx -k /Users/$($user.userName)/Library/Keychains/login.keychain -P $JCUSERCERTPASS -T "/System/Library/SystemConfiguration/EAPOLController.bundle/Contents/Resources/eapolclient"
         if [[ `$? -eq 0 ]]; then
             echo "Import Success"
         else
             echo "import failed"
             exit 4
+        fi
+        # set ssid info; this prevents multiple password prompts
+        /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security set-identity-preference -s "com.apple.network.eap.user.identity.wlan.ssid.`$networkSsid" -$($macCertSearch) "$($certIdentifier)"
+        if [[ `$? -eq 0 ]]; then
+            echo "SSID and certificate linked"
+        else
+            echo "Could not associate SSID and certifiacte"
         fi
     else
         echo "cert already imported"

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -105,7 +105,6 @@ foreach ($user in $userArray) {
             continue
         }
 
-        # TODO: is common name the same depending on the CertType?
         # Create new Command and upload the signed pfx
         try {
             $CommandBody = @{
@@ -170,12 +169,14 @@ if [[ `$currentUser ==  $($user.userName) ]]; then
             exit 4
         fi
         # set ssid info; this prevents multiple password prompts
-        /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security set-identity-preference -s "com.apple.network.eap.user.identity.wlan.ssid.`$networkSsid" -$($macCertSearch) "$($certIdentifier)"
-        if [[ `$? -eq 0 ]]; then
-            echo "SSID and certificate linked"
-        else
-            echo "Could not associate SSID and certifiacte"
-        fi
+        for i in `${networkSsid[@]}; do
+            /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security set-identity-preference -s "com.apple.network.eap.user.identity.wlan.ssid.`$i" -$($macCertSearch) "$($certIdentifier)"
+            if [[ `$? -eq 0 ]]; then
+                echo "SSID: `$i and certificate linked"
+            else
+                echo "Could not associate SSID: `$i and certifiacte"
+            fi
+        done
     else
         echo "cert already imported"
     fi

--- a/scripts/automation/Radius/readme.md
+++ b/scripts/automation/Radius/readme.md
@@ -86,7 +86,7 @@ The ID of the selected userGroup is the 24 character string between `/user/` and
 
 #### Set your network SSID Name
 
-Change the variable `$NETWORKSSID` to the name of the SSID network your clients will connect to. On macOS hosts, the user certificate will be set to automatically authenticate to this SSID when the end user selects the WiFi Network. Multiple SSIDs can be provided as a single string with SSID names separated by a space, ex: "CorpNetwork_Denver CorpNetwork_Boulder".
+Change the variable `$NETWORKSSID` to the name of the SSID network your clients will connect to. On macOS hosts, the user certificate will be set to automatically authenticate to this SSID when the end user selects the WiFi Network. Multiple SSIDs can be provided as a single string with SSID names separated by a space, ex: "CorpNetwork_Denver CorpNetwork_Boulder". **Note: The SSID and user certificate are only associated with macOS system commands are generated. This parameter does not affect windows generated commands**
 
 #### Set the openSSL Binary location
 

--- a/scripts/automation/Radius/readme.md
+++ b/scripts/automation/Radius/readme.md
@@ -84,6 +84,10 @@ After selecting the User Group, view the url for the user group it should look s
 
 The ID of the selected userGroup is the 24 character string between `/user/` and `/details`: `5f808a1bb544064831f7c9fb`
 
+#### Set your network SSID Name
+
+Change the variable `$NETWORKSSID` to the name of the SSID network your clients will connect to. On macOS hosts, the user certificate will be set to automatically authenticate to this SSID when the end user selects the WiFi Network.
+
 #### Set the openSSL Binary location
 
 Depending on the host system and how OpenSSL is installed, this variable can either point to a path or call the binary with just the name `openssl`.
@@ -225,6 +229,8 @@ After logging into the user account `Farmer_142` on `SE0PU00ABEXY-darwin` system
 After a user's certificate has been distributed to a system, those users can then connect to a radius network with certificate based authentication.
 
 ### macOS
+
+If the `$NETWORKSSID` variable in `Config.ps1` was specified, macOS users will only be prompted once to let `eapolclient` access the private key from the installed certificate. If the end user selects `Always Allow`, the'll not be prompted to enter their password for the entire life cycle of the user certificate, only when new certificates are deployed will end users have to re-enter their login password.
 
 In macOS a user simply needs to select the radius network from the wireless networks dialog prompt. A prompt to select a user certificate should be displayed, select the user certificate from the drop down menu and click "OK"
 

--- a/scripts/automation/Radius/readme.md
+++ b/scripts/automation/Radius/readme.md
@@ -86,7 +86,7 @@ The ID of the selected userGroup is the 24 character string between `/user/` and
 
 #### Set your network SSID Name
 
-Change the variable `$NETWORKSSID` to the name of the SSID network your clients will connect to. On macOS hosts, the user certificate will be set to automatically authenticate to this SSID when the end user selects the WiFi Network.
+Change the variable `$NETWORKSSID` to the name of the SSID network your clients will connect to. On macOS hosts, the user certificate will be set to automatically authenticate to this SSID when the end user selects the WiFi Network. Multiple SSIDs can be provided as a single string with SSID names separated by a space, ex: "CorpNetwork_Denver CorpNetwork_Boulder".
 
 #### Set the openSSL Binary location
 


### PR DESCRIPTION
## Issues
* [SA-3199](https://jumpcloud.atlassian.net/browse/SA-3199) - macOS Specify SSID and associate user certificate

## What does this solve?

In the previous release, macOS end users were prompted no less than three times to set their radius certificate identity preference to the desired Radius Network, to allow eapolclient access to sign using the private key from the cert and finally allow eapolclient access to use the private key from the user cert.

![radius user interaction macOS](https://user-images.githubusercontent.com/54448601/222820766-22d11280-d3b1-4536-a69f-18fff63324b4.jpg)

This release eliminates unnecessary user interaction but automatically assigning the user certificate to the SSID of the radius network and giving `eapolclinet` access to the private key during certificate import.

![radius user interaction macOS (1)](https://user-images.githubusercontent.com/54448601/222821424-ce3fb998-c163-4364-a68b-39d29f6121c9.jpg)

## Is there anything particularly tricky?

## How should this be tested?

Populate the `$NETWORKSSID` variable in `config.ps1`. Generate user certs and distribute to devices. When connecting to the Radius network specified in the `config.ps1` file, the System UI should only prompt for password once, and if the user selects "Always Allow" it will not prompt during the duration of the certificate's life. 

Subsequently installed certificates have a different private key and users will be prompted to enter their password when certificates are replaced.

## Screenshots

https://user-images.githubusercontent.com/54448601/222821964-e7eb6418-67ad-440f-b863-dc6b12b92f54.mov



[SA-3199]: https://jumpcloud.atlassian.net/browse/SA-3199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ