### PR TITLE
Readme and contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to the JumpCloud Support Repository
+
+Thank you for taking the time to contribute to open source software and JumpCloud.
+
+This repository contains the following products:
+
+- [JumpCloud PowerShell Module](./PowerShell/JumpCloud%20Module/)
+- [JumpCloud Command Templates](./PowerShell/JumpCloud%20Commands%20Gallery/)
+- Various scripts and example solutions within the [scripts](./scripts/) directory
+
+## Contributing
+
+### PowerShell Module
+
+Contributions to the JumpCloud PowerShell Module will be considered and reviewed by a member of the Customer Tools team.
+
+New versions of the PowerShell Module requires a semantic version change within the [module manifest file](./PowerShell/JumpCloud%20Module/JumpCloud.psd1) and the [changelog](./PowerShell/ModuleChangelog.md) to be updated.
+
+Pull requests should be labeled with a semantic version type: `major`, `minor` or `patch` along with `PowerShell Module`.
+
+### Commands Gallery
+
+Pull Requests with changes, additions and removed commands to the `Powershell/JumpCloud Commands Gallery` directory should be submitted and labeled with the `Commands Gallery` label
+
+### Other Changes
+
+Other pull requests outside of the JumpCloud PowerShell Module and Commands Gallery scripts may be submitted

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # support
 
-The purpose of this support repo is to provide helpful scripts that complement various JumpCloud services including API examples.  
+The purpose of this support repo is to provide helpful scripts that complement various JumpCloud services including API examples.
 
-* Feel free to submit PRs
-* Your API Key, keep it secret, keep it safe
-* Use example scripts at your own risk, this repo is maintained mainly by support staff and does not go through the normal Dev/QA process
+- Feel free to submit PRs, please see [CONTRIBUTING](./CONTRIBUTING.md) for more information
+- Your API Key, keep it secret, keep it safe
+- Use example scripts at your own risk, this repo is maintained mainly by support staff and does not go through the normal Dev/QA process
 
 Some scripts use the deprecated (and out-of-date) JCAPI. In many cases, these scripts fail when running against multi-tenant user data.
-Since most (if not all) functionality is available elsewhere (e.g., in powershell scripts), these scripts will not be officially adjusted.
-
+Since most (if not all) functionality is available elsewhere (e.g., in PowerShell scripts), these scripts will not be officially adjusted.


### PR DESCRIPTION
## Issues
* [CUT-3894](https://jumpcloud.atlassian.net/browse/CUT-3894) - Contributing documentation

## What does this solve?

Document required labels for `Command Gallery` and `JumpCloud PowerShell Module` pull requests.
Adds Contributing file for future documentation.

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots


[CUT-3894]: https://jumpcloud.atlassian.net/browse/CUT-3894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ