### PR TITLE
2.8.0 changes to remove sys/usr groups

### DIFF
--- a/PowerShell/JumpCloud Module/Public/Groups/SystemGroups/Remove-JCSystemGroup.ps1
+++ b/PowerShell/JumpCloud Module/Public/Groups/SystemGroups/Remove-JCSystemGroup.ps1
@@ -1,14 +1,28 @@
 Function Remove-JCSystemGroup () {
-    [CmdletBinding(DefaultParameterSetName = 'warn')]
+    [CmdletBinding(DefaultParameterSetName = 'byName')]
     param
     (
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName, ParameterSetName = 'warn', Position = 0, HelpMessage = 'The name of the System Group you want to remove.')]
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName, ParameterSetName = 'force', Position = 0, HelpMessage = 'The name of the System Group you want to remove.')]
+        [Parameter(Mandatory,
+            ValueFromPipelineByPropertyName,
+            ParameterSetName = 'byName',
+            Position = 0,
+            HelpMessage = 'The name of the System Group you want to remove.')]
         [Alias('name')]
         [String]$GroupName,
 
-        [Parameter(ParameterSetName = 'force', HelpMessage = 'A SwitchParameter which suppresses the warning message when removing a JumpCloud System Group.')]
-        [Switch]$force
+        [Parameter(Mandatory,
+            ValueFromPipelineByPropertyName,
+            ParameterSetName = 'ByID',
+            HelpMessage = 'The _id of the group which you want to remove. GroupID has an Alias of _id. This means you can leverage the PowerShell pipeline to populate this field automatically.')]
+        [Alias('_id', 'id')]
+        [String]$GroupID,
+
+        [Parameter(ParameterSetName = 'byName')]
+        [Parameter(
+            ParameterSetName = 'ByID',
+            HelpMessage = 'A SwitchParameter which suppresses the warning message when removing a JumpCloud System  Group.')]
+        [Switch]
+        $force
     )
 
     begin {
@@ -19,11 +33,9 @@ Function Remove-JCSystemGroup () {
 
         Write-Debug 'Populating API headers'
         $hdrs = @{
-
             'Content-Type' = 'application/json'
             'Accept'       = 'application/json'
             'X-API-KEY'    = $JCAPIKEY
-
         }
 
         if ($JCOrgID) {
@@ -33,49 +45,18 @@ Function Remove-JCSystemGroup () {
         Write-Debug 'Initilizing rawResults and results resultsArray'
         $resultsArray = @()
 
-
         Write-Debug 'Populating GroupNameHash'
         $GroupNameHash = Get-DynamicHash -Object Group -GroupType System -returnProperties name
-
-
     }
 
-
     process {
-        if ($PSCmdlet.ParameterSetName -eq 'warn') {
-            ForEach ($Gname in $GroupName) {
-                if ($GroupNameHash.Values.names -contains ($Gname)) {
-                    $GID = $GroupNameHash.GetEnumerator().Where({ $_.Value.name -contains ($Gname) }).Name
+        if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            if ($GroupNameHash.Values.name -contains ($GroupName)) {
+                $GID = $GroupNameHash.GetEnumerator().Where({ $_.Value.name -contains ($GroupName) }).Name
 
-                    Write-Warning "Are you sure you want to delete group: $Gname ?" -WarningAction Inquire
-
-                    $URI = "$JCUrlBasePath/api/v2/systemgroups/$GID"
-
-                    $DeletedGroup = Invoke-RestMethod -Method DELETE -Uri $URI -Headers $hdrs -UserAgent:(Get-JCUserAgent)
-
-                    $Status = 'Deleted'
-
-                    $FormattedResults = [PSCustomObject]@{
-
-                        'Name'   = $Gname
-                        'Result' = $Status
-
-                    }
-
-                    $resultsArray += $FormattedResults
+                if ('force' -notin $PSBoundParameters.keys) {
+                    Write-Warning "Are you sure you want to delete group: $GroupName ?" -WarningAction Inquire
                 }
-
-                else {
-                    Throw "Group does not exist. Run 'Get-JCGroup -type User' to see a list of all your JumpCloud user groups."
-                }
-            }
-        }
-
-        if ($PSCmdlet.ParameterSetName -eq 'force') {
-            ForEach ($Gname in $GroupName) {
-
-                $GID = $GroupNameHash.GetEnumerator().Where({ $_.Value.name -contains ($Gname) }).Name
-
                 try {
                     $URI = "$JCUrlBasePath/api/v2/systemgroups/$GID"
                     $DeletedGroup = Invoke-RestMethod -Method DELETE -Uri $URI -Headers $hdrs -UserAgent:(Get-JCUserAgent)
@@ -83,17 +64,35 @@ Function Remove-JCSystemGroup () {
                 } catch {
                     $Status = $_.ErrorDetails
                 }
-
                 $FormattedResults = [PSCustomObject]@{
-
                     'Name'   = $Gname
                     'Result' = $Status
-
                 }
-
                 $resultsArray += $FormattedResults
+            } else {
+                Throw "Group does not exist. Run 'Get-JCGroup -type system' to see a list of all your JumpCloud system groups."
             }
-
+        }
+        if ($PSCmdlet.ParameterSetName -eq 'ById') {
+            if ($GroupNameHash[$groupID]) {
+                if ('force' -notin $PSBoundParameters.keys) {
+                    Write-Warning "Are you sure you want to delete group: $($GroupNameHash[$groupID].name) ?" -WarningAction Inquire
+                }
+                try {
+                    $URI = "$JCUrlBasePath/api/v2/systemgroups/$groupID"
+                    $DeletedGroup = Invoke-RestMethod -Method DELETE -Uri $URI -Headers $hdrs -UserAgent:(Get-JCUserAgent)
+                    $Status = 'Deleted'
+                } catch {
+                    $Status = $_.ErrorDetails
+                }
+                $FormattedResults = [PSCustomObject]@{
+                    'Name'   = $GroupNameHash[$groupID].name
+                    'Result' = $Status
+                }
+                $resultsArray += $FormattedResults
+            } else {
+                Throw "Group does not exist. Run 'Get-JCGroup -type system' to see a list of all your JumpCloud system groups."
+            }
         }
     }
     end {

--- a/PowerShell/JumpCloud Module/Public/Groups/UserGroups/Remove-JCUserGroup.ps1
+++ b/PowerShell/JumpCloud Module/Public/Groups/UserGroups/Remove-JCUserGroup.ps1
@@ -1,26 +1,25 @@
 Function Remove-JCUserGroup () {
-    [CmdletBinding(DefaultParameterSetName = 'warn')]
-
+    [CmdletBinding(DefaultParameterSetName = 'byName')]
     param
     (
-
         [Parameter(Mandatory,
             ValueFromPipelineByPropertyName,
-            ParameterSetName = 'warn',
+            ParameterSetName = 'byName',
             Position = 0,
             HelpMessage = 'The name of the User Group you want to remove.')]
-
-        [Parameter(Mandatory,
-            ValueFromPipelineByPropertyName,
-            ParameterSetName = 'force',
-            Position = 0,
-            HelpMessage = 'The name of the User Group you want to remove.')]
-
         [Alias('name')]
         [String]$GroupName,
 
+        [Parameter(Mandatory,
+            ValueFromPipelineByPropertyName,
+            ParameterSetName = 'ByID',
+            HelpMessage = 'The _id of the group which you want to remove. GroupID has an Alias of _id. This means you can leverage the PowerShell pipeline to populate this field automatically.')]
+        [Alias('_id', 'id')]
+        [String]$GroupID,
+
+        [Parameter(ParameterSetName = 'byName')]
         [Parameter(
-            ParameterSetName = 'force',
+            ParameterSetName = 'ByID',
             HelpMessage = 'A SwitchParameter which suppresses the warning message when removing a JumpCloud User Group.')]
         [Switch]
         $force
@@ -34,11 +33,9 @@ Function Remove-JCUserGroup () {
 
         Write-Debug 'Populating API headers'
         $hdrs = @{
-
             'Content-Type' = 'application/json'
             'Accept'       = 'application/json'
             'X-API-KEY'    = $JCAPIKEY
-
         }
 
         if ($JCOrgID) {
@@ -48,49 +45,17 @@ Function Remove-JCUserGroup () {
         Write-Debug 'Initilizing rawResults and results resultsArray'
         $resultsArray = @()
 
-
         Write-Debug 'Populating GroupNameHash'
         $GroupNameHash = Get-DynamicHash -Object Group -GroupType User -returnProperties name
-
-
     }
 
-
     process {
-        if ($PSCmdlet.ParameterSetName -eq 'warn') {
-            ForEach ($Gname in $GroupName) {
-                if ($GroupNameHash.Values.names -contains ($Gname)) {
-                    $GID = $GroupNameHash.GetEnumerator().Where({ $_.Value.name -contains ($Gname) }).Name
-
-                    Write-Warning "Are you sure you want to delete group: $Gname ?" -WarningAction Inquire
-
-                    $URI = "$JCUrlBasePath/api/v2/usergroups/$GID"
-
-                    $DeletedGroup = Invoke-RestMethod -Method DELETE -Uri $URI -Headers $hdrs -UserAgent:(Get-JCUserAgent)
-
-                    $Status = 'Deleted'
-
-                    $FormattedResults = [PSCustomObject]@{
-
-                        'Name'   = $Gname
-                        'Result' = $Status
-
-                    }
-
-                    $resultsArray += $FormattedResults
+        if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            if ($GroupNameHash.Values.name -contains ($GroupName)) {
+                $GID = $GroupNameHash.GetEnumerator().Where({ $_.Value.name -contains ($GroupName) }).Name
+                if ('force' -notin $PSBoundParameters.keys) {
+                    Write-Warning "Are you sure you want to delete group: $GroupName ?" -WarningAction Inquire
                 }
-
-                else {
-                    Throw "Group does not exist. Run 'Get-JCGroup -type User' to see a list of all your JumpCloud user groups."
-                }
-            }
-        }
-
-        if ($PSCmdlet.ParameterSetName -eq 'force') {
-            ForEach ($Gname in $GroupName) {
-
-                $GID = $GroupNameHash.GetEnumerator().Where({ $_.Value.name -contains ($Gname) }).Name
-
                 try {
                     $URI = "$JCUrlBasePath/api/v2/usergroups/$GID"
                     $DeletedGroup = Invoke-RestMethod -Method DELETE -Uri $URI -Headers $hdrs -UserAgent:(Get-JCUserAgent)
@@ -98,17 +63,37 @@ Function Remove-JCUserGroup () {
                 } catch {
                     $Status = $_.ErrorDetails
                 }
-
                 $FormattedResults = [PSCustomObject]@{
-
-                    'Name'   = $Gname
+                    'Name'   = $GroupName
                     'Result' = $Status
-
                 }
-
                 $resultsArray += $FormattedResults
             }
 
+            else {
+                Throw "Group does not exist. Run 'Get-JCGroup -type User' to see a list of all your JumpCloud user groups."
+            }
+        }
+        if ($PSCmdlet.ParameterSetName -eq 'ById') {
+            if ($GroupNameHash[$groupID]) {
+                if ('force' -notin $PSBoundParameters.keys) {
+                    Write-Warning "Are you sure you want to delete group: $($GroupNameHash[$groupID].name) ?" -WarningAction Inquire
+                }
+                try {
+                    $URI = "$JCUrlBasePath/api/v2/usergroups/$groupID"
+                    $DeletedGroup = Invoke-RestMethod -Method DELETE -Uri $URI -Headers $hdrs -UserAgent:(Get-JCUserAgent)
+                    $Status = 'Deleted'
+                } catch {
+                    $Status = $_.ErrorDetails
+                }
+                $FormattedResults = [PSCustomObject]@{
+                    'Name'   = $GroupNameHash[$groupID].name
+                    'Result' = $Status
+                }
+                $resultsArray += $FormattedResults
+            } else {
+                Throw "Group does not exist. Run 'Get-JCGroup -type User' to see a list of all your JumpCloud user groups."
+            }
         }
     }
     end {

--- a/PowerShell/JumpCloud Module/Tests/Public/Groups/SystemGroups/Remove-JCSystemGroup.tests.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Groups/SystemGroups/Remove-JCSystemGroup.tests.ps1
@@ -1,10 +1,24 @@
 Describe -Tag:('JCSystemGroup') 'Remove-JCSystemGroup 1.0' {
     BeforeAll { Connect-JCOnline -JumpCloudApiKey:($PesterParams_ApiKey) -force | Out-Null }
-    It "Removes a system group" {
-        $NewG = New-JCSystemGroup -GroupName $(New-RandomString 8)
-        $DeletedG = Remove-JCSystemGroup -GroupName $NewG.name  -force
-        $DeletedG.Result | Should -Be 'Deleted'
 
+    Context 'Using the default parameter set' {
+
+        It "Removes a system group by Name" {
+            $NewG = New-JCSystemGroup -GroupName $(New-RandomString 8)
+            $DeletedG = Remove-JCSystemGroup -GroupName $NewG.name  -force
+            $DeletedG.Result | Should -Be 'Deleted'
+        }
+        It "Removes a system group by ID" {
+            $NewG = New-JCSystemGroup -GroupName $(New-RandomString 8)
+            $DeletedG = Remove-JCSystemGroup -GroupId $NewG.id  -force
+            $DeletedG.Result | Should -Be 'Deleted'
+        }
     }
-
+    Context 'Using pipeline input' {
+        It "Removes a system group by Name" {
+            $NewG = New-JCSystemGroup -GroupName $(New-RandomString 8)
+            $DeletedG = $NewG | Remove-JCSystemGroup -force
+            $DeletedG.Result | Should -Be 'Deleted'
+        }
+    }
 }

--- a/PowerShell/JumpCloud Module/Tests/Public/Groups/UserGroups/Remove-JCUserGroup.tests.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Groups/UserGroups/Remove-JCUserGroup.tests.ps1
@@ -1,10 +1,23 @@
 Describe -Tag:('JCUserGroup') 'New-JCUserGroup 1.0' {
     BeforeAll { Connect-JCOnline -JumpCloudApiKey:($PesterParams_ApiKey) -force | Out-Null }
-    It "Creates a new user group" {
-        $NewG = New-JCUserGroup -GroupName $(New-RandomString 8)
-        $DeletedG = Remove-JCUserGroup -GroupName $NewG.name  -force
-        $DeletedG.Result | Should -Be 'Deleted'
-
+    context 'Using the default parameter set' {
+        It "Creates a new user group by Name" {
+            $NewG = New-JCUserGroup -GroupName $(New-RandomString 8)
+            $DeletedG = Remove-JCUserGroup -GroupName $NewG.name  -force
+            $DeletedG.Result | Should -Be 'Deleted'
+        }
+        It "Creates a new user groupby ID" {
+            $NewG = New-JCUserGroup -GroupName $(New-RandomString 8)
+            $DeletedG = Remove-JCUserGroup -GroupId $NewG.id  -force
+            $DeletedG.Result | Should -Be 'Deleted'
+        }
     }
-
+    Context 'Using pipeline input' {
+        It "Removes a user group by Name" {
+            $NewG = New-JCUserGroup -GroupName $(New-RandomString 8)
+            $DeletedG = $NewG | Remove-JCUserGroup -force
+            $DeletedG.Result | Should -Be 'Deleted'
+        }
+    }
 }
+

--- a/PowerShell/ModuleChangelog.md
+++ b/PowerShell/ModuleChangelog.md
@@ -1,3 +1,17 @@
+## 2.8.0
+
+Release Date: August 1, 2023
+
+#### RELEASE NOTES
+
+```
+Addressed an issue with Remove-JCSystemGroup and Remove-JCUserGroup, groups can be removed by ID if specified
+```
+
+### BUG FIXES:
+
+Fixed an issue with Remove-JCSystemGroup and Remove-JCUserGroup where group names could not be identified
+
 ## 2.7.0
 
 Release Date: August 1, 2023
@@ -15,7 +29,6 @@ Admins can now upload a .reg file to a new or existing Windows - Advanced: Custo
 ### BUG FIXES:
 
 Fixed an issue with sequential results not returning as expected with large datasets
-
 
 ## 2.5.1
 


### PR DESCRIPTION
## Issues
* [SA-3583](https://jumpcloud.atlassian.net/browse/SA-3583) - Remove-JCuserGroup/JCSystemGroup updates and bugfix

## What does this solve?

Addresses an issue with Remove-JCUserGroup and Remove-JCSystemGroup where the group names could not be identified. Groups can now be removed by id

## Is there anything particularly tricky?

## How should this be tested?

Before pulling this version of the module, try to replicate the issue on 1.7.0 version of the module. Create a user or system group and attempt to remove it by name. The lookup never works and the group can not be deleted. 

Pull the contents of this branch, import and run:
```
New-JCUserGroup -GroupName Test1234
Remove-JCUserGroup -GroupName Test1234

New-JCSystemGroup -GroupName Test1234
Remove-JCSystemGroup - GroupName Test1234
```
The groups should be removed by name. They can also be removed by ID. 

## Screenshots


[SA-3583]: https://jumpcloud.atlassian.net/browse/SA-3583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ