### PR TITLE
Build Module Helpfiles, Pestertestfiles, and Changelog versioning tool

### DIFF
--- a/PowerShell/Deploy/Build-Module.ps1
+++ b/PowerShell/Deploy/Build-Module.ps1
@@ -19,7 +19,7 @@ param (
     [Boolean]
     $ManualModuleVersion
 )
-. "$PSScriptRoot/Get-Config.ps1" -GitSourceBranch:($GitSourceBranch) -GitSourceRepo:($GitSourceRepo) -ReleaseType:($ReleaseType) -RequiredModulesRepo:($RequiredModulesRepo)
+. "$PSScriptRoot/Get-Config.ps1"
 # Region Checking PowerShell Gallery module version
 Write-Host ('[status]Check PowerShell Gallery for module version info')
 $PSGalleryInfo = Get-PSGalleryModuleVersion -Name:($ModuleName) -ReleaseType:($RELEASETYPE) #('Major', 'Minor', 'Patch')
@@ -34,6 +34,38 @@ if ($ManualModuleVersion) {
 }
 Write-Host ('[status]PowerShell Gallery Name:' + $PSGalleryInfo.Name + ';CurrentVersion:' + $PSGalleryInfo.Version + '; NextVersion:' + $ModuleVersion )
 # EndRegion Checking PowerShell Gallery module version
+
+## Get the module version from the psd1 file and changelog
+$VersionPsd1Regex = [regex]"(?<=ModuleVersion\s*=\s*')(([0-9]+)\.([0-9]+)\.([0-9]+))"
+$VersionMatchPsd1 = Select-String -Path:($FilePath_psd1) -Pattern:($VersionPsd1Regex)
+$PSD1Version = $VersionMatchPsd1.Matches.Value
+
+
+$FilePath_ModuleChangelog = Join-Path -Path $PSScriptRoot -ChildPath '..\ModuleChangelog.md'
+$ModuleChangelog = Get-Content -Path:($FilePath_ModuleChangelog)
+$ModuleChangelogVersionRegex = "([0-9]+)\.([0-9]+)\.([0-9]+)"
+$ModuleChangelogVersionMatch = ($ModuleChangelog | Select-Object -First 1) | Select-String -Pattern:($ModuleChangelogVersionRegex)
+$ModuleChangelogVersion = $ModuleChangelogVersionMatch.Matches.Value
+
+# Update ModuleChangelog.md File:
+If ($ModuleChangelogVersion -ne $PSD1Version) {
+    # add a new version section to the module ModuleChangelog.md
+    Write-Host "[Status]: Appending new changelog for version: $PSD1Version"
+    $NewModuleChangelogRecord = New-ModuleChangelog -LatestVersion:($PSD1Version) -ReleaseNotes:('{{Fill in the Release Notes}}') -Features:('{{Fill in the Features}}') -Improvements:('{{Fill in the Improvements}}') -BugFixes('{{Fill in the Bug Fixes}}')
+
+    ($NewModuleChangelogRecord + ($ModuleChangelog | Out-String)).Trim() | Set-Content -Path:($FilePath_ModuleChangelog) -Force
+} else {
+    # Get content between latest version and last
+    $ModuleChangelogContent = Get-Content -Path:($FilePath_ModuleChangelog) | Select -First 3
+    $ReleaseDateRegex = [regex]'(?<=Release Date:\s)(.*)'
+    $ReleaseDateRegexMatch = $ModuleChangelogContent | Select-String -Pattern $ReleaseDateRegex
+    $ReleaseDate = $ReleaseDateRegexMatch.Matches.Value
+    $todaysDate = $(Get-Date -UFormat:('%B %d, %Y'))
+    if (($ReleaseDate) -and ($ReleaseDate -ne $todaysDate)) {
+        write-host "[Status] Updating Changelog date: $ReleaseDate to: $todaysDate)"
+        $ModuleChangelog.Replace($ReleaseDate, $todaysDate) | Set-Content $FilePath_ModuleChangelog
+    }
+}
 # Region Building New-JCModuleManifest
 Write-Host ('[status]Building New-JCModuleManifest')
 New-JCModuleManifest -Path:($FilePath_psd1) `
@@ -49,3 +81,12 @@ If (!(($ModuleChangelog | Select-Object -First 1) -match $ModuleVersion)) {
     ($NewModuleChangelogRecord + ($ModuleChangelog | Out-String)).Trim() | Set-Content -Path:($FilePath_ModuleChangelog) -Force
 }
 # EndRegion Updating module change log
+
+Write-Host "Building help files" -ForegroundColor Green
+."$PSScriptRoot/Build-HelpFiles.ps1" -ModuleName "JumpCloud" -ModulePath "./PowerShell/JumpCloud Module"
+
+Write-Host "Building Pester test files" -ForegroundColor Green
+."$PSScriptRoot/Build-PesterTestFiles.ps1"
+
+Write-Host "Building module" -ForegroundColor Green
+."$PSScriptRoot/SdkSync/jcapiToSupportSync.ps1"

--- a/PowerShell/Deploy/Build-Module.ps1
+++ b/PowerShell/Deploy/Build-Module.ps1
@@ -1,5 +1,8 @@
 [CmdletBinding()]
 param (
+    # Validate Set for ReleaseType
+    [ValidateSet('Major', 'Minor', 'Patch')]
+    [Parameter(Mandatory = $true)]
     [String]
     $ReleaseType,
     [Parameter()]

--- a/PowerShell/Deploy/Build-Module.ps1
+++ b/PowerShell/Deploy/Build-Module.ps1
@@ -70,7 +70,7 @@ If (!(($ModuleChangelog | Select-Object -First 1) -match $ModuleVersion)) {
 # EndRegion Updating module change log
 
 Write-Host "Building help files" -ForegroundColor Green
-."$PSScriptRoot/Build-HelpFiles.ps1" -ModuleName "JumpCloud" -ModulePath "./PowerShell/JumpCloud Module"
+."$PSScriptRoot/Build-HelpFiles.ps1" -ModuleName "JumpCloud" -ModulePath (Get-Item -Path:($FilePath_psd1)).directory
 
 Write-Host "Building Pester test files" -ForegroundColor Green
 ."$PSScriptRoot/Build-PesterTestFiles.ps1"

--- a/PowerShell/Deploy/Build-Module.ps1
+++ b/PowerShell/Deploy/Build-Module.ps1
@@ -1,20 +1,7 @@
 [CmdletBinding()]
 param (
-    [Parameter()]
-    [String]
-    $GitSourceBranch,
-    [Parameter()]
-    [String]
-    $GitSourceRepo,
-    [Parameter()]
     [String]
     $ReleaseType,
-    [Parameter()]
-    [String]
-    $ModuleName,
-    [Parameter()]
-    [string]
-    $RequiredModulesRepo,
     [Parameter()]
     [Boolean]
     $ManualModuleVersion
@@ -22,7 +9,7 @@ param (
 . "$PSScriptRoot/Get-Config.ps1"
 # Region Checking PowerShell Gallery module version
 Write-Host ('[status]Check PowerShell Gallery for module version info')
-$PSGalleryInfo = Get-PSGalleryModuleVersion -Name:($ModuleName) -ReleaseType:($RELEASETYPE) #('Major', 'Minor', 'Patch')
+$PSGalleryInfo = Get-PSGalleryModuleVersion -Name:("JumpCloud") -ReleaseType:($RELEASETYPE) #('Major', 'Minor', 'Patch')
 # Check to see if ManualModuleVersion parameter is set to true
 if ($ManualModuleVersion) {
     $ManualModuleVersionRetrieval = Get-Content -Path:($FilePath_psd1) | Where-Object { $_ -like '*ModuleVersion*' }

--- a/PowerShell/Deploy/Build-PesterTestFiles.ps1
+++ b/PowerShell/Deploy/Build-PesterTestFiles.ps1
@@ -1,10 +1,3 @@
-[CmdletBinding()]
-param (
-    [Parameter()]
-    [string]
-    $RequiredModulesRepo
-)
-
 . "$PSScriptRoot/Get-Config.ps1"
 ################################################################################
 # This script creates a new test file for each function in the PowerShell Module

--- a/PowerShell/Deploy/SdkSync/jcapiToSupportSync.ps1
+++ b/PowerShell/Deploy/SdkSync/jcapiToSupportSync.ps1
@@ -1,9 +1,3 @@
-[CmdletBinding()]
-param (
-    [Parameter()]
-    [string]
-    $RequiredModulesRepo
-)
 . "$PSScriptRoot/../Get-Config.ps1"
 ###########################################################################
 $ApprovedFunctions = [Ordered]@{


### PR DESCRIPTION
## Issues
* [SA-3705-Build-Module-Function](https://jumpcloud.atlassian.net/browse/SA-3705) - SA-3705-Build-Module-Function

## What does this solve?
This tool fixes the issue with the change from CircleCI to GHA migration where we are unable to write back our automations with building module, help and test files, and changelog edits. This process is now done locally with this change.
## Is there anything particularly tricky?
N/A
## How should this be tested?
1. Run `."PowerShell/Deploy/Build-Module.ps1" -releasetype major `  

- Test out different release type
2. Validate changelog changes

- Change current version date to different date
- Rerun Build-Module
- Validate that the date is today's date 
3. Validate JumpCloud.psd1 changes (date, version)
