### PR TITLE
Sa 3608 build pack nuspec

### DIFF
--- a/.github/workflows/build-pack-pwsh-ci.yml
+++ b/.github/workflows/build-pack-pwsh-ci.yml
@@ -49,12 +49,12 @@ jobs:
         with:
           name: jumpcloud-module-nupkg
       - shell: pwsh
-      run : |
-        # add nuget source:
-        dotnet nuget add source "https://www.powershellgallery.com/api/v2/package" --name PSGallery
-        # get nupkg artifact:
-        $nupkgPath = (Get-ChildItem -Path:("./*.nupkg")).FullName
-        # test
-        $nupkgPath | Should -Exist
-        Write-Host $nupkgPath
-        # nuget push from here:
+        run: |
+          # add nuget source:
+          dotnet nuget add source "https://www.powershellgallery.com/api/v2/package" --name PSGallery
+          # get nupkg artifact:
+          $nupkgPath = (Get-ChildItem -Path:("./*.nupkg")).FullName
+          # test
+          $nupkgPath | Should -Exist
+          Write-Host $nupkgPath
+          # nuget push from here:

--- a/.github/workflows/build-pack-pwsh-ci.yml
+++ b/.github/workflows/build-pack-pwsh-ci.yml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   Deploy-Nupkg:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v3

--- a/.github/workflows/build-pack-pwsh-ci.yml
+++ b/.github/workflows/build-pack-pwsh-ci.yml
@@ -1,0 +1,37 @@
+name: Build & Pack PoewrShell Module
+on: push
+
+jobs:
+  Deploy-Nupkg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: "/home/runner/.local/share/powershell/Modules/"
+          key: PS-Dependancies
+      - name: Build Nuspec
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          . "${{ github.workspace }}/PowerShell/Deploy/BuildNuspecFromPsd1.ps1" -RequiredModulesRepo PSGallery
+      - name: Add nuget sources
+        shell: pwsh
+        run: |
+          dotnet nuget add source "https://www.powershellgallery.com/api/v2/package" --name PSGallery
+      - name: Pack nuspec
+        shell: pwsh
+        run: |
+          nuget pack "${{ github.workspace }}/PowerShell/JumpCloud Module/JumpCloud.nuspec" -Properties NoWarn=NU5111,NU5110
+      - name: Validate NuPKG File
+        shell: pwsh
+        run: |
+          $NupkgPathDirectory = (Get-ChildItem -Path:("./*.nupkg")).Directory
+          $nupkgPath = (Get-ChildItem -Path:("./*.nupkg")).FullName
+          Write-Host "NuPkg Path: $nupkgPath"
+          mkdir $NupkgPathDirectory/nupkg_module
+          unzip $nupkgPath -d $NupkgPathDirectory/nupkg_module
+          $moduleRootFiles = Get-ChildItem -File -Path:("$NupkgPathDirectory/nupkg_module")
+          $moduleRootDirectories = Get-ChildItem -Directory -Path:("$NupkgPathDirectory/nupkg_module")
+          Write-Host "Module Files:\n$moduleRootFiles"
+          Write-Host "Module Directories:\n$moduleRootDirectories"

--- a/.github/workflows/build-pack-pwsh-ci.yml
+++ b/.github/workflows/build-pack-pwsh-ci.yml
@@ -14,6 +14,9 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
+          install-module JumpCloud.SDK.V1 -Force
+          install-module JumpCloud.SDK.V2 -Force
+          install-module JumpCloud.SDK.DirectoryInsights -Force
           . "${{ github.workspace }}/PowerShell/Deploy/BuildNuspecFromPsd1.ps1" -RequiredModulesRepo PSGallery
       - name: Add nuget sources
         shell: pwsh

--- a/.github/workflows/build-pack-pwsh-ci.yml
+++ b/.github/workflows/build-pack-pwsh-ci.yml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   Deploy-Nupkg:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v3
@@ -14,9 +14,6 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          install-module JumpCloud.SDK.V1 -Force
-          install-module JumpCloud.SDK.V2 -Force
-          install-module JumpCloud.SDK.DirectoryInsights -Force
           . "${{ github.workspace }}/PowerShell/Deploy/BuildNuspecFromPsd1.ps1" -RequiredModulesRepo PSGallery
       - name: Add nuget sources
         shell: pwsh
@@ -38,3 +35,5 @@ jobs:
           $moduleRootDirectories = Get-ChildItem -Directory -Path:("$NupkgPathDirectory/nupkg_module")
           Write-Host "Module Files:\n$moduleRootFiles"
           Write-Host "Module Directories:\n$moduleRootDirectories"
+          "Private" | should -bein $moduleRootDirectories.name
+          "Public" | should -bein $moduleRootDirectories.name

--- a/.github/workflows/build-pack-pwsh-ci.yml
+++ b/.github/workflows/build-pack-pwsh-ci.yml
@@ -15,10 +15,6 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           . "${{ github.workspace }}/PowerShell/Deploy/BuildNuspecFromPsd1.ps1" -RequiredModulesRepo PSGallery
-      - name: Add nuget sources
-        shell: pwsh
-        run: |
-          dotnet nuget add source "https://www.powershellgallery.com/api/v2/package" --name PSGallery
       - name: Pack nuspec
         shell: pwsh
         run: |
@@ -37,3 +33,28 @@ jobs:
           Write-Host "Module Directories:\n$moduleRootDirectories"
           "Private" | should -bein $moduleRootDirectories.name
           "Public" | should -bein $moduleRootDirectories.name
+      - name: Upload Nupkg
+        uses: actions/upload-artifact@v3
+        with:
+          name: jumpcloud-module-nupkg
+          path: /home/runner/work/support/support/JumpCloud.*.nupkg
+          retention-days: 1
+
+  Publish-Nupkg:
+    runs-on: ubuntu-latest
+    needs: Deploy-Nupkg
+    steps:
+      - name: download artifact and test
+        uses: actions/download-artifact@v3
+        with:
+          name: jumpcloud-module-nupkg
+      - shell: pwsh
+      run : |
+        # add nuget source:
+        dotnet nuget add source "https://www.powershellgallery.com/api/v2/package" --name PSGallery
+        # get nupkg artifact:
+        $nupkgPath = (Get-ChildItem -Path:("./*.nupkg")).FullName
+        # test
+        $nupkgPath | Should -Exist
+        Write-Host $nupkgPath
+        # nuget push from here:

--- a/PowerShell/Deploy/BuildNuspecFromPsd1.ps1
+++ b/PowerShell/Deploy/BuildNuspecFromPsd1.ps1
@@ -8,9 +8,9 @@ param (
 . "$PSScriptRoot/Get-Config.ps1"
 # $nuspecFiles = @{ src = 'en-Us/**;Private/**;Public/**;JumpCloud.psd1;JumpCloud.psm1;LICENSE'; }
 $nuspecFiles = @(
-    @{src = "en-Us/**/*.*"; target = "./" },
-    @{src = "Public/**/*.*"; target = "./" },
-    @{src = "Private/**/*.*"; target = "./" },
+    @{src = "en-Us/**/*.*"; target = "en-Us" },
+    @{src = "Public/**/*.*"; target = "Public" },
+    @{src = "Private/**/*.*"; target = "Private" },
     @{src = "JumpCloud.psd1" },
     @{src = "JumpCloud.psm1" },
     @{src = "LICENSE" }


### PR DESCRIPTION
## Issues
* [SA-3608](https://jumpcloud.atlassian.net/browse/SA-3608) - nuspec/ nupkg updates for GitHub Actions

## What does this solve?

Linux runners process the `BuildNuspecForPsd1.ps1` file ever so slightly different from Windows or macOS systems. When building a nuspec file in linux, the nuspec file contains a flattened set of functions. In other words functions that are split between `public` and `private` directories were flattened into their sub directories like `users` and `systems`.

Some public functions reference these private functions by relative paths and when the nupkg file contains flattened function directories, those functions were inaccessible.

This release addresses the issue of building the nuspec file specifically for the `ubuntu-latest` runners in Github Actions. There is a new job introduced to the release step that will validate that the "Public" and "Private" directory exist within the nupkg file. The newly create nupkg file is uploaded as an artifact.

This step occurs before the manual approval job. SAs should be able to validate the nupkg file is correct before approving. 

After manual approval, the nupkg artifact is downloaded, and published to PSGallery.

## Is there anything particularly tricky?

## How should this be tested?



## Screenshots
