### PR TITLE
fix env variable casing

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -168,7 +168,7 @@ jobs:
           $nupkgPath | Should -Exist
           Write-Host "Nupkg Artifact Restored: $nupkgPath"
           # nuget push from here:
-          dotnet nuget push $nupkgPath --source PSGallery --api-key $env:NUGETAPIKEY
+          dotnet nuget push $nupkgPath --source PSGallery --api-key $env:NuGetApiKey
         env:
           NuGetApiKey: ${{ secrets.NUGETAPIKEY }}
 


### PR DESCRIPTION
## Issues
* [SA-3608](https://jumpcloud.atlassian.net/browse/<jira-id>) - Set env variable casing for release nupkg step

## What does this solve?

Environment variables are case sensitive, this change reverts a change I made which inadvertently broke deployments.

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots


[SA-3608]: https://jumpcloud.atlassian.net/browse/SA-3608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ