### PR TITLE
Cert Generation Tests + SN in Commands

### DIFF
--- a/scripts/automation/Radius/Config.ps1
+++ b/scripts/automation/Radius/Config.ps1
@@ -12,7 +12,7 @@ $Global:JCR_USER_CERT_EXPIRE_WARNING_DAYS = 15
 # For Multiple SSIDs enter as a single string separated by a semicolon  ex:
 # "CorpNetwork_Denver;CorpNetwork_Boulder;CorpNetwork_Boulder 5G;Guest Network"
 $Global:JCR_NETWORKSSID = "YOUR_SSID"
-# OpenSSLBinary by default this is (openssl)
+# JCR_OPENSSL by default this is (openssl)
 # NOTE: If openssl does not work, try using the full path to the openssl file
 # MacOS HomeBrew Example: '/usr/local/Cellar/openssl@3/3.1.1/bin/openssl'
 $Global:JCR_OPENSSL = 'openssl'

--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
@@ -79,7 +79,7 @@ function Deploy-UserCertificate {
                 'EmailDN' {
                     # Else set cert identifier to email of cert subject
                     $regex = 'emailAddress = (.*?)$'
-                    $JCR_SUBJECT_HEADERSMatch = Select-String -InputObject "$($certHash.Subject)" -Pattern $regex
+                    $JCR_SUBJECT_HEADERSMatch = Select-String -InputObject "$($certInfo.Subject)" -Pattern $regex
                     $certIdentifier = $JCR_SUBJECT_HEADERSMatch.matches.Groups[1].value
                     # in macOS search user certs by email
                     $macCertSearch = 'e'
@@ -117,7 +117,7 @@ unzip -o /tmp/$($user.userName)-client-signed.zip -d /tmp
 chmod 755 /tmp/$($user.userName)-client-signed.pfx
 currentUser=`$(/usr/bin/stat -f%Su /dev/console)
 currentUserUID=`$(id -u "`$currentUser")
-currentCertSN="$($certHash.serial)"
+currentCertSN="$($certInfo.serial)"
 networkSsid="$($JCR_NETWORKSSID)"
 # store orig case match value
 caseMatchOrigValue=`$(shopt -p nocasematch; true)
@@ -329,7 +329,7 @@ if (`$CurrentUser -eq "$($user.localUsername)") {
 
         foreach (`$cert in `$certs){
             if (`$cert.subject -match "$($certIdentifier)") {
-                if (`$(`$cert.serialNumber) -eq "$($certHash.serial)"){
+                if (`$(`$cert.serialNumber) -eq "$($certInfo.serial)"){
                     write-host "Found Cert:``nCert SN: `$(`$cert.serialNumber)"
                 } else {
                     write-host "Removing Cert:``nCert SN: `$(`$cert.serialNumber)"

--- a/scripts/automation/Radius/Functions/Private/CertGeneration/Invoke-UserCertProcess.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertGeneration/Invoke-UserCertProcess.ps1
@@ -81,6 +81,16 @@ Function Invoke-UserCertProcess {
             Generate-UserCert -CertType $JCR_CERT_TYPE -user $MatchedUser -rootCAKey "$JCScriptRoot/Cert/radius_ca_key.pem" -rootCA "$JCScriptRoot/Cert/radius_ca_cert.pem" *> /dev/null
             # validate that the cert was written correctly:
             #TODO: validate and return as variable
+
+            #TODO: cert should be written with $JCR_CERT_TYPE, if other certs exist, remove them.
+            $CertInfo = Get-CertInfo -UserCerts -username $MatchedUser.username
+            if ($CertInfo.count -gt 1) {
+                $foundCerts = Get-ChildItem -path "$JCScriptRoot/UserCerts/$($MatchedUser.username)-*.crt"
+                $orderedCerts = $founDcerts | Sort-Object -Property LastWriteTime -Descending | select -Skip 1
+                foreach ($cert in $orderedCerts) {
+                    Remove-Item $cert.FullName
+                }
+            }
         }
 
         # generate the cert depending if -force or if new


### PR DESCRIPTION
## Issues
* [SA-3832](https://jumpcloud.atlassian.net/browse/SA-3832) - Cert Generation SN in Commands

## What does this solve?

Changes in #553  modified the command generation process. The Serial Number variable was no longer being passed into the generated command and, certificate installations would fail on devices. This addresses the issue by passing in the serial number when generating commands.

Additional tests were written to:
- Validate a certificate serial number is correctly passed into generated macOS/ Windows commands
- When changing certificate generation types
- - The subject headers of the certificate are correct
- - Any old .crt file is deleted for a user. i.e. users should not have more than one .crt file at any given time if the certificate generation type is changed from `usernameCN` to `emailSAN` 

## Is there anything particularly tricky?

## How should this be tested?

No manual tests required, the functionally of the PR should be tested automatically with pester tests.

## Screenshots
