### PR TITLE
CUT-2922: Bulk User Private Functions

### DIFF
--- a/PowerShell/JumpCloud Module/Private/BulkUser/Split-JcBulkUserJob.ps1
+++ b/PowerShell/JumpCloud Module/Private/BulkUser/Split-JcBulkUserJob.ps1
@@ -1,0 +1,37 @@
+function Split-JcBulkUserJob {
+    [CmdletBinding()]
+    param (
+        [Parameter(Position = 0, Mandatory = $true)][ValidateNotNullOrEmpty()][PSObject[]]$userArray
+    )
+    begin {
+        # Amount to split into separate arrays (800 user objects)
+        $count = 800
+
+        # New list to hold new split arrays
+        $aggregateList = @()
+    }
+    process {
+        # Find how many split blocks
+        $splitBlocks = [Math]::Floor($userArray.Count / $count)
+
+        # Determine how many items are leftover
+        $leftOver = $userArray.Count % $count
+
+        # Iterate through splitBlocks and add newly formed arrays to the aggregateList
+        for ($i = 0; $i -lt $splitBlocks; $i++) {
+            $end = $count * ($i + 1) - 1
+
+            $aggregateList += @(, $userArray[$start..$end])
+            $start = $end + 1
+        }
+
+        # Add any remaining leftover items to a final array
+        if ($leftOver -gt 0) {
+            $aggregateList += @(, $userArray[$start..($end + $leftOver)])
+        }
+    }
+    end {
+        # Return the aggregateList of arrays
+        return $aggregateList
+    }
+}

--- a/PowerShell/JumpCloud Module/Private/BulkUser/Wait-JcBulkUserJob.ps1
+++ b/PowerShell/JumpCloud Module/Private/BulkUser/Wait-JcBulkUserJob.ps1
@@ -1,0 +1,47 @@
+function Wait-JcBulkUserJob {
+    [CmdletBinding()]
+    param (
+        [Parameter(Position = 0, Mandatory = $true)][ValidateNotNullOrEmpty()][string[]]$jobIds
+    )
+    begin {
+        $finishedJobs = [System.Collections.Generic.List[PSObject]]::new()
+        $unfinishedJobs = [System.Collections.Generic.List[PSObject]]::new()
+    }
+    process {
+        # Initial JobStatus check
+        $JobIds | ForEach-Object {
+            $bulkJobResult = Get-JcSdkBulkUsersResult -JobId $_
+
+            # If job is finished, add to finished list, otherwise add to unfinished list
+            If ($bulkJobResult.Status -eq 'finished') {
+                $finishedJobs.Add($bulkJobResult)
+            } else {
+                $unfinishedJobs.Add($bulkJobResult)
+            }
+        }
+
+        # Continuously iterate through the unfinishedJob list to check status until unfinishedJob list is empty
+        do {
+            $unfinishedJobs | ForEach-Object {
+                $bulkJobResult = Get-JcSdkBulkUsersResult -JobId $_.Id
+
+                If ($bulkJobResult.Status -eq 'finished') {
+                    # Add the finished job to the finished array
+                    $finishedJobs.Add($bulkJobResult)
+                    Write-Debug "$($_.Id) is finished"
+
+                    # Remove the finished job from the unfinished array
+                    $unfinishedJobs.Remove($bulkJobResult)
+                    Write-Debug "Removing $($_.Id) from unfinished list"
+                } else {
+                    # If the job isn't finished, sleep 5 seconds.
+                    Write-Debug "$($_.Id) is not finished... sleeping 5 seconds..."
+                    Start-Sleep -Seconds 5
+                }
+            }
+        } while ($unfinishedJobs.Count -gt 0)
+    }
+    end {
+        return $finishedJobs
+    }
+}


### PR DESCRIPTION
## Issues
* [CUT-2922:](https://jumpcloud.atlassian.net/browse/CUT-2922:) - Bulk User Private Functions

## What does this solve?

Adds the following private functions for the use in BulkUser operations:
- `Split-JcBulkUserJob`
- `Wait-JcBulkUserJob`

### Split-JcBulkUserJob
**Synopsis**: This function's purpose is to accept a list or user objects and then based on the amount of user object's split the original list into several smaller lists that will allow for job batching

**Example**:
Given a group of 2000 user objects, the function will split the original 2000 object array into 3 separate arrays. The first two indexes will contain 800 users as per the API restriction, and finally the last index will contain the remainder of 400

```powershell
$updateUsers = 1..2000
Split-JcBulkUserJob -userArray $updateUsers
```
### Wait-JcBulkUserJob
**Synopsis**: This function's purpose is to accept an array of jobIDs and to check to validate that all the jobs are in a finished state. It achieves this by initially iterating through the list of jobIDs to check the status and adding them to either the finished or unfinished array. From there, a do-while loop operates to iterate through the unfinished list constantly checking the status. If a job's status changes to finished, it will be removed from the unfinished array and added to the finished. Once the unfinished list no longer contains anything, the do-while loop will end and the finished array will be returned.

**Example**:
Given a list of 5 jobs, the function will check each one for it's status. Once the statuses are finished, it will return the job results in an array

```powershell
Wait-JcBulkUserJob -jobIds $updateJobIds
```
## Is there anything particularly tricky?
It's difficult to test the Wait-JcBulkUserJob function at scale due to not having the main functions completed. We can create fake JobResult objects using `[JumpCloud.SDK.V2.Models.Jobworkresult]::new() `

## How should this be tested?
Wait-JcBulkUserJob - Create a bunch of fake JobResult Objects with arbitrary values and inject them into function directly
Split-JcBulkUserJob - Create an array with an arbitrary count, and pass it into the function. The function will split the array based on the count.