### PR TITLE
Backup AD Agent Logs and Config in AD server

### DIFF
--- a/scripts/windows/BackupADLog_JCSupportTeam.ps1
+++ b/scripts/windows/BackupADLog_JCSupportTeam.ps1
@@ -1,0 +1,9 @@
+﻿$time = Get-Date -UFormat "%B_%d_%Y_%T" | ForEach-Object { $_ -replace ":", "-" }  2> $null
+
+New-Item -Path "C:\Windows\Temp\JumpCloud_Log_$time" -ItemType Directory
+Copy-Item -Path "C:\Windows\Temp\JumpCloud_AD_Integration.log" -Destination "C:\Windows\Temp\JumpCloud_Log_$time"
+Copy-Item -Path "C:\Program Files\JumpCloud\AD Sync\adsync.log" -Destination "C:\Windows\Temp\JumpCloud_Log_$time"
+Copy-Item -Path "C:\Program Files\JumpCloud AD Bridge\adint.config.json" -Destination "C:\Windows\Temp\JumpCloud_Log_$time"
+
+Compress-Archive -Path "C:\Windows\Temp\JumpCloud_Log_$time" -DestinationPath "C:\Windows\Temp\JumpCloud_Log_$time.zip"
+Move-Item -Path "C:\Windows\Temp\JumpCloud_Log_$time.zip" -Destination "$([Environment]::GetFolderPath('Desktop'))\JumpCloud_Log_$time.zip"


### PR DESCRIPTION
## Issues
* [<jira-id>](https://jumpcloud.atlassian.net/browse/<jira-id>) - <jira-title>

## What does this solve?
Backup JumpCloud AD Integration log, AD Sync log, and JumpCloud AD Bridge config in the customer AD server for the JumpCloud Support team during the support meeting call.
It helps customers to backup logs/config files as one ZIP file and send this file to support for investigation.
## Is there anything particularly tricky?

## How should this be tested?
Run this script on the AD server to get logs and config. This will show a zip file on the user's Desktop. The customer (Admin) can send to JumpCloud support.
## Screenshots
