### PR TITLE
codeowners & gitpython version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,8 @@
 
 # PowerShell Module
 
-/PowerShell/ @TheJumpCloud/jc-sa
+/PowerShell/ @TheJumpCloud/customer-tools
 
 # Scripts
 
-/scripts/ @TheJumpCloud/jc-sa
+/scripts/ @TheJumpCloud/customer-tools

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -4,7 +4,7 @@ charset-normalizer==3.3.0
 docopt==0.6.2
 exceptiongroup==1.1.3
 gitdb==4.0.10
-GitPython==3.1.37
+GitPython==3.1.41
 idna==3.4
 iniconfig==2.0.0
 packaging==23.2


### PR DESCRIPTION
## Issues
* [CUT-3812](https://jumpcloud.atlassian.net/browse/CUT-3812) - GitPython Verison 

## What does this solve?

[Addresses Dependabot warning on gitpython verison](https://github.com/TheJumpCloud/support/security/dependabot/3)
Update CodeOwners file

## Is there anything particularly tricky?

## How should this be tested?

Install requirements 
`pip3 install -r requirements.txt`

Run `python3 ./build_commands_gallery.py`

The script should update `commands.json` when a change is detected in commands gallery scripts

## Screenshots


[CUT-3812]: https://jumpcloud.atlassian.net/browse/CUT-3812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ