### PR TITLE
replace git.io links in command gallery

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Generic DMG Installer.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Generic DMG Installer.md
@@ -210,5 +210,5 @@ Deleted /tmp/Download-2019-01-23-10-28-49
 To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
 
 ```
-Import-JCCommand -URL 'https://git.io/fhF4l'
+Import-JCCommand -URL 'https://github.com/TheJumpCloud/support/blob/master/PowerShell/JumpCloud%20Commands%20Gallery/Mac%20Commands/Application%20Installs/Mac%20-%20Generic%20DMG%20Installer.md'
 ```

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Install FireFox DMG.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Install FireFox DMG.md
@@ -191,7 +191,7 @@ Searching headers for download links
 Download link found
 Downloaded Firefox%2065.0.dmg to /tmp/Download-2019-01-23-10-28-59
 DMG File Found: Firefox%2065.0.dmg
-Used hdiutil to mount Firefox%2065.0.dmg 
+Used hdiutil to mount Firefox%2065.0.dmg
 Located DMG Volume: /Volumes/Firefox
 Located DMG Mount Point: /dev/disk3s3
 Located App: Firefox.app
@@ -208,5 +208,5 @@ Deleted /tmp/Download-2019-01-23-10-28-59
 To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
 
 ```
-Import-JCCommand -URL 'https://git.io/fhQD5'
+Import-JCCommand -URL 'https://github.com/TheJumpCloud/support/blob/master/PowerShell/JumpCloud%20Commands%20Gallery/Mac%20Commands/Application%20Installs/Mac%20-%20Install%20FireFox%20DMG.md'
 ```

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Install Microsoft Office.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Install Microsoft Office.md
@@ -125,5 +125,5 @@ This is a community written command from [joffems](https://github.com/joffems) t
 To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
 
 ```
-Import-JCCommand -URL 'https://git.io/JJ6Vk'
+Import-JCCommand -URL 'https://github.com/TheJumpCloud/support/blob/master/PowerShell/JumpCloud%20Commands%20Gallery/Mac%20Commands/Application%20Installs/Mac%20-%20Install%20Microsoft%20Office.md'
 ```

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Install Slack DMG.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Install Slack DMG.md
@@ -191,7 +191,7 @@ Searching headers for download links
 Download link found
 Downloaded Slack-3.3.7.dmg to /tmp/Download-2019-01-23-10-28-49
 DMG File Found: Slack-3.3.7.dmg
-Used hdiutil to mount Slack-3.3.7.dmg 
+Used hdiutil to mount Slack-3.3.7.dmg
 Located DMG Volume: /Volumes/Slack.app
 Located DMG Mount Point: /dev/disk2s1
 Located App: Slack.app
@@ -208,5 +208,5 @@ Deleted /tmp/Download-2019-01-23-10-28-49
 To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
 
 ```
-Import-JCCommand -URL 'https://git.io/fhQDd'
+Import-JCCommand -URL 'https://github.com/TheJumpCloud/support/blob/master/PowerShell/JumpCloud%20Commands%20Gallery/Mac%20Commands/Application%20Installs/Mac%20-%20Install%20Slack%20DMG.md'
 ```

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/LaunchDaemons/Mac - List All Launch Daemons.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/LaunchDaemons/Mac - List All Launch Daemons.md
@@ -22,5 +22,5 @@ Shows all the running /System daemons. Daemons scheduled via JumpCloud commands 
 To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
 
 ```
-Import-JCCommand -URL 'https://git.io/fhSkF'
+Import-JCCommand -URL 'https://github.com/TheJumpCloud/support/blob/master/PowerShell/JumpCloud%20Commands%20Gallery/Mac%20Commands/LaunchDaemons/Mac%20-%20List%20All%20Launch%20Daemons.md'
 ```

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/LaunchDaemons/Mac - Remove Daily System Restart Daemon.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/LaunchDaemons/Mac - Remove Daily System Restart Daemon.md
@@ -24,12 +24,12 @@ rm jumpcloud.reboot.plist
 
 #### Description
 
-Removes the launch daemon `jumpcloud.reboot.plist` created by the command [Mac - Schedule Daily System Restart Daemon](https://git.io/fhSkx)
+Removes the launch daemon `jumpcloud.reboot.plist` created by the command [Mac - Schedule Daily System Restart Daemon](https://github.com/TheJumpCloud/support/blob/master/PowerShell/JumpCloud%20Commands%20Gallery/Mac%20Commands/LaunchDaemons/Mac%20-%20Schedule%20Daily%20System%20Restart%20Daemon.md)
 
 #### *Import This Command*
 
 To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
 
 ```
-Import-JCCommand -URL 'https://git.io/fhSkA'
+Import-JCCommand -URL 'https://github.com/TheJumpCloud/support/blob/master/PowerShell/JumpCloud%20Commands%20Gallery/Mac%20Commands/LaunchDaemons/Mac%20-%20Remove%20Daily%20System%20Restart%20Daemon.md'
 ```

--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/LaunchDaemons/Mac - Schedule Daily System Restart Daemon.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/LaunchDaemons/Mac - Schedule Daily System Restart Daemon.md
@@ -59,7 +59,7 @@ launchctl load -w "/Library/LaunchDaemons/jumpcloud.reboot.plist"
 
 #### Description
 
-Uses a [launch daemon](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html) to schedule a forced daily system restart for a given time specified in the hour='' and minute='' variables. The daemon will be listed as JumpCloud.system.reboot.at.'${hour}':'${minute}' within the launch daemon list. Use the command [Mac - List All Launch Daemons.md](https://git.io/fhSkF) to see a list of all launch daemons.
+Uses a [launch daemon](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html) to schedule a forced daily system restart for a given time specified in the hour='' and minute='' variables. The daemon will be listed as JumpCloud.system.reboot.at.'${hour}':'${minute}' within the launch daemon list. Use the command [Mac - List All Launch Daemons.md](https://github.com/TheJumpCloud/support/blob/master/PowerShell/JumpCloud%20Commands%20Gallery/Mac%20Commands/LaunchDaemons/Mac%20-%20List%20All%20Launch%20Daemons.md) to see a list of all launch daemons.
 
 This .plist file can be modifyed to run using differnt time based parameters (day of week, specific month). Find more information on this [here](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/ScheduledJobs.html#//apple_ref/doc/uid/10000172i-CH1-SW1).
 
@@ -68,5 +68,5 @@ This .plist file can be modifyed to run using differnt time based parameters (da
 To import this command into your JumpCloud tenant run the below command using the [JumpCloud PowerShell Module](https://github.com/TheJumpCloud/support/wiki/Installing-the-JumpCloud-PowerShell-Module)
 
 ```
-Import-JCCommand -URL 'https://git.io/fhSkx'
+Import-JCCommand -URL 'https://github.com/TheJumpCloud/support/blob/master/PowerShell/JumpCloud%20Commands%20Gallery/Mac%20Commands/LaunchDaemons/Mac%20-%20Schedule%20Daily%20System%20Restart%20Daemon.md'
 ```


### PR DESCRIPTION
## Issues
* [CUT-3969](https://jumpcloud.atlassian.net/browse/CUT-3969) - Replace Git.IO links

## What does this solve?

`Import-JCCommand` will no longer import git.io links, these remaining commands needed to have their url updated to the full path before these commands could be imported using `Import-JCCommand`

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots


[CUT-3969]: https://jumpcloud.atlassian.net/browse/CUT-3969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ