### PR TITLE
no users logged in / changelog updates

### DIFF
--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,17 +1,20 @@
 ## 1.0.3
 
-Release Date: May 24, 2023
+Release Date: May 30, 2023
 
 #### RELEASE NOTES
 
 ```
 Fixed an issue affecting permissions on certain MacOS devices when attempting to deploy certs
 Improved performance when reviewing Command Results by changing fetch requests to Search-JCSDKCommandResult endpoint
+Added a condidtion for returning exit 4 on windows systems when no users are logged in
 ```
+
 #### FEATURES:
 
 - Fixed an issue affecting permissions on certain MacOS devices when attempting to deploy certs
 - Improved performance when reviewing Command Results by changing fetch requests to Search-JCSDKCommandResult endpoint
+
 ## 1.0.2
 
 Release Date: May 2, 2023
@@ -21,6 +24,7 @@ Release Date: May 2, 2023
 ```
 Fixed an issue with the JCUSERCERTPASS not being correctly passed into Windows devices when changed from default
 ```
+
 #### FEATURES:
 
 - JCUSERCERTPASS was not being correctly referenced when the device commands are generated resulting in certificates not being installed

--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -37,7 +37,7 @@ $CertType = "UsernameCn"
 # Do not modify below
 ################################################################################
 
-$UserAgent_ModuleVersion = '1.0.2'
+$UserAgent_ModuleVersion = '1.0.3'
 $UserAgent_ModuleName = 'PasswordlessRadiusConfig'
 #Build the UserAgent string
 $UserAgent_ModuleName = "JumpCloud_$($UserAgent_ModuleName).PowerShellModule"

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -259,7 +259,12 @@ fi
 If ("Nuget" -notin `$PkgProvider.Name){
     Install-PackageProvider -Name NuGet -Force
 }
-`$CurrentUser = ((Get-WMIObject -ClassName Win32_ComputerSystem).Username).Split('\')[1]
+`$CurrentUser = (Get-WMIObject -ClassName Win32_ComputerSystem).Username
+if ( -Not [string]::isNullOrEmpty(`$CurrentUser) ){
+    `$CurrentUser = `$CurrentUser.Split('\')[1]
+} else {
+    `$CurrentUser = `$null
+}
 if (`$CurrentUser -eq "$($user.userName)") {
     if (-not(Get-InstalledModule -Name RunAsUser -errorAction "SilentlyContinue")) {
         Write-Host "RunAsUser Module not installed, Installing..."
@@ -329,7 +334,11 @@ if (`$CurrentUser -eq "$($user.userName)") {
         Throw "Cert was not installed"
     }
 } else {
-    Write-Host "Current logged in user, `$CurrentUser, does not match expected certificate user. Please ensure $($user.userName) is signed in and retry."
+    if (`$CurrentUser -eq `$null){
+        Write-Host "No users are signed into the system. Please ensure $($user.userName) is signed in and retry."
+    } else {
+        Write-Host "Current logged in user, `$CurrentUser, does not match expected certificate user. Please ensure $($user.userName) is signed in and retry."
+    }
     # finally clean up temp files:
     If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.zip"){
         Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.zip"


### PR DESCRIPTION
## Issues
* [SA-3355](https://jumpcloud.atlassian.net/browse/SA-3355) - Throw exit 4 when no users are logged in to a windows host

## What does this solve?

Instead of throwing a generic exit 1, the radius example scripts will now throw an exit code 4 and inform users that no one is logged in.

## Is there anything particularly tricky?

## How should this be tested?

On a windows host, deploy the radius cert with no user logged in. The exit code for the command result should be exit code 4.

## Screenshots

When the correct user is logged in (previous behavior unchanged)
![Screen Shot 2023-05-30 at 10 55 41 AM](https://github.com/TheJumpCloud/support/assets/54448601/cedac732-5197-4d74-b326-20d227441cc6)

When the incorrect user is logged in (previous behavior unchanged)
![Screen Shot 2023-05-30 at 10 54 30 AM](https://github.com/TheJumpCloud/support/assets/54448601/4456e5ff-9e52-4448-9d93-f9188b90a4fd)

When no one is logged in (new behavior)
![Screen Shot 2023-05-30 at 10 56 37 AM](https://github.com/TheJumpCloud/support/assets/54448601/b8dce6e6-13af-4ff2-8f9d-d77303a2418b)


[SA-3355]: https://jumpcloud.atlassian.net/browse/SA-3355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ