### PR TITLE
CUT-4112: Userstate Lookups

### DIFF
--- a/PowerShell/JumpCloud Module/Public/Users/Get-JCScheduledUserstate.ps1
+++ b/PowerShell/JumpCloud Module/Public/Users/Get-JCScheduledUserstate.ps1
@@ -1,0 +1,87 @@
+Function Get-JCScheduledUserstate () {
+    [CmdletBinding(DefaultParameterSetName = 'BulkLookup')]
+    param (
+        [Parameter(Mandatory, ParameterSetName = 'BulkLookup', ValueFromPipelineByPropertyName = $True, HelpMessage = "The scheduled state you'd like to query (SUSPENDED or ACTIVATED)")]
+        [ValidateSet('SUSPENDED', 'ACTIVATED')]
+        [string]$State,
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, ParameterSetName = 'ByID', HelpMessage = 'The _id of the User which you want to lookup. UserID has an Alias of _id.')]
+        [Alias('_id', 'id')]
+        [String]$UserId
+    )
+    begin {
+        Write-Verbose 'Verifying JCAPI Key'
+        if ($JCAPIKEY.length -ne 40) {
+            Connect-JCOnline
+        }
+
+        Write-Verbose 'Initilizing resultsArray'
+        $resultsArrayList = New-Object -TypeName System.Collections.ArrayList
+
+        Write-Verbose "Parameter Set: $($PSCmdlet.ParameterSetName)"
+    }
+    process {
+        switch ($PSCmdlet.ParameterSetName) {
+            BulkLookup {
+                if ($state -eq 'SUSPENDED') {
+                    $scheduledUsers = Get-JcSdkBulkUserState | Where-Object State -EQ 'SUSPENDED'
+                } else {
+                    $scheduledUsers = Get-JcSdkBulkUserState | Where-Object State -EQ 'ACTIVATED'
+                }
+
+                # Create SearchBody to parse users
+                $searchUserBody = @{
+                    filter = @{
+                        or = @(
+                        )
+                    }
+                    fields = "firstname lastname email username _id"
+                }
+
+                # Create OR lookup for IDs
+                $scheduledUsers | ForEach-Object {
+                    $searchUserBody.filter.or += "_id:`$eq:$($_.SystemUserId)"
+                }
+
+                # Get users
+                $searchUsers = Search-JcSdkUser -Body $searchUserBody
+                $searchUsers | ForEach-Object {
+                    # Get the scheduled date for the user
+                    $user = $scheduledUsers | Where-Object SystemUserID -EQ $_.Id
+                    # Convert the scheduled date to datetime (also seems to convert to local as well)
+                    $localScheduledDate = [datetime]$user.ScheduledDate
+                    # Create userResult
+                    $userResult = [pscustomobject]@{
+                        id            = $_.Id
+                        Firstname     = $_.Firstname
+                        Lastname      = $_.Lastname
+                        Email         = $_.email
+                        Username      = $_.username
+                        ScheduledDate = $localScheduledDate
+                    }
+                    $resultsArrayList.Add($userResult) | Out-Null
+                }
+            }
+            ByID {
+                # Get User's scheduled state
+                $scheduledUser = Get-JcSdkBulkUserState -Userid $userId
+                # User attribute lookup
+                $user = Get-JcSdkUser -Id $userId | Select-Object firstname, lastname, email, username, id
+                # Convert date to local
+                $localScheduledDate = [datetime]$scheduledUser.ScheduledDate
+                # Create custom return object
+                $userResult = [pscustomobject]@{
+                    id            = $user.Id
+                    Firstname     = $user.Firstname
+                    Lastname      = $user.Lastname
+                    Email         = $user.email
+                    Username      = $user.username
+                    ScheduledDate = $LocalScheduledDate
+                }
+                $resultsArrayList.Add($userResult) | Out-Null
+            }
+        }
+    }
+    end {
+        return $resultsArrayList
+    }
+}

--- a/PowerShell/JumpCloud Module/Public/Users/Get-JCScheduledUserstate.ps1
+++ b/PowerShell/JumpCloud Module/Public/Users/Get-JCScheduledUserstate.ps1
@@ -56,6 +56,7 @@ Function Get-JCScheduledUserstate () {
                         Lastname      = $_.Lastname
                         Email         = $_.email
                         Username      = $_.username
+                        State         = $State
                         ScheduledDate = $localScheduledDate
                     }
                     $resultsArrayList.Add($userResult) | Out-Null
@@ -66,18 +67,22 @@ Function Get-JCScheduledUserstate () {
                 $scheduledUser = Get-JcSdkBulkUserState -Userid $userId
                 # User attribute lookup
                 $user = Get-JcSdkUser -Id $userId | Select-Object firstname, lastname, email, username, id
-                # Convert date to local
-                $localScheduledDate = [datetime]$scheduledUser.ScheduledDate
-                # Create custom return object
-                $userResult = [pscustomobject]@{
-                    id            = $user.Id
-                    Firstname     = $user.Firstname
-                    Lastname      = $user.Lastname
-                    Email         = $user.email
-                    Username      = $user.username
-                    ScheduledDate = $LocalScheduledDate
+
+                $scheduledUser | ForEach-Object {
+                    # Convert date to local
+                    $localScheduledDate = [datetime]$_.ScheduledDate
+                    # Create custom return object
+                    $userResult = [pscustomobject]@{
+                        id            = $user.Id
+                        Firstname     = $user.Firstname
+                        Lastname      = $user.Lastname
+                        Email         = $user.email
+                        Username      = $user.username
+                        State         = $_.State
+                        ScheduledDate = $LocalScheduledDate
+                    }
+                    $resultsArrayList.Add($userResult) | Out-Null
                 }
-                $resultsArrayList.Add($userResult) | Out-Null
             }
         }
     }

--- a/PowerShell/JumpCloud Module/Tests/Public/Users/Get-JCScheduledUserstate.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Users/Get-JCScheduledUserstate.ps1
@@ -1,0 +1,48 @@
+Describe -Tag:('JCScheduledUserstate') 'Get-JCScheduledUserstate' {
+    BeforeAll {
+        # Create a few users to test suspension and activation
+        $NewStateUser1 = New-RandomUser -domain "delNewUser.$(New-RandomString -NumberOfChars 5)" | New-JCUser
+        $NewStateUser2 = New-RandomUser -domain "delNewUser.$(New-RandomString -NumberOfChars 5)" | New-JCUser
+        $NewStateUser3 = New-RandomUser -domain "delNewUser.$(New-RandomString -NumberOfChars 5)" | New-JCUser -state "SUSPENDED"
+
+        $ScheduledSuspension = New-JcSdkBulkUserState -UserIds "$($NewStateUser1.Id), $($NewStateUser2.Id)" -State 'SUSPENDED' -StartDate (Get-Date -Hour 12 -Minute 0 -Second 0).AddDays(1)
+        $ScheduledActivation = New-JcSdkBulkUserState -UserIds $NewStateUser3.Id -State 'ACTIVATED' -StartDate (Get-Date -Hour 12 -Minute 0 -Second 0).AddDays(1)
+    }
+    It "Gets scheduled SUSPENDED users" {
+        $scheduledUsers = Get-JcScheduledSuspension -State "SUSPENDED"
+        $scheduledUsers.count | Should -Be 2
+
+        $scheduledUsers.id | Should -Not -BeNullOrEmpty
+        $scheuldedUsers.Firstname | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Lastname | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Email | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Username | Should -Not -BeNullOrEmpty
+        $scheuldedUsers.ScheduledDate | Should -Be (Get-Date -Hour 12 -Minute 0 -Second 0).AddDays(1)
+    }
+    It "Gets scheduled ACTIVATED users" {
+        $scheduledUsers = Get-JcScheduledSuspension -State "ACTIVATED"
+        $scheduledUsers.count | Should -Be 1
+
+        $scheduledUsers.id | Should -Not -BeNullOrEmpty
+        $scheuldedUsers.Firstname | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Lastname | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Email | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Username | Should -Not -BeNullOrEmpty
+        $scheuldedUsers.ScheduledDate | Should -Be (Get-Date -Hour 12 -Minute 0 -Second 0).AddDays(1)
+    }
+    It "Gets scheduled user by ID" {
+        $scheduledUsers = Get-JcScheduledSuspension -UserID $NewStateUser1.Id
+
+        $scheduledUsers.id | Should -Not -BeNullOrEmpty
+        $scheuldedUsers.Firstname | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Lastname | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Email | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Username | Should -Not -BeNullOrEmpty
+        $scheuldedUsers.ScheduledDate | Should -Be (Get-Date -Hour 12 -Minute 0 -Second 0).AddDays(1)
+    }
+    AfterAll {
+        Remove-JCUser -UserID $NewStateUser1.Id -ByID -force
+        Remove-JCUser -UserID $NewStateUser2.Id -ByID -force
+        Remove-JCUser -UserID $NewStateUser3.Id -ByID -force
+    }
+}

--- a/PowerShell/JumpCloud Module/Tests/Public/Users/Get-JCScheduledUserstate.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Users/Get-JCScheduledUserstate.ps1
@@ -40,6 +40,18 @@ Describe -Tag:('JCScheduledUserstate') 'Get-JCScheduledUserstate' {
         $scheduledUsers.Username | Should -Not -BeNullOrEmpty
         $scheuldedUsers.ScheduledDate | Should -Be (Get-Date -Hour 12 -Minute 0 -Second 0).AddDays(1)
     }
+    It "Gets scheduled user by ID with 2 userstate changes" {
+        $ScheduledSuspension = New-JcSdkBulkUserState -UserIds $NewStateUser3.Id -State 'SUSPENDED' -StartDate (Get-Date -Hour 13 -Minute 0 -Second 0).AddDays(1)
+        $scheduledUsers = Get-JcScheduledSuspension -UserID $NewStateUser1.Id
+        $scheduledUsers.count | Should -Be 2
+
+        $scheduledUsers.id | Should -Not -BeNullOrEmpty
+        $scheuldedUsers.Firstname | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Lastname | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Email | Should -Not -BeNullOrEmpty
+        $scheduledUsers.Username | Should -Not -BeNullOrEmpty
+        $scheuldedUsers.ScheduledDate | Should -Not -BeNullOrEmpty
+    }
     AfterAll {
         Remove-JCUser -UserID $NewStateUser1.Id -ByID -force
         Remove-JCUser -UserID $NewStateUser2.Id -ByID -force


### PR DESCRIPTION
## Issues
* [CUT-4112](https://jumpcloud.atlassian.net/browse/CUT-4112) - Userstate Lookups

## What does this solve?
Introducing a new function to the JumpCloud PowerShell module called `Get-JCScheduledUserstate`

This function will allow for admins to see all of their scheduled userstate changes in their org, as well as being able to filter based on scheduled suspensions, activations or even UserIDs

## Is there anything particularly tricky?
A single user can have multiple scheduled userstate changes. As an example, a user can be scheduled for suspension at `7/1/2024` as well as being scheduled for activation at `8/1/2024`. Looking up the user by their UserID should return both results

## How should this be tested?
1. In your admin console, schedule a few users to be suspended as well as a few users to be activated at a later time. Make note of the time of suspension/activation as it should be your local time.
2. To get a list of scheduled user suspensions run the following:
```powershell
Get-JCScheduledUserstate -State 'SUSPENDED'
```
3. Validate that this list matches the list of users you scheduled in the admin console
4. To get a list of scheduled user activations run the following:
```powershell
Get-JCScheduledUserstate -State 'ACTIVATED'
```
5. Validate that this list matches the list of users you scheduled in the admin console
6. To get a list of a single user's scheduled userstate changes run the following:
```powershell
Get-JCScheduledUserstate -UserID "UserID"
```
7. Validate that this list matches the list of users you scheduled in the admin console