### PR TITLE
v1.0.4, update distribute script

### DIFF
--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,3 +1,17 @@
+## 1.0.4
+
+Release Date: June 5, 2023
+
+#### RELEASE NOTES
+
+```
+Addressed an issue on macOS with EmailSAN and EmailDN type cert deployments where assigning network SSIDs during certificate import.
+```
+
+#### Bug Fixes:
+
+- In previous versions, deploying either an EmailSAN or EmailDN type cert would throw an error while attempting to associate a network SSID to the newly imported certificate. The cert identifier in this case was updated to the SHA1 hash of the certificates instead of the common name (which was incorrectly identified in previous iterations of these example scripts).
+
 ## 1.0.3
 
 Release Date: May 30, 2023

--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -37,7 +37,7 @@ $CertType = "UsernameCn"
 # Do not modify below
 ################################################################################
 
-$UserAgent_ModuleVersion = '1.0.3'
+$UserAgent_ModuleVersion = '1.0.4'
 $UserAgent_ModuleName = 'PasswordlessRadiusConfig'
 #Build the UserAgent string
 $UserAgent_ModuleName = "JumpCloud_$($UserAgent_ModuleName).PowerShellModule"


### PR DESCRIPTION
## Issues
* [SA-3379](https://jumpcloud.atlassian.net/browse/SA-3379) - Radius Cert Deployment, SSID mac set preference regardless of the certificate identifier type.

## What does this solve?

In previous iterations of the Radius Cert Deployment scripts, if a cert type of `EmailSAN` or `EmailDN` was selected and distributed to a macOS system, the step to assign a network SSID to the installed certificate would fail. The deployment script was erroneously attempting to identify a certificate by it's email identifier which is not a valid option for the [Security Set-Identity-Preference](https://ss64.com/osx/security-id.html) command. This would result in the command results throwing an exit code 2, and an "illegal option --e" error:

![Screen Shot 2023-06-06 at 9 10 06 AM](https://github.com/TheJumpCloud/support/assets/54448601/80668e1b-4ed9-4a6a-ae20-84b4540b0230)

To address this, instead of identifying commands by their common name, or email (depending on the cert type), now all installed certificates will be identified by their SHA1 hash. When the macOS command attempts to assign a network SSID to the installed certificate, the certificate will be explicitly identified by its SHA1 hash.

## Is there anything particularly tricky?

## How should this be tested?

Validate the previous behavior, generate a set of user certs of type `EmailSAN` or `EmailDN` and deploy to a macOS host.  The commands should fail on the `set-identity-preference` step.

Pull the changes from this branch into your local project and attempt to distribute a set of `EmailSAN` or `EmailDN` certs again. The certificate should be installed correctly and not throw any errors. 

## Screenshots


[SA-3379]: https://jumpcloud.atlassian.net/browse/SA-3379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ