### PR TITLE
Get-JCPolicyTargetGroup Index Error Bug Fix

### DIFF
--- a/PowerShell/JumpCloud Module/Public/Policies/PolicyTargets/Get-JCPolicyTargetGroup.ps1
+++ b/PowerShell/JumpCloud Module/Public/Policies/PolicyTargets/Get-JCPolicyTargetGroup.ps1
@@ -9,7 +9,7 @@ Function Get-JCPolicyTargetGroup {
 
         Write-Verbose 'Verifying JCAPI Key'
         If ($JCAPIKEY.length -ne 40) {
-            Connect-JCOnline 
+            Connect-JCOnline
         }
 
         Write-Verbose 'Populating API headers'
@@ -35,10 +35,10 @@ Function Get-JCPolicyTargetGroup {
     Process {
         switch ($PSCmdlet.ParameterSetName) {
             'ByName' {
-                $Policy = Get-JCPolicy -Name:($PolicyName) 
+                $Policy = Get-JCPolicy -Name:($PolicyName)
             }
             'ById' {
-                $Policy = Get-JCPolicy -PolicyID:($PolicyID) 
+                $Policy = Get-JCPolicy -PolicyID:($PolicyID)
             }
         }
         If ($Policy) {
@@ -47,8 +47,14 @@ Function Get-JCPolicyTargetGroup {
             $URL = $URL_Template -f $JCUrlBasePath, $PolicyID
             $Results = Invoke-JCApi -Method:('GET') -Paginate:($true) -Url:($URL)
             ForEach ($Result In $Results) {
-                $GroupID = $Result.id
-                $GroupName = $SystemGroupNameHash[$GroupID].name
+                # Try-catch block to handle the case where policy group is not assigned a a device group
+                Try {
+                    $GroupID = $Result.id
+                    $GroupName = $SystemGroupNameHash[$GroupID].name
+                } Catch {
+                    $GroupID = $null
+                    $GroupName = $null
+                }
                 $OutputObject = [PSCustomObject]@{
                     'PolicyID'   = $PolicyID
                     'PolicyName' = $PolicyName

--- a/PowerShell/ModuleChangelog.md
+++ b/PowerShell/ModuleChangelog.md
@@ -1,3 +1,17 @@
+## 2.8.2
+
+Release Date: November 1, 2023
+
+#### RELEASE NOTES
+
+```
+Addressed the issue with Get-JCPolicyTargetGroup indexing error
+```
+
+### BUG FIXES:
+
+- Fixed an issue with Get-JCPolicyTargetGroup index error when a policy group is not bound to a device group
+
 ## 2.8.1
 
 Release Date: October 19, 2023


### PR DESCRIPTION
## Issues
* [SA-3674](https://jumpcloud.atlassian.net/browse/SA-3674) -SA-3674-PolicyTargetGrouo-IndexError-Bug

## What does this solve?
Indexing error bug when policy group is not bound to a device group
## Is there anything particularly tricky?
n/a
## How should this be tested?
1.  Run: `Get-JCPolicy | Get-JCPolicyTargetGroup`  with the current module version, it should return errors.
2. Import this module
3. Validate that the bug is fixed
## Screenshots
![image](https://github.com/TheJumpCloud/support/assets/97972790/566f5a04-a0cf-480e-a9a0-5569e32a7051)
![image](https://github.com/TheJumpCloud/support/assets/97972790/7f7a4f22-1bca-42b2-83b4-af21ce80d0ae)


[SA-3674]: https://jumpcloud.atlassian.net/browse/SA-3674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ