### PR TITLE
userAgent on invoke rest method scripts

### DIFF
--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -37,6 +37,12 @@ $CertType = "UsernameCn"
 # Do not modify below
 ################################################################################
 
+UserAgent_ModuleVersion='1.0.0'
+UserAgent_ModuleName='PasswordlessRadiusConfig'
+#Build the UserAgent string
+$UserAgent_ModuleName = "JumpCloud_$($UserAgent_ModuleName).PowerShellModule"
+$Template_UserAgent = "{0}/{1}"
+$UserAgent = $Template_UserAgent -f $UserAgent_ModuleName, $UserAgent_ModuleVersion
 # When we import this config, this function will run and validate the openSSL binary location
 function Get-OpenSSLVersion {
     [CmdletBinding()]

--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -37,8 +37,8 @@ $CertType = "UsernameCn"
 # Do not modify below
 ################################################################################
 
-UserAgent_ModuleVersion='1.0.0'
-UserAgent_ModuleName='PasswordlessRadiusConfig'
+$UserAgent_ModuleVersion = '1.0.0'
+$UserAgent_ModuleName = 'PasswordlessRadiusConfig'
 #Build the UserAgent string
 $UserAgent_ModuleName = "JumpCloud_$($UserAgent_ModuleName).PowerShellModule"
 $Template_UserAgent = "{0}/{1}"

--- a/scripts/automation/Radius/Functions/Private/Clear-JCQueuedCommand.ps1
+++ b/scripts/automation/Radius/Functions/Private/Clear-JCQueuedCommand.ps1
@@ -8,7 +8,7 @@ function Clear-JCQueuedCommand {
             'x-api-key' = $Env:JCApiKey
             'x-org-id'  = $Env:JCOrgId
         }
-        $response = Invoke-RestMethod -Uri "https://console.jumpcloud.com/api/v2/commandqueue/$workflowId" -Method DELETE -Headers $headers
+        $response = Invoke-RestMethod -Uri "https://console.jumpcloud.com/api/v2/commandqueue/$workflowId" -Method DELETE -Headers $headers -UserAgent $UserAgent
     }
     end {
         return $response

--- a/scripts/automation/Radius/Functions/Private/Invoke-CommandRun.ps1
+++ b/scripts/automation/Radius/Functions/Private/Invoke-CommandRun.ps1
@@ -19,7 +19,7 @@ function Invoke-CommandRun {
         $body = @{
             _id = $commandID
         } | ConvertTo-Json
-        $response = Invoke-RestMethod -Uri 'https://console.jumpcloud.com/api/runCommand' -Method POST -Headers $headers -ContentType 'application/json' -Body $body
+        $response = Invoke-RestMethod -Uri 'https://console.jumpcloud.com/api/runCommand' -Method POST -Headers $headers -ContentType 'application/json' -Body $body -UserAgent $UserAgent
     }
     end {
         if (!$response.queueIds) {


### PR DESCRIPTION
## Issues
* [SA-3202](https://jumpcloud.atlassian.net/browse/SA-3202) - Add custom user agent on Radius Passwordless Generation scripts

## What does this solve?

User agent added to invoke rest method calls to distinguish calls from PowerShell module

## Is there anything particularly tricky?

## How should this be tested?

Generate user certs/ distribute there should be no changes to the functionality of the project

## Screenshots


[SA-3202]: https://jumpcloud.atlassian.net/browse/SA-3202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ