### PR TITLE
SA-3640 fix -type association bug

### DIFF
--- a/PowerShell/JumpCloud Module/Private/Association/Format-JCAssociation.ps1
+++ b/PowerShell/JumpCloud Module/Private/Association/Format-JCAssociation.ps1
@@ -55,8 +55,13 @@ Function Format-JCAssociation {
                 $AssociationProperties = $_ |
                 ForEach-Object { $_.PSObject.Properties.name } | Select-Object -Unique
                 If ($AssociationProperties) {
-                    ForEach ($AssociationProperty In $AssociationProperties | Where-Object { $_ -notin ('id', 'type') }) {
+                    ForEach ($AssociationProperty In $AssociationProperties | Where-Object { $_ -notin ('id', 'type', 'name') }) {
                         $AssociationHash.Add($AssociationProperty, $_.($AssociationProperty)) | Out-Null
+                        # if ($AssociationProperty -notin $AssociationHash.keys) {
+                        #     $AssociationHash.Add($AssociationProperty, $_.($AssociationProperty))
+                        # } else {
+                        #     Write-Debug "$AssociationProperty already in hash"
+                        # }
                     }
                 } Else {
                     Write-Error ('No object properties found for association record.')

--- a/PowerShell/JumpCloud Module/Public/Association/Get-JCAssociation.ps1
+++ b/PowerShell/JumpCloud Module/Public/Association/Get-JCAssociation.ps1
@@ -9,7 +9,9 @@ Function Get-JCAssociation {
         $RuntimeParameterDictionary = If ($Type) {
             Get-DynamicParamAssociation -Action:($Action) -Force:($Force) -Type:($Type)
         } Else {
+            Write-Debug "Type is not set in PARAM block"
             Get-DynamicParamAssociation -Action:($Action) -Force:($Force)
+            $isDynamicPAram = $true
         }
         Return $RuntimeParameterDictionary
     }
@@ -27,6 +29,17 @@ Function Get-JCAssociation {
         # Add input parameters from function in to hash table and filter out unnecessary parameters
         $PSBoundParameters.GetEnumerator() | Where-Object { -not [System.String]::IsNullOrEmpty($_.Value) } | ForEach-Object { $FunctionParameters.Add($_.Key, $_.Value) | Out-Null }
         # Add action
+        # Check if the type is a manual type or a dynamic type
+        if ($isDynamicPAram) {
+            Write-Debug "Type is not set in PARAM block"
+            # Set the type to the dynamic type in functionParameters
+            $getDynamicType = Get-JCType -Type $type
+            Write-Debug "Manual Type: $($getDynamicType.targets.targetsingular)"
+            $FunctionParameters['TargetType'] = $getDynamicType.targets.targetsingular
+        } else {
+            Write-Debug "Type is set in PARAM block: $Type"
+        }
+
         ($FunctionParameters).Add('Action', $Action) | Out-Null
         # Run the command
         $Results += Invoke-JCAssociation @FunctionParameters


### PR DESCRIPTION
## Issues
* [SA-3640](https://jumpcloud.atlassian.net/browse/SA-3640) - SA-3640-TargetTypeBugFix

## What does this solve?
This change fixes issue where a device associated to a command gives error due to duplicate keys in the hash. Another issue is when a dynamic parameter -type is set, it does not get the right targetType.
## Is there anything particularly tricky?
N/A
## How should this be tested?
1. First run these 2 commands before importing the fix module: `Get-JCAssociation -id YOURSYSTEM` and a system bound to a command `Get-JCAssociation -id YOURSYSTEM -type system`. Both commands should return an error
2. Import-module
3. Run same commands, validate the results should not have error


[SA-3640]: https://jumpcloud.atlassian.net/browse/SA-3640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ