### PR TITLE
Fix and install agents edit to MSI

### DIFF
--- a/scripts/windows/FixWindowsAgent.ps1
+++ b/scripts/windows/FixWindowsAgent.ps1
@@ -7,7 +7,7 @@
 .NOTES
     Name: FixWindowsAgent.ps1
     Author: www.jumpcloud.com
-    Date Updated: 2019-12-09
+    Date Updated: 2023-03-23
 .LINK
     http://support.jumpcloud.com
 .EXAMPLE

--- a/scripts/windows/FixWindowsAgent.ps1
+++ b/scripts/windows/FixWindowsAgent.ps1
@@ -31,16 +31,14 @@ $msvc2013x86Install = "$TempPath$msvc2013x86File /install /quiet /norestart"
 $msvc2013x64Install = "$TempPath$msvc2013x64File /install /quiet /norestart"
 $AGENT_PATH = "${env:ProgramFiles}\JumpCloud"
 $AGENT_BINARY_NAME = "JumpCloud-agent.exe"
-$AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/JumpCloudInstaller.exe"
-$AGENT_INSTALLER_PATH = "C:\windows\Temp\JumpCloudInstaller.exe"
 
 $AGENT_PATH = "${env:ProgramFiles}\JumpCloud"
-$AGENT_BINARY_NAME = "jumpcloud-agent.exe"
+$AGENT_BINARY_NAME = "jcagent-msi-signed.msi"
 
 $AGENT_SERVICE_NAME = "jumpcloud-agent"
 
-$AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/JumpCloudInstaller.exe"
-$AGENT_INSTALLER_PATH = "$env:TEMP\JumpCloudInstaller.exe"
+$AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signed.msi"
+$AGENT_INSTALLER_PATH = "C:\windows\Temp\jcagent-msi-signed.msi"
 
 
 $EVENT_LOGGER_KEY_NAME = "hklm:\SYSTEM\CurrentControlSet\services\eventlog\Application\jumpcloud-agent"
@@ -61,8 +59,7 @@ Function AgentInstallerExists() {
 }
 
 Function InstallAgent() {
-    $params = ("${AGENT_INSTALLER_PATH}", "-k ${CONNECT_KEY}", "/VERYSILENT", "/NORESTART", "/SUPRESSMSGBOXES", "/NOCLOSEAPPLICATIONS", "/NORESTARTAPPLICATIONS", "/LOG=$env:TEMP\jcUpdate.log")
-    Invoke-Expression "$params"
+    msiexec /i $AGENT_INSTALLER_PATH /quiet JCINSTALLERARGUMENTS=`"-k $JumpCloudConnectKey /VERYSILENT /NORESTART /NOCLOSEAPPLICATIONS /L*V "C:\Windows\Temp\jcUpdate.log"`"
 }
 
 Function UninstallAgent() {
@@ -121,8 +118,8 @@ Function DeleteAgent() {
 
 
 Function InstallAgent() {
-    $params = ("${AGENT_INSTALLER_PATH}", "-k ${JumpCloudConnectKey}", "/VERYSILENT", "/NORESTART", "/NOCLOSEAPPLICATIONS", "/NORESTARTAPPLICATIONS", "/LOG=$env:TEMP\jcUpdate.log")
-    Invoke-Expression "$params"
+    msiexec /i $AGENT_INSTALLER_PATH /quiet JCINSTALLERARGUMENTS=`"-k $JumpCloudConnectKey /VERYSILENT /NORESTART /NOCLOSEAPPLICATIONS /L*V "C:\Windows\Temp\jcUpdate.log"`"
+
 }
 Function DownloadAgentInstaller() {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/scripts/windows/InstallWindowsAgent.ps1
+++ b/scripts/windows/InstallWindowsAgent.ps1
@@ -2,7 +2,6 @@
 # Example ./InstallWindowsAgent.ps1 -JumpCloudConnectKey "56b403784365r6o2n311cosr218u1762le4y9e9a"
 # Your JumpCloudConnectKey can be found on the systems tab within the JumpCloud admin console.
 
-
 Param (
     [Parameter (Mandatory = $true)]
     [string] $JumpCloudConnectKey
@@ -19,17 +18,15 @@ $TempPath = 'C:\Windows\Temp\'
 $msvc2013x86Install = "$TempPath$msvc2013x86File /install /quiet /norestart"
 $msvc2013x64Install = "$TempPath$msvc2013x64File /install /quiet /norestart"
 $AGENT_PATH = "${env:ProgramFiles}\JumpCloud"
-$AGENT_BINARY_NAME = "JumpCloud-agent.exe"
-$AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/JumpCloudInstaller.exe"
-$AGENT_INSTALLER_PATH = "C:\windows\Temp\JumpCloudInstaller.exe"
-
+$AGENT_BINARY_NAME = "jcagent-msi-signed.msi"
+$AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signed.msi"
+$AGENT_INSTALLER_PATH = "C:\windows\Temp\jcagent-msi-signed.msi"
 # JumpCloud Agent Installation Functions
 Function AgentIsOnFileSystem() {
     Test-Path -Path:(${AGENT_PATH} + '/' + ${AGENT_BINARY_NAME})
 }
 Function InstallAgent() {
-    $params = ("${AGENT_INSTALLER_PATH}", "-k ${JumpCloudConnectKey}", "/VERYSILENT", "/NORESTART", "/NOCLOSEAPPLICATIONS", "/NORESTARTAPPLICATIONS", "/LOG=$env:TEMP\jcUpdate.log")
-    Invoke-Expression "$params"
+    msiexec /i $AGENT_INSTALLER_PATH /quiet JCINSTALLERARGUMENTS=`"-k $JumpCloudConnectKey /VERYSILENT /NORESTART /NOCLOSEAPPLICATIONS /L*V "C:\Windows\Temp\jcUpdate.log"`"
 }
 Function DownloadAgentInstaller() {
     (New-Object System.Net.WebClient).DownloadFile("${AGENT_INSTALLER_URL}", "${AGENT_INSTALLER_PATH}")


### PR DESCRIPTION
## Issues
* [SA-3208](https://jumpcloud.atlassian.net/browse/SA-3208) - SA-3208-Windows-Agent-Installer-MSI

## What does this solve?
Replace .exe installer to .msi installer. This enables admins to have single executable type installer and simplify installation process for admins.
## Is there anything particularly tricky?
n/a
## How should this be tested?
1. Run: [Install Windows Agent](https://github.com/TheJumpCloud/support/blob/SA-3208-Windows-Agent-Installer-MSI/scripts/windows/InstallWindowsAgent.ps1) on a machine without JC Agent. Validate that the agent is installed silently and no changes in functionality.
2. Run: [Fix Windows Agent](https://github.com/TheJumpCloud/support/blob/SA-3208-Windows-Agent-Installer-MSI/scripts/windows/FixWindowsAgent.ps1 ) on a machine with JC Agent. Validate that the agent is uninstalled and installed silently and no changes in functionality.



[SA-3208]: https://jumpcloud.atlassian.net/browse/SA-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ