### PR TITLE
1.0.6 multi ssid and non-exportable macos certs

### DIFF
--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,4 +1,4 @@
-## 1.0.5
+## 1.0.6
 
 Release Date: September 25, 2023
 

--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,5 +1,19 @@
 ## 1.0.5
 
+Release Date: September 25, 2023
+
+#### RELEASE NOTES
+
+```
+Certificates distributed to macOS device are now imported using the -x flag to prevent them from being exported.
+```
+
+#### Bug Fixes:
+
+- For users with multiple SSIDs where one SSID has a space in the name, previous versions of the script could not account for this. This version addresses this change by passing text with a ';' delimiter rather than a space.
+
+## 1.0.5
+
 Release Date: July 20, 2023
 
 #### RELEASE NOTES

--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -9,8 +9,8 @@ $JCUSERCERTPASS = 'secret1234!'
 # USER CERT Validity Length (days)
 $JCUSERCERTVALIDITY = 90
 # List Of Radius Network SSID(s)
-# For Multiple SSIDs enter as a single string seperated by spaces ex:
-# "CorpNetwork_Denver CorpNetwork_Boulder"
+# For Multiple SSIDs enter as a single string seperated by a semicolon  ex:
+# "CorpNetwork_Denver;CorpNetwork_Boulder;CorpNetwork_Boulder 5G;Guest Network"
 $NETWORKSSID = "YOUR_SSID"
 # OpenSSLBinary by default this is (openssl)
 # NOTE: If openssl does not work, try using the full path to the openssl file
@@ -37,7 +37,7 @@ $CertType = "UsernameCn"
 # Do not modify below
 ################################################################################
 
-$UserAgent_ModuleVersion = '1.0.5'
+$UserAgent_ModuleVersion = '1.0.6'
 $UserAgent_ModuleName = 'PasswordlessRadiusConfig'
 #Build the UserAgent string
 $UserAgent_ModuleName = "JumpCloud_$($UserAgent_ModuleName).PowerShellModule"

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -163,7 +163,7 @@ if [[ `$currentUser ==  $($user.localUsername) ]]; then
     fi
 
     if [[ `$import == true ]]; then
-        /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security import /tmp/$($user.userName)-client-signed.pfx -k /Users/$($user.localUsername)/Library/Keychains/login.keychain -P $JCUSERCERTPASS -T "/System/Library/SystemConfiguration/EAPOLController.bundle/Contents/Resources/eapolclient"
+        /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security import /tmp/$($user.userName)-client-signed.pfx -x -k /Users/$($user.localUsername)/Library/Keychains/login.keychain -P $JCUSERCERTPASS -T "/System/Library/SystemConfiguration/EAPOLController.bundle/Contents/Resources/eapolclient"
         if [[ `$? -eq 0 ]]; then
             echo "Import Success"
             # get the SHA hash of the newly imported cert
@@ -181,8 +181,9 @@ if [[ `$currentUser ==  $($user.localUsername) ]]; then
     fi
 
     # check if the cert secruity preference is set:
-    for i in `${networkSsid[@]}; do
-        echo "begin sertting network SSID: `$i security certificate"
+    IFS=';' read -ra network <<< "`$networkSsid"
+    for i in "`${network[@]}"; do
+        echo "begin setting network SSID: `$i"
         if /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security get-identity-preference -s "com.apple.network.eap.user.identity.wlan.ssid.`$i" -Z "`$installedCertSHA"; then
             echo "it was already set"
         else
@@ -195,7 +196,6 @@ if [[ `$currentUser ==  $($user.localUsername) ]]; then
             fi
         fi
     done
-
 
     # print results
     echo "################## Cert Install Results ##################"


### PR DESCRIPTION
## Issues
* [SA-3558](https://jumpcloud.atlassian.net/browse/SA-3558) - Multiple SSIDs with spaces

## What does this solve?

In previous versions of the radius example scripts, multiple SSIDs could be specified as long as those SSIDs did not have a space in the name. Some SSID set like "network_5G network_2.5G" would have been valid in a previous release whereas "network 5G network 2.5G" would not. In this release, space is no longer a delimiter to split network names, instead, the semicolon ";" is used to split network names. In this release setting the `$NETWORKSSID` variable to "network 5G;network 2.5G" would assign a macOS user's wifi certificate to both networks `network 5G` and `network 2.5G`

In addition this release changes the import certificate macOS security commands slightly by adding the `-x` flag which prevents the certificates from being exported from the keychain after installation.

## Is there anything particularly tricky?

NA

## How should this be tested?

In the radius `config.ps1` file, change the `$NETWORKSSID` variable to a string with several network names one of which should have a space in the name. 

Generate and distribute a set of certs to a test user on a VM, when the certificate is distributed and installed on the user's device, the certificate should be set to automatically apply when connected to each network specified in the `$NETWORKSSID` variable. 

Furthermore the installed certificate should no longer be exportable once it's in the user's keychain

## Screenshots

In this screenshot both networks `TP-Link_3832` and `Some network with a space` were set to use the installed certificate for authentication after the certificate was installed: 

![Screenshot 2023-09-25 at 1 43 43 PM](https://github.com/TheJumpCloud/support/assets/54448601/d084533a-0423-412a-8421-961f35d6bb9e)

After the certificate was installed, it can no longer be exported by right-clicking the private key and selecting export. The following error should be displayed when a user attempts to export this installed certificate. 

<img width="353" alt="Screen Shot 2023-09-12 at 10 50 38 AM 2" src="https://github.com/TheJumpCloud/support/assets/54448601/2737f7bf-9e9d-4b6d-a3f1-474cf27e57b8">


[SA-3558]: https://jumpcloud.atlassian.net/browse/SA-3558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ