### PR TITLE
Fix windows JC PWM installer

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Install JumpCloud Password Manager App.md
+++ b/PowerShell/JumpCloud Commands Gallery/Windows Commands/Windows - Install JumpCloud Password Manager App.md
@@ -1,6 +1,6 @@
 #### Name
 
-Windows - Install JumpCloud Password Manager App | v1.0 JCCG
+Windows - Install JumpCloud Password Manager App | v1.1 JCCG
 
 #### commandType
 


### PR DESCRIPTION
## Issues
* [SA-3495](https://jumpcloud.atlassian.net/browse/SA-3495) - SA-3495-Fix-JCPwm-Windows-Install-Script

## What does this solve?
This solves the issue with System to User file permission where when the script tries to install the .exe file download in the Windows temp folder, the user command is unable to run the .exe if the user is not an admin. This change, downloads the .exe file to the current logged on user temp file.
## Is there anything particularly tricky?
N/A
## How should this be tested?
Run the command through the UI and validate if the password manager installs in a couple of minutes. Do this on a standard user and admin user