### PR TITLE
local user fix for cert CN identification

### DIFF
--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,3 +1,17 @@
+## 1.0.5
+
+Release Date: July 3, 2023
+
+#### RELEASE NOTES
+
+```
+Addressed an issue generating certificates for users with localUsernames (systemUsernames specified in the JumpCloud console). These user certificates were generated with the localUsername instead of their username field. The resulting certificate would never be allowed to access a radius backed network as their localUsername does not match the username.
+```
+
+#### Bug Fixes:
+
+- Certificates for users with localUsername (systemUsernames) should now authenticate to radius networks. Their CNs should now be based on their usernames, not localUsernames.
+
 ## 1.0.4
 
 Release Date: June 5, 2023

--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,6 +1,6 @@
 ## 1.0.5
 
-Release Date: July 3, 2023
+Release Date: July 20, 2023
 
 #### RELEASE NOTES
 

--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -14,7 +14,7 @@ $JCUSERCERTVALIDITY = 90
 $NETWORKSSID = "YOUR_SSID"
 # OpenSSLBinary by default this is (openssl)
 # NOTE: If openssl does not work, try using the full path to the openssl file
-# MacOS HomeBrew Example: '/usr/local/Cellar/openssl@3/3.0.7/bin/openssl'
+# MacOS HomeBrew Example: '/usr/local/Cellar/openssl@3/3.1.1/bin/openssl'
 $opensslBinary = 'openssl'
 # Enter Cert Subject Headers (do not enter strings with spaces)
 $Subj = [PSCustomObject]@{
@@ -37,7 +37,7 @@ $CertType = "UsernameCn"
 # Do not modify below
 ################################################################################
 
-$UserAgent_ModuleVersion = '1.0.4'
+$UserAgent_ModuleVersion = '1.0.5'
 $UserAgent_ModuleName = 'PasswordlessRadiusConfig'
 #Build the UserAgent string
 $UserAgent_ModuleName = "JumpCloud_$($UserAgent_ModuleName).PowerShellModule"

--- a/scripts/automation/Radius/Functions/Private/Get-WebJCUser.ps1
+++ b/scripts/automation/Radius/Functions/Private/Get-WebJCUser.ps1
@@ -15,10 +15,16 @@ function get-webjcuser {
         $response = Invoke-RestMethod -Uri "https://console.jumpcloud.com/api/systemusers/$userID" -Method GET -Headers $headers
         $userObj = [PSCustomObject]@{
             # If the localUserAccount field is set, use that for username, otherwise use JC username
-            username = $(if ([string]::IsNullOrEmpty($response.systemUsername)) { $response.username } else { $response.systemUsername })
+            hasLocalUsername = $(if ([string]::IsNullOrEmpty($response.systemUsername)) {
+                    $false
+                } else {
+                    $true
+                })
+            username         = $response.username
+            localUsername    = $response.systemUsername
 
-            id       = $response._id
-            email    = $response.email
+            id               = $response._id
+            email            = $response.email
         }
     }
     end {

--- a/scripts/automation/Radius/Functions/Public/Generate-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Generate-UserCerts.ps1
@@ -62,14 +62,13 @@ if (Test-Path "$JCScriptRoot/UserCerts") {
 foreach ($user in $groupMembers) {
     # Create the User Certs
     $MatchedUser = get-webjcuser -userID $user.id
-
     Write-Host "Generating Cert for user: $($MatchedUser.username)"
 
     if ($MatchedUser.id -in $userArray.userId) {
         if (Test-Path -Path "$JCScriptRoot/UserCerts/$($MatchedUser.username)-client-signed.pfx") {
             Write-Host "[status] $($MatchedUser.username) already has certs generated... skipping"
         } else {
-            Generate-UserCert -CertType $CertType -user $MatchedUser -rootCAKey "$JCScriptRoot/Cert/radius_ca_key.pem" -rootCA "$JCScriptRoot/Cert/radius_ca_cert.pem"
+            Generate-UserCert -CertType $CertType -user $MatchedUser.username -rootCAKey "$JCScriptRoot/Cert/radius_ca_key.pem" -rootCA "$JCScriptRoot/Cert/radius_ca_cert.pem"
         }
     } else {
         Write-Host "[status] $($MatchedUser.username) not found in users.json"
@@ -92,6 +91,11 @@ foreach ($user in $groupMembers) {
         $userTable = @{
             userId              = $MatchedUser.id
             userName            = $MatchedUser.username
+            localUsername       = $(If ($MatchedUser.hasLocalUsername) {
+                    $matchedUser.localUsername
+                } else {
+                    $matchedUser.username
+                })
             systemAssociations  = $systemAssociations
             commandAssociations = @()
         }


### PR DESCRIPTION
## Issues
* [SA-3225](https://jumpcloud.atlassian.net/browse/SA-3225) - Local Username Certificate CN Fix

## What does this solve?

Previously when generating certificates with users who also have a systemUsername (local username account field set). The resulting certificates were generated with a users 'systemUsername'. Radius authentication only matches a user's username and user's with these certificates would never be allowed to access a radius backed network. 

This change tracks a user's localUsername and username (if both exist). Certs are generated with the users username but installed to the localUsername directory.

## Is there anything particularly tricky?

## How should this be tested?

- Associate a user who has a systemUsername (local username account field set) to a radius access group
- Generate a radius user certificate for this user
- distribute the radius certificate to the user's macOS and windows system
- the certificate should install
- the certificate should allow a user to access a radius backed network even though their localUsername is different from the CA in the resulting certificate.


## Screenshots


[SA-3225]: https://jumpcloud.atlassian.net/browse/SA-3225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ