### PR TITLE
SA-3732: Certificate Filter/ Similar Usernames

### DIFF
--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,3 +1,17 @@
+## 1.1.0
+
+Release Date: December 13, 2023
+
+#### RELEASE NOTES
+
+```
+Fixed an issue where similar usernames were having incorrect certificates deployed
+```
+
+#### Bug Fixes:
+
+- Addressed a bug where similar usernames were having incorrect certificates deployed. Ex: john.smith and john
+
 ## 1.0.7
 
 Release Date: December 1, 2023

--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -37,7 +37,7 @@ $CertType = "UsernameCn"
 # Do not modify below
 ################################################################################
 
-$UserAgent_ModuleVersion = '1.0.7'
+$UserAgent_ModuleVersion = '1.1.0'
 $UserAgent_ModuleName = 'PasswordlessRadiusConfig'
 #Build the UserAgent string
 $UserAgent_ModuleName = "JumpCloud_$($UserAgent_ModuleName).PowerShellModule"

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -52,7 +52,7 @@ if ($RadiusCertCommands.Count -ge 1) {
 # Create commands for each user
 foreach ($user in $userArray) {
     # Get certificate and zip to upload to Commands
-    $userCertFiles = Get-ChildItem -Path "$JCScriptRoot/UserCerts" -Filter "$($user.userName)*"
+    $userCertFiles = Get-ChildItem -Path "$JCScriptRoot/UserCerts" -Filter "$($user.userName)-*"
     # set crt and pfx filepaths
     $userCrt = ($userCertFiles | Where-Object { $_.Name -match "crt" }).FullName
     $userPfx = ($userCertFiles | Where-Object { $_.Name -match "pfx" }).FullName


### PR DESCRIPTION
## Issues
* [SA-3732](https://jumpcloud.atlassian.net/browse/SA-3732) - Certificate Filter/ Similar Usernames

## What does this solve?
https://github.com/TheJumpCloud/support/issues/550

## Is there anything particularly tricky?
N/A

## How should this be tested?

1. Have 2 users (john and john.smith)
2. Deploy certs to both users
3. Ensure that the command for each user only has their respective cert


[SA-3732]: https://jumpcloud.atlassian.net/browse/SA-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ