### PR TITLE
update mac - generic dmg installer

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Generic DMG Installer.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Generic DMG Installer.md
@@ -10,7 +10,7 @@ mac
 
 ```
 #!/bin/bash
-# *** USAGE *** Version: 1.1
+# *** USAGE *** Version: 1.2
 
 # *NOTE* this template is only designed to work with DMG files and does not support .pkg, .zip files or DMGs that contain .pkg installers.
 
@@ -22,6 +22,7 @@ mac
 
 
 DownloadUrl="DOWNLOAD_URL"
+### Modify below this line at your own risk!
 # Locate DMG Download Link From URL
 regex='^https.*.dmg$'
 if [[ $DownloadUrl =~ $regex ]]; then

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Generic DMG Installer.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Generic DMG Installer.md
@@ -9,6 +9,7 @@ mac
 #### Command
 
 ```
+#!/bin/bash
 # *** USAGE *** Version: 1.1
 
 # *NOTE* this template is only designed to work with DMG files and does not support .pkg, .zip files or DMGs that contain .pkg installers.
@@ -19,164 +20,118 @@ mac
 
 # *NOTE* this template is only designed to work with DMG files and does not support .pkg or .zip files.
 
-DownloadUrl=""
 
-### Modify below this line at your own risk!
-
+DownloadUrl="DOWNLOAD_URL"
 # Locate DMG Download Link From URL
-
 regex='^https.*.dmg$'
 if [[ $DownloadUrl =~ $regex ]]; then
     echo "URL points to direct DMG download"
     validLink="True"
 else
     echo "Searching headers for download links"
-    urlHead=$(curl -s --head $DownloadUrl)
-
+    urlHead=$(curl -s --head "$DownloadUrl")
     locationSearch=$(echo "$urlHead" | grep https:)
-
     if [ -n "$locationSearch" ]; then
-
-        locationRaw=$(echo "$locationSearch" | cut -d' ' -f2)
-
+        locationRaw=$(echo "$locationSearch" | awk '{print $2}')
         locationFormatted="$(echo "${locationRaw}" | tr -d '[:space:]')"
-
         regex='^https.*'
         if [[ $locationFormatted =~ $regex ]]; then
             echo "Download link found"
-            DownloadUrl=$(echo "$locationFormatted")
+            DownloadUrl="$locationFormatted"
         else
             echo "No https location download link found in headers"
             exit 1
         fi
-
     else
-
         echo "No location download link found in headers"
         exit 1
     fi
-
 fi
-
-#Create Temp Folder
+# Create Temp Folder
 DATE=$(date '+%Y-%m-%d-%H-%M-%S')
-
 TempFolder="Download-$DATE"
-
-mkdir /tmp/$TempFolder
-
+mkdir -p "/tmp/$TempFolder"
 # Navigate to Temp Folder
-cd /tmp/$TempFolder
-
+cd "/tmp/$TempFolder" || exit
 # Download File into Temp Folder
 curl -s -O "$DownloadUrl"
-
 # Capture name of Download File
 DownloadFile="$(ls)"
-
 echo "Downloaded $DownloadFile to /tmp/$TempFolder"
-
-# Verifies DMG File
+# Verify DMG File
 regex='\.dmg$'
 if [[ $DownloadFile =~ $regex ]]; then
-    DMGFile="$(echo "$DownloadFile")"
+    DMGFile="$DownloadFile"
     echo "DMG File Found: $DMGFile"
 else
     echo "File: $DownloadFile is not a DMG"
-    rm -r /tmp/$TempFolder
+    rm -r "/tmp/$TempFolder"
     echo "Deleted /tmp/$TempFolder"
     exit 1
 fi
-
-# Mount DMG File -nobrowse prevents the volume from popping up in Finder
-
-hdiutilAttach=$(hdiutil attach /tmp/$TempFolder/$DMGFile -nobrowse)
-
-echo "Used hdiutil to mount $DMGFile "
-
+# Mount DMG File (-nobrowse prevents the volume from popping up in Finder)
+hdiutilAttach=$(hdiutil attach "/tmp/$TempFolder/$DMGFile" -nobrowse)
+echo "Used hdiutil to mount $DMGFile"
 err=$?
 if [ ${err} -ne 0 ]; then
     echo "Could not mount $DMGFile Error: ${err}"
-    rm -r /tmp/$TempFolder
+    rm -r "/tmp/$TempFolder"
     echo "Deleted /tmp/$TempFolder"
     exit 1
 fi
-
 regex='\/Volumes\/.*'
 if [[ $hdiutilAttach =~ $regex ]]; then
-    DMGVolume="${BASH_REMATCH[@]}"
+    DMGVolume="${BASH_REMATCH[0]}"
     echo "Located DMG Volume: $DMGVolume"
 else
     echo "DMG Volume not found"
-    rm -r /tmp/$TempFolder
+    rm -r "/tmp/$TempFolder"
     echo "Deleted /tmp/$TempFolder"
     exit 1
 fi
-
 # Identify the mount point for the DMG file
-DMGMountPoint="$(hdiutil info | grep "$DMGVolume" | awk '{ print $1 }')"
-
+DMGMountPoint=$(hdiutil info | grep "$DMGVolume" | awk '{ print $1 }')
 echo "Located DMG Mount Point: $DMGMountPoint"
-
 # Capture name of App file
-
-cd "$DMGVolume"
-
-AppName="$(ls | Grep .app)"
-
-cd ~
-
+cd "$DMGVolume" || exit
+AppName=$(ls | grep '.app')
+cd ~ || exit
 echo "Located App: $AppName"
-
 # Test to ensure App is not already installed
-
 ExistingSearch=$(find "/Applications/" -name "$AppName" -depth 1)
-
 if [ -n "$ExistingSearch" ]; then
-
     echo "$AppName already present in /Applications folder"
-    hdiutil detach $DMGMountPoint
+    hdiutil detach "$DMGMountPoint"
     echo "Used hdiutil to detach $DMGFile from $DMGMountPoint"
-    rm -r /tmp/$TempFolder
+    rm -r "/tmp/$TempFolder"
     echo "Deleted /tmp/$TempFolder"
     exit 1
-
 else
-
     echo "$AppName not present in /Applications folder"
 fi
-
 DMGAppPath=$(find "$DMGVolume" -name "*.app" -depth 1)
-
 # Copy the contents of the DMG file to /Applications/
 # Preserves all file attributes and ACLs
 cp -pPR "$DMGAppPath" /Applications/
-
 err=$?
 if [ ${err} -ne 0 ]; then
     echo "Could not copy $DMGAppPath Error: ${err}"
-    hdiutil detach $DMGMountPoint
+    hdiutil detach "$DMGMountPoint"
     echo "Used hdiutil to detach $DMGFile from $DMGMountPoint"
-    rm -r /tmp/$TempFolder
+    rm -r "/tmp/$TempFolder"
     echo "Deleted /tmp/$TempFolder"
     exit 1
 fi
-
 echo "Copied $DMGAppPath to /Applications"
-
 # Unmount the DMG file
-hdiutil detach $DMGMountPoint
-
+hdiutil detach "$DMGMountPoint"
 echo "Used hdiutil to detach $DMGFile from $DMGMountPoint"
-
 err=$?
 if [ ${err} -ne 0 ]; then
-    abort "Could not detach DMG: $DMGMountPoint Error: ${err}"
+    echo "Could not detach DMG: $DMGMountPoint Error: ${err}"
 fi
-
 # Remove Temp Folder and download
-rm -r /tmp/$TempFolder
-
+rm -r "/tmp/$TempFolder"
 echo "Deleted /tmp/$TempFolder"
 ```
 
@@ -237,7 +192,7 @@ Searching headers for download links
 Download link found
 Downloaded Slack-3.3.7.dmg to /tmp/Download-2019-01-23-10-28-49
 DMG File Found: Slack-3.3.7.dmg
-Used hdiutil to mount Slack-3.3.7.dmg 
+Used hdiutil to mount Slack-3.3.7.dmg
 Located DMG Volume: /Volumes/Slack.app
 Located DMG Mount Point: /dev/disk2s1
 Located App: Slack.app


### PR DESCRIPTION
## Issues
* [SA-3359](https://jumpcloud.atlassian.net/browse/<jira-id>) - SA-3359

## What does this solve?
Update mac generic dmg installer to fix error issues.

## Is there anything particularly tricky?
n/a
## How should this be tested?
Test with with a direct download link stored in S3 or links you're able to directly download from a website.

## Screenshots


[SA-3359]: https://jumpcloud.atlassian.net/browse/SA-3359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ