### PR TITLE
Sa 3318 remove jc policy 2

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -49,7 +49,7 @@ parameters:
   PublishToPSGallery:
     description: "When `true` and when run against Master branch, this workflow will publish the latest code to PSGallery"
     type: boolean
-    default: false
+    default: true
   ManualModuleVersion:
     description: "When `true` the pipeline will use the Module Version specified in JumpCloud Module JumpCloud.psd1 file"
     type: boolean

--- a/PowerShell/JumpCloud Module/Public/Policies/Remove-JCPolicy.ps1
+++ b/PowerShell/JumpCloud Module/Public/Policies/Remove-JCPolicy.ps1
@@ -1,0 +1,104 @@
+Function Remove-JCPolicy () {
+    param
+    (
+        [Parameter(Mandatory,
+            ValueFromPipelineByPropertyName,
+            ParameterSetName = 'ByID',
+            Position = 0,
+            HelpMessage = 'The PolicyID of the JumpCloud policy you wish to remove.')]
+        [Alias('_id', 'id')]
+        [String]$PolicyID,
+        [Parameter(
+            ValueFromPipelineByPropertyName,
+            ParameterSetName = 'Name',
+            HelpMessage = 'The Name of the JumpCloud policy you wish to remove.')]
+        [String]$Name,
+        [Parameter(HelpMessage = 'A SwitchParameter which suppresses the warning message when removing a JumpCloud Policy.')]
+        [Switch]
+        $force
+    )
+    begin {
+        Write-Debug 'Verifying JCAPI Key'
+        if ($JCAPIKEY.length -ne 40) {
+            Connect-JCOnline
+        }
+
+        if ($PsCmdlet.ParameterSetName -eq "Name") {
+            $policyHash = Get-JCPolicy | Select-Object Id, Name
+        }
+
+        $deletedArray = @()
+    }
+    process {
+        switch ($PsCmdlet.ParameterSetName) {
+            ByID {
+                if (!$force) {
+                    Write-Warning "Are you sure you wish to delete policy: $PolicyID ?" -WarningAction Inquire
+
+                    try {
+                        $removePolicy = Remove-JcSdkPolicy -Id $PolicyID -ErrorAction Stop
+                        $Status = 'Deleted'
+                    } catch {
+                        $Status = $_.ErrorDetails
+                    }
+
+                    $FormattedResults = [PSCustomObject]@{
+                        'Policy'  = $PolicyID
+                        'Results' = $Status
+                    }
+                } else {
+                    try {
+                        $removePolicy = Remove-JcSdkPolicy -Id $PolicyID -ErrorAction Stop
+                        $Status = 'Deleted'
+                    } catch {
+                        $Status = $_.ErrorDetails
+                    }
+
+                    $FormattedResults = [PSCustomObject]@{
+                        'Policy'  = $PolicyID
+                        'Results' = $Status
+                    }
+                }
+                $deletedArray += $FormattedResults
+            }
+            Name {
+                # Check if Policy exists with given name
+                if ($policyHash.Name -ccontains ($Name)) {
+                    $Policy = $policyHash | Where-Object Name -CEQ $Name
+                } else {
+                    throw "Policy does not exist. Run 'Get-JCPolicy | Select-Object Name' to see a list of all your JumpCloud policies"
+                }
+
+                if (!$force) {
+
+                    Write-Warning "Are you sure you wish to delete policy: $Name ?" -WarningAction Inquire
+                    try {
+                        $removePolicy = Remove-JcSdkPolicy -Id $Policy.id -ErrorAction Stop
+                        $Status = 'Deleted'
+                    } catch {
+                        $Status = $_.ErrorDetails
+                    }
+                    $FormattedResults = [PSCustomObject]@{
+                        'Policy'  = $Policy.Name
+                        'Results' = $Status
+                    }
+                } else {
+                    try {
+                        $removePolicy = Remove-JcSdkPolicy -Id $Policy.id -ErrorAction Stop
+                        $Status = 'Deleted'
+                    } catch {
+                        $Status = $_.ErrorDetails
+                    }
+                    $FormattedResults = [PSCustomObject]@{
+                        'Policy'  = $Policy.Name
+                        'Results' = $Status
+                    }
+                }
+                $deletedArray += $FormattedResults
+            }
+        }
+    }
+    end {
+        return $deletedArray
+    }
+}

--- a/PowerShell/JumpCloud Module/Tests/Public/Policies/Remove-JCPolicy.tests.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Policies/Remove-JCPolicy.tests.ps1
@@ -1,0 +1,26 @@
+Describe -Tag:('JCPolicy') 'Remove-JCPolicy 1.10' {
+    BeforeAll { Connect-JCOnline -JumpCloudApiKey:($PesterParams_ApiKey) -force | Out-Null }
+    It 'Remove Policy by PolicyID' {
+        # Create test policy for removal
+        $policyTemplates = Get-JcSdkPolicyTemplate
+        $policyTemplate = $policyTemplates | Where-Object { $_.name -eq "rename_local_administrator_account_windows" }
+        $templateId = $policyTemplate.id
+        $stringPolicy = New-JCPolicy -Name "Pester - Remove Policy Test" -templateID $templateId -ADMINISTRATORSTRING "Test String"
+
+        $DeletedPolicy = Remove-JCPolicy -Id $stringPolicy.Id -Force
+        $DeletedPolicy.results | Should -Be 'Deleted'
+    }
+    It 'Remove Policy by Name' {
+        # Create test policy for removal
+        $policyTemplates = Get-JcSdkPolicyTemplate
+        $policyTemplate = $policyTemplates | Where-Object { $_.name -eq "rename_local_administrator_account_windows" }
+        $templateId = $policyTemplate.id
+        $stringPolicy = New-JCPolicy -Name "Pester - Remove Policy Test" -templateID $templateId -ADMINISTRATORSTRING "Test String"
+
+        $DeletedPolicy = Remove-JCPolicy -Name $stringPolicy.Name -Force
+        $DeletedPolicy.results | Should -Be 'Deleted'
+    }
+    It "Remove Policy by Non-existant Name" {
+        $DeletedPolicy = { Remove-JCPolicy -Name "Pester - Fake Policy Test" -Force -ErrorAction Stop } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Issues
* [SA-3318](https://jumpcloud.atlassian.net/browse/SA-3318) - Remove-JCPolicy

## What does this solve?
This introduces the Remove-JCPolicy function that will be able to remove JumpCloud Policies either by the Policy's ID or the Name

## Is there anything particularly tricky?
N/A

## How should this be tested?
A test suite was written for the function for the CI Pipeline

### Manual Tests:

- Remove Policy by PolicyID:

```powershell
# Create test policy for removal
$policyTemplates = Get-JcSdkPolicyTemplate
$policyTemplate = $policyTemplates | Where-Object { $_.name -eq "rename_local_administrator_account_windows" }
$templateId = $policyTemplate.id
$stringPolicy = New-JCPolicy -Name "Pester - Remove Policy Test" -templateID $templateId -ADMINISTRATORSTRING "Test String"

$DeletedPolicy = Remove-JCPolicy -Id $stringPolicy.Id -Force
$DeletedPolicy.results | Should -Be 'Deleted'
```

- Remove Policy by Name

```powershell
# Create test policy for removal
$policyTemplates = Get-JcSdkPolicyTemplate
$policyTemplate = $policyTemplates | Where-Object { $_.name -eq "rename_local_administrator_account_windows" }
$templateId = $policyTemplate.id
$stringPolicy = New-JCPolicy -Name "Pester - Remove Policy Test" -templateID $templateId -ADMINISTRATORSTRING "Test String"

$DeletedPolicy = Remove-JCPolicy -Name $stringPolicy.Name -Force
$DeletedPolicy.results | Should -Be 'Deleted'
```

- Remove Policy by Non-existant Name

```powershell
$DeletedPolicy = Remove-JCPolicy -Name "Pester - Fake Policy Test" -Force | Should -Throw
```

Redo of #489 