### PR TITLE
SA-3170: Replace Get-JCCommandResults with Search-JCSdkCommandResult

### DIFF
--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,3 +1,17 @@
+## 1.0.3
+
+Release Date: May 24, 2023
+
+#### RELEASE NOTES
+
+```
+Fixed an issue affecting permissions on certain MacOS devices when attempting to deploy certs
+Improved performance when reviewing Command Results by changing fetch requests to Search-JCSDKCommandResult endpoint
+```
+#### FEATURES:
+
+- Fixed an issue affecting permissions on certain MacOS devices when attempting to deploy certs
+- Improved performance when reviewing Command Results by changing fetch requests to Search-JCSDKCommandResult endpoint
 ## 1.0.2
 
 Release Date: May 2, 2023

--- a/scripts/automation/Radius/Functions/Private/Get-CommandObjectTable.ps1
+++ b/scripts/automation/Radius/Functions/Private/Get-CommandObjectTable.ps1
@@ -29,7 +29,7 @@ Function Get-CommandObjectTable {
                 }
                 $commandResults = Search-JcSdkCommandResult -SearchFilter $SearchFilter
                 if ($commandResults) {
-                    $groupedCommandResults = $commandResults | Group-Object name, SystemId | Sort-Object -Property responseTime -Descending
+                    $groupedCommandResults = $commandResults | Sort-Object -Property responseTime -Descending | Group-Object name, SystemId
                     $mostRecentCommandResults = $groupedCommandResults | ForEach-Object { $_.Group | Select-Object -First 1 }
                     $commandResults | ForEach-Object {
                         if ($_.id -in $mostRecentCommandResults.id) {
@@ -83,7 +83,7 @@ Function Get-CommandObjectTable {
                 }
                 $commandResults = Search-JcSdkCommandResult -SearchFilter $SearchFilter
                 if ($commandResults) {
-                    $groupedCommandResults = $commandResults | Group-Object name, systemId | Sort-Object -Property responseTime -Descending
+                    $groupedCommandResults = $commandResults | Sort-Object -Property responseTime -Descending | Group-Object name, SystemId
                     $mostRecentCommandResults = $groupedCommandResults | ForEach-Object { $_.Group | Select-Object -First 1 }
                     $commandResults | ForEach-Object {
                         if ($_.id -in $mostRecentCommandResults.id) {
@@ -121,7 +121,7 @@ Function Get-CommandObjectTable {
                     if ($finishedCommands) {
                         # If there are finished command results, iterate through each and add to command object array
                         $finishedCommands | ForEach-Object {
-                            if (($finishedCommands.DataExitCode -eq 0)) {
+                            if (($_.DataExitCode -eq 0)) {
                                 $character = "$([char]0x1b)[92mOK"
                                 # Remove successful systems from command associations
                                 Set-JcSdkCommandAssociation -CommandId:("$($command.commandId)") -Op 'remove' -Type:('system') -Id:("$($_.systemId)") -ErrorAction SilentlyContinue | Out-Null

--- a/scripts/automation/Radius/Functions/Private/Get-CommandObjectTable.ps1
+++ b/scripts/automation/Radius/Functions/Private/Get-CommandObjectTable.ps1
@@ -23,15 +23,19 @@ Function Get-CommandObjectTable {
                 $CommandObjectTable = @()
 
                 # Clean up command results
-                $commandResults = Get-JCCommandResult | Where-Object name -Like "RadiusCert-Install*"
+                $SearchFilter = @{
+                    searchTerm = 'RadiusCert-Install'
+                    fields     = @('name')
+                }
+                $commandResults = Search-JcSdkCommandResult -SearchFilter $SearchFilter
                 if ($commandResults) {
-                    $groupedCommandResults = $commandResults | Group-Object name, system | Sort-Object -Property responseTime -Descending
+                    $groupedCommandResults = $commandResults | Group-Object name, SystemId | Sort-Object -Property responseTime -Descending
                     $mostRecentCommandResults = $groupedCommandResults | ForEach-Object { $_.Group | Select-Object -First 1 }
                     $commandResults | ForEach-Object {
-                        if ($_._id -in $mostRecentCommandResults._id) {
+                        if ($_.id -in $mostRecentCommandResults.id) {
                             return
                         } else {
-                            Remove-JCCommandResult -CommandResultID $_._id -force | Out-Null
+                            Remove-JCCommandResult -CommandResultID $_.id -force | Out-Null
                         }
                     }
                 }
@@ -42,17 +46,17 @@ Function Get-CommandObjectTable {
                     if ($finishedCommands) {
                         # If there are finished command results, iterate through each and add to command object array
                         $finishedCommands | ForEach-Object {
-                            if (($_.exitCode -ne 0)) {
+                            if (($_.DataExitCode -ne 0)) {
                                 $character = "$([char]0x1b)[91mFAILED"
-                                $output = Get-JCCommandResult -id $_._id | Select-Object -ExpandProperty output
+                                #$output = Get-JCCommandResult -id $_._id | Select-Object -ExpandProperty output
                             } else {
                                 continue
                             }
                             $CommandTable = @{
                                 commandName       = $command.commandName
-                                systemDisplayName = $_.system
+                                systemDisplayName = $SystemHash | Where-Object _id -EQ $_.systemId | Select-Object -ExpandProperty displayName
                                 status            = $character
-                                output            = $output
+                                output            = $_.DataOutput
                             }
                             $CommandObjectTable += $CommandTable
                         }
@@ -73,15 +77,19 @@ Function Get-CommandObjectTable {
                 $CommandObjectTable = @()
 
                 # Clean up command results
-                $commandResults = Get-JCCommandResult | Where-Object name -Like "RadiusCert-Install*"
+                $SearchFilter = @{
+                    searchTerm = 'RadiusCert-Install'
+                    fields     = @('name')
+                }
+                $commandResults = Search-JcSdkCommandResult -SearchFilter $SearchFilter
                 if ($commandResults) {
-                    $groupedCommandResults = $commandResults | Group-Object name, system | Sort-Object -Property responseTime -Descending
+                    $groupedCommandResults = $commandResults | Group-Object name, systemId | Sort-Object -Property responseTime -Descending
                     $mostRecentCommandResults = $groupedCommandResults | ForEach-Object { $_.Group | Select-Object -First 1 }
                     $commandResults | ForEach-Object {
-                        if ($_._id -in $mostRecentCommandResults._id) {
+                        if ($_.id -in $mostRecentCommandResults.id) {
                             return
                         } else {
-                            Remove-JCCommandResult -CommandResultID $_._id -force | Out-Null
+                            Remove-JCCommandResult -CommandResultID $_.id -force | Out-Null
                         }
                     }
                 }
@@ -113,7 +121,7 @@ Function Get-CommandObjectTable {
                     if ($finishedCommands) {
                         # If there are finished command results, iterate through each and add to command object array
                         $finishedCommands | ForEach-Object {
-                            if (($finishedCommands.exitCode -eq 0)) {
+                            if (($finishedCommands.DataExitCode -eq 0)) {
                                 $character = "$([char]0x1b)[92mOK"
                                 # Remove successful systems from command associations
                                 Set-JcSdkCommandAssociation -CommandId:("$($command.commandId)") -Op 'remove' -Type:('system') -Id:("$($_.systemId)") -ErrorAction SilentlyContinue | Out-Null
@@ -122,7 +130,7 @@ Function Get-CommandObjectTable {
                             }
                             $CommandTable = @{
                                 commandName       = $command.commandName
-                                systemDisplayName = $_.system
+                                systemDisplayName = $SystemHash | Where-Object _id -EQ $_.systemId | Select-Object -ExpandProperty displayName
                                 status            = $character
                             }
                             $CommandObjectTable += $CommandTable

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -112,6 +112,7 @@ foreach ($user in $userArray) {
                 Command           = @"
 set -e
 unzip -o /tmp/$($user.userName)-client-signed.zip -d /tmp
+chmod 755 /tmp/$($user.userName)-client-signed.pfx
 currentUser=`$(/usr/bin/stat -f%Su /dev/console)
 currentUserUID=`$(id -u "`$currentUser")
 currentCertSN="$($certHash.serial)"


### PR DESCRIPTION
## Issues
* [SA-3170](https://jumpcloud.atlassian.net/browse/SA-3170) - Replace Get-JCCommandResults with Search-JCSdkCommandResult
* [SA-3345](https://jumpcloud.atlassian.net/browse/SA-3345) - PFX Permission adjustment on MacOS distribute script

## What does this solve?
This change will reduce the time it takes to aggregate command results in tenants with large amounts of existing command results. The search endpoint doesn't require as many API calls to paginate the data.

Added chmod to the MacOS distribute script due to reports of permission issues on deployment

## Is there anything particularly tricky?
The command result clean up had to be adjusted to account for the new return body that the SDK uses compared to the Get-JCCommandResult function.

## How should this be tested?
Attempt the deployment scripts as usual
View the command results by selection option 4 in the main menu
When viewing the command results, ensure that the latest round of command results are displayed and that the previous command results are removed in the console

[SA-3170]: https://jumpcloud.atlassian.net/browse/SA-3170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SA-3345]: https://jumpcloud.atlassian.net/browse/SA-3345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ