### PR TITLE
SA-3724 Radius Certificate Utility - Match case-insensitive macOS usernames

### DIFF
--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,3 +1,19 @@
+## 1.0.7
+
+Release Date: December 1, 2023
+
+#### RELEASE NOTES
+
+```
+In macOS, it's possible for a user to define their username as `user1234` or `USER1234`. When JumpCloud takes of a user it'll perform a case insensive string comparison and take over the account that matches the username from JumpCloud.
+
+Commands executed by JumpCloud in macOS run as shell scripts `/bin/bash` by default, this shell does not perform case-insensitive string comparisons. This patch version of the Radius Certificate Utility addresses this limitation by explicitly changing the `bash` match patterns to be case-insensitive.
+```
+
+#### Bug Fixes:
+
+- Addressed a bug were users with differing casing (`user1234` vs `USER1234`) between the system and JumpCloud username
+
 ## 1.0.6
 
 Release Date: September 25, 2023

--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -37,7 +37,7 @@ $CertType = "UsernameCn"
 # Do not modify below
 ################################################################################
 
-$UserAgent_ModuleVersion = '1.0.6'
+$UserAgent_ModuleVersion = '1.0.7'
 $UserAgent_ModuleName = 'PasswordlessRadiusConfig'
 #Build the UserAgent string
 $UserAgent_ModuleName = "JumpCloud_$($UserAgent_ModuleName).PowerShellModule"

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -117,13 +117,13 @@ currentUserUID=`$(id -u "`$currentUser")
 currentCertSN="$($certHash.serial)"
 networkSsid="$($NETWORKSSID)"
 # store orig case match value
-orig_nocasematch=`$(shopt -p nocasematch; true)
-# set to case insenitive
+caseMatchOrigValue=`$(shopt -p nocasematch; true)
+# set to case-insensitive
 shopt -s nocasematch
 userCompare="$($user.localUsername)"
 if [[ "`$currentUser" ==  "`$userCompare" ]]; then
     # restore case match type
-    `$orig_nocasematch
+    `$caseMatchOrigValue
     certs=`$(security find-certificate -a -$($macCertSearch) "$($certIdentifier)" -Z /Users/$($user.localUsername)/Library/Keychains/login.keychain)
     regexSHA='SHA-1 hash: ([0-9A-F]{5,40})'
     regexSN='"snbr"<blob>=0x([0-9A-F]{5,40})'
@@ -221,7 +221,7 @@ if [[ "`$currentUser" ==  "`$userCompare" ]]; then
     fi
 else
     # restore case match type
-    `$orig_nocasematch
+    `$caseMatchOrigValue
     echo "Current logged in user, `$currentUser, does not match expected certificate user. Please ensure $($user.localUsername) is signed in and retry"
     # Finally clean up files
     if [[ -f "/tmp/$($user.userName)-client-signed.zip" ]]; then

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -116,7 +116,14 @@ currentUser=`$(/usr/bin/stat -f%Su /dev/console)
 currentUserUID=`$(id -u "`$currentUser")
 currentCertSN="$($certHash.serial)"
 networkSsid="$($NETWORKSSID)"
-if [[ `$currentUser ==  $($user.localUsername) ]]; then
+# store orig case match value
+orig_nocasematch=`$(shopt -p nocasematch; true)
+# set to case insenitive
+shopt -s nocasematch
+userCompare="$($user.localUsername)"
+if [[ "`$currentUser" ==  "`$userCompare" ]]; then
+    # restore case match type
+    `$orig_nocasematch
     certs=`$(security find-certificate -a -$($macCertSearch) "$($certIdentifier)" -Z /Users/$($user.localUsername)/Library/Keychains/login.keychain)
     regexSHA='SHA-1 hash: ([0-9A-F]{5,40})'
     regexSN='"snbr"<blob>=0x([0-9A-F]{5,40})'
@@ -213,6 +220,8 @@ if [[ `$currentUser ==  $($user.localUsername) ]]; then
         rm "/tmp/$($user.userName)-client-signed.pfx"
     fi
 else
+    # restore case match type
+    `$orig_nocasematch
     echo "Current logged in user, `$currentUser, does not match expected certificate user. Please ensure $($user.localUsername) is signed in and retry"
     # Finally clean up files
     if [[ -f "/tmp/$($user.userName)-client-signed.zip" ]]; then


### PR DESCRIPTION
## Issues
* [SA-3724](https://jumpcloud.atlassian.net/browse/SA-3724) - Radius Cert Util: Match case-insensitive macOS usernames

## What does this solve?

In macOS, it's possible for a user to define their username as `user1234` or `USER1234`. When JumpCloud takes of a user it'll perform a case insensive string comparison and take over the account that matches the username from JumpCloud.

Commands executed by JumpCloud in macOS run as shell scripts `/bin/bash` by default, this shell does not perform case-insensitive string comparisons. This patch version of the Radius Certificate Utility addresses this limitation by explicitly changing the `bash` match patterns to be case-insensitive.

## Is there anything particularly tricky?

N/A

## How should this be tested?

- On a macOS device, create a user, define the username "USER1234"
- Within JumpCloud, create a user, define the username "user1234"
- Assign the user to the device and perform user takeover; log out and back into that account, typing old/ new password
- After the user has been taken over, assign the user to your radius group, generate and distribute a certificate for that user using this branch of Radius Certificate Utility. 
- The certificate should install the certificate

## Screenshots

Example Error thrown on previous versions of the tool:
![Screenshot 2023-12-01 at 12 38 54 PM](https://github.com/TheJumpCloud/support/assets/54448601/0669167c-93b5-4715-a66e-2f9d6dd5282f)


[SA-3724]: https://jumpcloud.atlassian.net/browse/SA-3724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ