### PR TITLE
SA-3282: localUserAccount field check

### DIFF
--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,0 +1,30 @@
+## 1.0.1
+
+Release Date: April 21, 2023
+
+#### RELEASE NOTES
+
+```
+Users with Local User Account names that differ from their JumpCloud Username are now supported
+```
+
+#### FEATURES:
+
+- If a user's local account name (systemUsername) is specified on an account, the certificates for those users will be generated with their local account name (not username) and installed correctly.
+
+## 1.0.0
+
+Release Date: March 21, 2023
+
+#### RELEASE NOTES
+
+```
+Iniital release of the Passwordless Radius User Certificate Generation automation scritps
+```
+
+#### FEATURES:
+
+- Generate/ Import CA Certificate
+- Generate User Certificates from CA Certificate
+- Distribute User Certificates to JumpCloud Devices w/ JumpCloud Commands
+- Monitor Command Deployments

--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -37,7 +37,7 @@ $CertType = "UsernameCn"
 # Do not modify below
 ################################################################################
 
-$UserAgent_ModuleVersion = '1.0.0'
+$UserAgent_ModuleVersion = '1.0.1'
 $UserAgent_ModuleName = 'PasswordlessRadiusConfig'
 #Build the UserAgent string
 $UserAgent_ModuleName = "JumpCloud_$($UserAgent_ModuleName).PowerShellModule"

--- a/scripts/automation/Radius/Functions/Private/Get-WebJCUser.ps1
+++ b/scripts/automation/Radius/Functions/Private/Get-WebJCUser.ps1
@@ -13,14 +13,14 @@ function get-webjcuser {
     }
     process {
         $response = Invoke-RestMethod -Uri "https://console.jumpcloud.com/api/systemusers/$userID" -Method GET -Headers $headers
-    }
-    end {
-        # return ${id, username, email }
         $userObj = [PSCustomObject]@{
-            username = $response.username
+            # If the localUserAccount field is set, use that for username, otherwise use JC username
+            username = $(if ($response.systemUsername -eq "") { $response.username } else { $response.systemUsername })
             id       = $response._id
             email    = $response.email
         }
+    }
+    end {
         return $userObj
     }
 }

--- a/scripts/automation/Radius/Functions/Private/Get-WebJCUser.ps1
+++ b/scripts/automation/Radius/Functions/Private/Get-WebJCUser.ps1
@@ -15,7 +15,8 @@ function get-webjcuser {
         $response = Invoke-RestMethod -Uri "https://console.jumpcloud.com/api/systemusers/$userID" -Method GET -Headers $headers
         $userObj = [PSCustomObject]@{
             # If the localUserAccount field is set, use that for username, otherwise use JC username
-            username = $(if ($response.systemUsername -eq "") { $response.username } else { $response.systemUsername })
+            username = $(if ([string]::IsNullOrEmpty($response.systemUsername)) { $response.username } else { $response.systemUsername })
+
             id       = $response._id
             email    = $response.email
         }


### PR DESCRIPTION
## Issues
* [SA-3282](https://jumpcloud.atlassian.net/browse/SA-3282) - localUserAccount field check

## What does this solve?
Previously, if a user had their localUserAccount field changed in the console, it would not be taken into account when the certs are generated which could lead to issues installing the script.

We simply added a conditional check to see if the `systemUsername` field (which corresponds with the `localUserAccount` field in the console) is not empty. If it is empty, we will continue to use the user's JumpCloud `username`. If it is not empty, we will instead use the user's `systemUsername` and set that as the user's `username` in a customObject that is returned in the `Generate-UserCert.ps1` function

## Is there anything particularly tricky?
No

## How should this be tested?

1. Change a user's localUserAccount is the console
2. Assign the user to a device
3. Add the user to the Radius group
4. Generate a root cert for testing
5. Generate the user certs for testing
6. Attempt to deploy the certs while the user is logged into the device

## Screenshots
![image](https://user-images.githubusercontent.com/89030113/233486244-cb60bd25-6938-4863-aecd-6b7da70abc78.png)
![image](https://user-images.githubusercontent.com/89030113/233487207-a2107c01-0004-4aeb-82f1-a7990ecb1d56.png)
![image](https://user-images.githubusercontent.com/89030113/233487267-acece8e6-1e85-4b9d-881d-ed304e283ead.png)
![image](https://user-images.githubusercontent.com/89030113/233487463-feceabff-633b-4138-850e-a26782969bcd.png)


[SA-3282]: https://jumpcloud.atlassian.net/browse/SA-3282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ