### PR TITLE
SA-3322: Radius Cert Secret Fix

### DIFF
--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,3 +1,17 @@
+## 1.0.2
+
+Release Date: May 2, 2023
+
+#### RELEASE NOTES
+
+```
+Fixed an issue with the JCUSERCERTPASS not being correctly passed into Windows devices when changed from default
+```
+#### FEATURES:
+
+- JCUSERCERTPASS was not being correctly referenced when the device commands are generated resulting in certificates not being installed
+- Adjusted error tracking for more precise results when a certificate wasn't installed
+
 ## 1.0.1
 
 Release Date: April 21, 2023

--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -4,7 +4,7 @@ $JCAPIKEY = 'YOURAPIKEY'
 $JCORGID = 'YOURORGID'
 # JUMPCLOUD USER GROUP ID
 $JCUSERGROUP = 'YOURJCUSERGROUP'
-# USER CERT PASSWORD (user must enter this when importing cert)
+# USER CERT PASSWORD (this password is sent to the devices via JumpCloud Commands)
 $JCUSERCERTPASS = 'secret1234!'
 # USER CERT Validity Length (days)
 $JCUSERCERTVALIDITY = 90

--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -37,7 +37,7 @@ $CertType = "UsernameCn"
 # Do not modify below
 ################################################################################
 
-$UserAgent_ModuleVersion = '1.0.1'
+$UserAgent_ModuleVersion = '1.0.2'
 $UserAgent_ModuleName = 'PasswordlessRadiusConfig'
 #Build the UserAgent string
 $UserAgent_ModuleName = "JumpCloud_$($UserAgent_ModuleName).PowerShellModule"

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -277,7 +277,7 @@ if (`$CurrentUser -eq "$($user.userName)") {
     # expand archive as root and copy to temp location
     Expand-Archive -LiteralPath C:\Windows\Temp\$($user.userName)-client-signed.zip -DestinationPath C:\RadiusCert -Force
     `$password = ConvertTo-SecureString -String $JCUSERCERTPASS -AsPlainText -Force
-    `$ScriptBlockInstall = { `$password = ConvertTo-SecureString -String "secret1234!" -AsPlainText -Force
+    `$ScriptBlockInstall = { `$password = ConvertTo-SecureString -String $JCUSERCERTPASS -AsPlainText -Force
     Import-PfxCertificate -Password `$password -FilePath "C:\RadiusCert\$($user.userName)-client-signed.pfx" -CertStoreLocation Cert:\CurrentUser\My
     }
     `$imported = Get-PfxData -Password `$password -FilePath "C:\RadiusCert\$($user.userName)-client-signed.pfx"
@@ -322,7 +322,7 @@ if (`$CurrentUser -eq "$($user.userName)") {
     }
 
     # Lastly validate if the cert was installed
-    if (`$certValidate){
+    if (`$certValidate.Trim() -eq "True"){
         Write-Host "Cert was installed"
     } else {
         Throw "Cert was not installed"


### PR DESCRIPTION
## Issues
* [SA-3322](https://jumpcloud.atlassian.net/browse/SA-3322) - Radius Cert Secret Fix

## What does this solve?
Fixed an issue with the `$JCUSERCERTPASS` not being correctly passed into Windows device commands when changed from default in `config.ps1`

## Is there anything particularly tricky?
N/A

## How should this be tested?

1. Change the default value of `$JCUSERCERTPASS` in `config.ps1`
2. Generate and Distribute certs
3. Validate in the command that the Password value is as expected
4. Ensure that certificates are installed correctly

1. Change the password value in the JC Command to a random value and rerun command
2. Should produce an error stating the password does not match

## Screenshots
N/A

[SA-3322]: https://jumpcloud.atlassian.net/browse/SA-3322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ