### PR TITLE
Cut 4185 mac windows log collection

### DIFF
--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -93,7 +93,6 @@ log show --last ${days}d --debug --info --style compact --predicate 'senderImage
 echo "Gathering profiles & OS Patch Management settings"
 profiles show -o stdout > $baseDir/installedProfiles.txt
 
-# from James W.
 softwareupdate --list > $basedir/systemInfo/SoftwareUpdateList.txt 2>$1
 
 defaults read /Library/Preferences/com.apple.SoftwareUpdate > $baseDir/com.apple.SoftwareUpdate.plist 2>&1

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+
+
+automate=false   # set to true if running via a JumpCloud command (recommended)
+days=2           # number of days of OS logs to gather
+
+
+
+#######
+# do not edit below
+#######
+
+datestamp=$(date "+%Y%m%d")
+hostDir="/Users/Shared/"
+baseDir="${hostDir}JumpCloudLogCollect"
+localuser=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }')
+version=1.0
+
+### Get Consent to collect information
+
+if [[ ! $automate =~ "true" ]]
+then
+    read -p "This log collection script gathers:
+- All JumpCloud agent, service, and installation logs
+- JumpCloud logging recorded in the macOS system logs for the past 4 days
+- Currently installed configuration profiles
+- MDM triggered software installations for the past 4 days (Appstore, VPP and Custom Software)
+- Filevault and secure token information (no passwords or secrets are collected)
+- Usernames of JumpCloud managed users
+If you agree to this, enter 'Y', or any other key to cancel." -n 1 -r
+    echo    # move to a new line
+    if [[ ! $REPLY =~ ^[Yy]$ ]]
+    then
+        echo "Exiting script."
+        [[ "$0" = "$BASH_SOURCE" ]] && exit 1
+    fi
+fi
+
+## verify script is running as root.
+if [ $(/usr/bin/id -u) -ne 0 ]
+then
+    echo "This script must be run as root."
+    exit
+fi
+
+## verify system is enrolled in JumpCloud
+
+if [ ! -e /opt/jc/jcagent.conf ]
+then
+    echo "System does not appear to be currently managed by JumpCloud - exiting."
+    [[ "$0" = "$BASH_SOURCE" ]] && exit 1
+fi
+
+## verify bash has full disk access
+if ! plutil -lint /Library/Preferences/com.apple.TimeMachine.plist >/dev/null ; then
+    echo "Full Disk Access required for bash operations. Please add '/bin/bash' to Full Disk Access or apply the bash_fda configuration profile."
+    exit 1
+fi
+
+
+## Create directories for log collection
+mkdir -p {$baseDir/jumpcloud_logs,$baseDir/systemLogs,$baseDir/systemInfo,$baseDir/userLogs}
+
+echo "Gathering all JumpCloud agent and process Logs..."
+
+## gather JumpCloud system logs (agent, install, patch management)
+for f in /var/log/jc*.log*
+do
+    cp $f $baseDir/jumpcloud_logs/
+done
+
+if [ -d /var/log/jumpcloud ]
+then
+    cp -r /var/log/jumpcloud $baseDir/jumpcloud_logs/
+fi
+
+if [ -d /var/log/jumpcloud-loginwindow ]
+then
+    cp -r /var/log/jumpcloud-loginwindow $baseDir/jumpcloud_logs/
+fi
+
+## Set permissions for gathered logs
+chmod -R 777 $baseDir
+
+## pull jumpcloud log entries from the system logs
+echo "Gathering jumpcloud logs from macOS system logs"
+log show --last ${days}d --predicate="eventMessage CONTAINS[c] 'jumpcloud'" > $baseDir/systemLogs/jumpcloud_syslog.log
+log show --last ${days}d --debug --info --style compact --predicate 'senderImagePath CONTAINS[c] "JCLoginPlugin"' > $baseDir/systemLogs/SSAP_LoginWindow_events.log
+
+
+## pull patch management logs
+echo "Gathering profiles & OS Patch Management settings"
+profiles show -o stdout > $baseDir/installedProfiles.txt
+
+# from James W.
+softwareupdate --list > $basedir/systemInfo/SoftwareUpdateList.txt 2>$1
+
+defaults read /Library/Preferences/com.apple.SoftwareUpdate > $baseDir/com.apple.SoftwareUpdate.plist 2>&1
+sudo -u $localuser defaults read com.github.macadmins.Nudge.plist > $baseDir/com.github.macadmins.Nudge.plist 2>&1
+
+## gather relevent system logs for software installs
+echo "Gathering software installation logs"
+log show --last ${days}d --predicate="process CONTAINS[c] 'appstored'" > $baseDir/systemLogs/appstored.log
+
+## list secure tokens and filesystem information
+echo "Gathering filesystem and secure token information"
+fdesetup list > $baseDir/systemInfo/secureTokenList.txt
+diskutil apfs list > $baseDir/systemInfo/diskReport.txt
+
+## list managed usernames
+echo "finding managed users"
+grep -o '\"username\":\"\w*' /opt/jc/managedUsers.json | cut -d '"' -f 4 > $baseDir/systemInfo/managedUsers.txt
+
+## descend into managed user's homedirs (requires full disk access) and gather JumpCloud logs
+for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do
+    echo "pulling logs from user $u"
+    if [ -d /Users/$u/Library/Logs/JumpCloud\ Password\ Manager ]; then
+        cp -r /Users/$u/Library/Logs/JumpCloud\ Password\ Manager $baseDir/userLogs/$u/
+    fi
+
+    if [ -d /Users/$u/Library/Logs/JumpCloud\ Remote\ Assist ]; then
+        cp -r /Users/$u/Library/Logs/JumpCloud\ Remote\ Assist $baseDir/userLogs/$u/
+    fi
+
+    cp -r /Users/$u/Library/Logs/JumpCloud $baseDir/userLogs/$u/
+
+done
+
+echo "Resetting gathered logs permissions"
+chmod -R 777 $baseDir
+
+## compress everything
+echo "Compressing logs"
+tar -czvf "${hostDir}JumpCloudLogArchive-v${version}-$datestamp.tar.gz" -C $baseDir .
+chmod 777 ${hostDir}JumpCloudLogArchive-v${version}-$datestamp.tar.gz
+
+echo "cleaning up."
+rm -R $baseDir
+
+sudo -u $localuser open $hostDir

--- a/scripts/windows/log_collection.ps1
+++ b/scripts/windows/log_collection.ps1
@@ -1,0 +1,317 @@
+##################### Do Not Modify Below ######################
+# set to $true if running via a JumpCloud command (recommended)
+$automate = $false   
+
+################################################################
+
+# Function to Check if the Script is Running as an Administrator
+function Test-Administrator {
+    $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($currentUser)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if (-not (Test-Administrator)) {
+    Write-Warning "This script needs to be run as an administrator."
+    exit
+}
+
+# Function to Gather Logs Based on User Selection
+function Gather-Logs {
+    [CmdletBinding()]
+    param (
+        [Parameter(ParameterSetName = 'SearchFilter')]
+        [ValidateSet( "Agent Logs",
+            "Remote Assist logs",
+            "Password Manager Logs",
+            "MDM Enrollment and Hosted Software Management",
+            "Bitlocker",
+            "Software Management: Chocolatey",
+            "Software Management: Windows Store",
+            "Policies",
+            "Active Directory Logs")]
+        [String[]]
+        $selections,
+        [Parameter(ParameterSetName = 'All Logs')]
+        [switch]
+        $All
+    )
+
+    begin {
+        # Temp Directory Used During Log Gathering
+        $tempDir = Join-Path $env:TEMP "Jumpcloud_Temp_Logs"
+
+        # Check if the Temp Directory Already Exists and Remove it if it Does
+        if (Test-Path $tempDir) {
+            Remove-Item -Path $tempDir -Recurse -Force
+        }
+
+        # Create the Temp Directory
+        New-Item -ItemType Directory -Path $tempDir > $null
+
+        # List of Log Files and Event Logs to Gather
+        $fileList = @{
+            "AgentLogs"           = @(
+                "C:\windows\temp\jcagent.log",
+                "C:\windows\temp\jcagent.log.*",
+                "C:\Windows\Temp\jcagent_updater.log",
+                "C:\Windows\Temp\jcExecUpgradeScript.log",
+                "C:\Windows\Temp\jcUninstallUpgrade.log",
+                "C:\Windows\Temp\jcUpdate.log",
+                "C:\Windows\Temp\jcUpgradeScript.log",
+                "C:\Windows\Temp\jcUninstallUpgrade.log",
+                "C:\windows\temp\jcagent.log.prev",
+                "C:\windows\temp\pid-agent-updater.txt",
+                "C:\Windows\Logs\JCCredentialProvider\provider.log",
+                "C:\Program Files\JumpCloud\Plugins\Contrib\jcagent.conf",
+                "C:\Program Files\JumpCloud\Plugins\Contrib\lockoutCache.json",
+                "C:\Program Files\JumpCloud\Plugins\Contrib\managedUsers.json",
+                "C:\Program Files\JumpCloud\Plugins\Contrib\version.txt"
+            )
+            "RemoteAssistLogs"    = @(
+                "C:\Windows\System32\config\systemprofile\AppData\Roaming\JumpCloud-Remote-Assist\logs\*.log",
+                "C:\Windows\Temp\jc_raasvc.log"
+            )
+            "PasswordManagerLogs" = @(
+                # Placeholder, Actual Value Will be Set Based on User Input
+            )
+            "ChocolateyLogs"      = @(
+                "C:\ProgramData\chocolatey\logs\choco.summary.log",
+                "C:\ProgramData\chocolatey\logs\chocolatey.log",
+                "C:\windows\temp\jcagent.log"
+            )
+            "ADLogs"              = @(
+                "C:\Program Files\JumpCloud\AD Integration\JumpCloud AD Import\JumpCloud_AD_Import_Grpc.log",
+                "C:\Windows\Temp\JumpCloud_AD_Integration.log",
+                "C:\Program Files\JumpCloud\AD Integration\JumpCloud AD Import\jcadimportagent.config.json",
+                "C:\Program Files\JumpCloud\AD Integration\JumpCloud AD Sync\JumpCloud_AD_Sync.log",
+                "C:\Program Files\JumpCloud\AD Integration\JumpCloud AD Sync\config.json"
+        
+            )
+            "Policies"            = @(
+                "C:\windows\temp\jcagent.log"
+            )
+        }
+
+        $eventLogList = @{
+            "EssentialEvents"    = @("Application", "Security", "System", "Windows PowerShell")
+            "BitLockerEvents"    = @("Microsoft-Windows-BitLocker/BitLocker Management")
+            "WindowsStoreEvents" = @(
+                "Microsoft-Windows-AppXDeployment/Operational",
+                "Microsoft-Windows-AppXDeploymentServer/Operational",
+                "Microsoft-Windows-AppxPackaging/Operational"
+            )
+        }
+
+        $files = @()
+        $eventLogs = @()
+        $nonExistentFiles = @()
+
+        if ($PSCmdlet.ParameterSetName -eq 'SearchFilter') {
+            $selectedSections = $selections
+        }
+        elseif ($PSCmdlet.ParameterSetName -eq 'All Logs') {
+            
+            $selectedSections = @("Agent Logs",
+                "Remote Assist logs",
+                "Password Manager Logs",
+                "MDM Enrollment and Hosted Software Management",
+                "Bitlocker",
+                "Software Management: Chocolatey",
+                "Software Management: Windows Store",
+                "Policies",
+                "Active Directory Logs")
+        }
+    }
+
+            
+    process {
+
+        foreach ($logType in $selectedSections) {
+
+            Write-Host "Getting $($logType)"
+            switch ($logType) {
+                "Agent Logs" {
+                    $files += $fileList["AgentLogs"]
+                    $eventLogs += $eventLogList["EssentialEvents"]
+                }
+                "Remote Assist logs" {
+                    $files += $fileList["RemoteAssistLogs"]
+                }
+                "Password Manager Logs" {
+                    $allUsers = Get-LocalUser
+                    foreach ($user in $allUsers) {
+                        if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)" -Name "ProfileImagePath" -ErrorAction SilentlyContinue) {
+                            $profilePath = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)" -Name "ProfileImagePath"
+                            $profileImagePath = $profilePath.ProfileImagePath
+                        }
+                        
+                        if (Test-Path -Path "$profileImagePath\AppData\Roaming\JumpCloud Password Manager\logs\logs-live.log") {
+                            $passwordManagerLogPath = "$profileImagePath\AppData\Roaming\JumpCloud Password Manager\logs\logs-live.log"
+                            $files += $passwordManagerLogPath
+                        }
+
+                    }
+                }
+                "MDM Enrollment and Hosted Software Management" {
+                    $eventLogs += $eventLogList["EssentialEvents"]
+                    $mdmDiagDir = Join-Path $tempDir "MDMDiag"
+                    New-Item -ItemType Directory -Path $mdmDiagDir
+                    $mdmDiagCmd = "mdmdiagnosticstool.exe -area 'DeviceEnrollment;DeviceProvisioning;Autopilot' -zip $mdmDiagDir\MDMDiag.zip"
+                    Invoke-Expression $mdmDiagCmd
+                }
+                "Bitlocker" {
+                    $files += $fileList["AgentLogs"]
+                    $eventLogs += $eventLogList["EssentialEvents"]
+                    $eventLogs += $eventLogList["BitLockerEvents"]
+                }
+                "Software Management: Chocolatey" {
+                    $files += $fileList["ChocolateyLogs"]
+                    $eventLogs += $eventLogList["EssentialEvents"]
+                }
+                "Software Management: Windows Store" {
+                    $eventLogs += $eventLogList["EssentialEvents"]
+                    $eventLogs += $eventLogList["WindowsStoreEvents"]
+                }
+                "Policies" {
+                    $files += $fileList["Policies"]
+    
+                    # Generate RSOP Output
+                    $rsopOutputPath = Join-Path $tempDir "RSOP.html"
+                    $rsopCmd = "gpresult /H $rsopOutputPath"
+                    Invoke-Expression $rsopCmd
+                }
+                "Active Directory Logs" {
+                    $files += $fileList["ADLogs"]
+                    # Export AD Integration Registry Keys
+                    # test for import agent files
+                    if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\JumpCloud\AD Integration Import Agent" -ErrorAction SilentlyContinue ) {
+                        reg export "HKLM:\SOFTWARE\JumpCloud\AD Integration Import Agent" "$tempDir\AD_Integration_Import_Agent.reg" -ErrorAction SilentlyContinue
+                    }
+                    else {
+                        Write-Warning "No AD Import Agent Logs exist"
+                    }
+                    # test for sync agent files
+                    if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\AD Integration Sync Agent" -ErrorAction SilentlyContinue ) {
+                        reg export "HKLM:\SOFTWARE\JumpCloud\AD Integration Sync Agent" "$tempDir\AD_Integration_Sync_Agent.reg" -ErrorAction SilentlyContinue
+                    }
+                    else {
+                        Write-Warning "No AD Sync Agent Logs exist"
+                    }
+                    # Output DistinguishedName to a Text File
+                    if (Get-Module -Name ActiveDirectory) {
+                        $distinguishedName = (Get-ADDomain).DistinguishedName
+                        $distinguishedName | Out-File -FilePath (Join-Path $tempDir "AD_DistinguishedName.txt")
+                    }
+                    else {
+                        Write-Warning "The Active Directory PowerShell Module was not installed"
+                    }
+                }
+            }
+        }
+    
+        # Check if the Zip File Already Exists and Remove it if it Does
+        $zipFilePath = "C:\Windows\Temp\Jumpcloud_Agent_Logs.zip"
+        if (Test-Path $zipFilePath) {
+            Remove-Item $zipFilePath
+        }
+    
+        # Copy the Files to the Temporary Directory if They Exist
+        foreach ($file in $files) {
+            if (Test-Path $file) {
+                if ($file -match "logs-live") {
+                    
+                    $pwmFile = $file | Select-String -Pattern "C:\\Users\\([\s\S]+)\\AppData"
+                    $pwnFileUsername = $pwmFile.matches.groups[1].value
+                    Copy-Item -Path $file -Destination "$tempDir/$pwnFileUsername-logs-live.txt" -ErrorAction SilentlyContinue
+                }
+                else {
+                    Copy-Item -Path $file -Destination $tempDir -ErrorAction SilentlyContinue
+                }
+            }
+            else {
+                $nonExistentFiles += $file
+            }
+        }
+    
+        # Export Event Logs to Temporary Directory
+        foreach ($log in $eventLogs) {
+            $evtFile = Join-Path $tempDir "$($log -replace '/', '-').evtx"
+            if (Test-Path -Path $evtFile) {
+                Remove-Item -Path $evtFile -Force
+            }
+            try {
+                wevtutil epl $log $evtFile
+            }
+            catch {
+                Write-Host "Skipping $log event log: $_"
+            }
+        }
+    }
+    end {
+
+        # Create a Log File of All Copied Files
+        $logFilePath = Join-Path (Get-Location) "CopiedFiles.log"
+        $files | Out-File -FilePath $logFilePath -ErrorAction SilentlyContinue
+    
+        # Create the Zip File
+        $hostname = $env:COMPUTERNAME
+        $selectedSectionsString = $selectedSections -join "_"
+        $zipFileName = "${hostname}_Jumpcloud_Agent_Logs.zip"
+        $zipFilePath = Join-Path "C:\Windows\Temp" $zipFileName
+        if (Test-Path $zipFilePath) {
+            Remove-Item -Path $zipFilePath -Recurse -Force
+        }
+        Compress-Archive -Path $tempDir\* -DestinationPath $zipFilePath -Force
+    
+        Write-Host "Logs have been gathered and compressed into $zipFilePath"
+    
+        # Open the Folder Containing the Zip File
+        #explorer.exe /select, $zipFilePath
+        Start-Process "explorer.exe" -ArgumentList "/select,`"$zipFilepath`""
+    
+        # Cleanup Temporary Directory
+        Remove-Item -Path $tempDir -Recurse -Force
+    }
+}
+
+
+
+# if automate is selected, do not prompt, set all logs
+if ($automate) {
+    Gather-Logs -All
+}
+else {
+
+    # Prompt the User to Select the Sections to Gather Logs From
+    $sections = @(
+        "All Logs",
+        "Agent Logs",
+        "Remote Assist logs",
+        "Password Manager Logs",
+        "MDM Enrollment and Hosted Software Management",
+        "Bitlocker",
+        "Software Management: Chocolatey",
+        "Software Management: Windows Store",
+        "Policies",
+        "Active Directory Logs"
+    )
+    
+    $selectionPrompt = "Please select the sections to gather logs from:`n"
+    for ($i = 0; $i -lt $sections.Count; $i++) {
+        $selectionPrompt += "$($i + 1). $($sections[$i])`n"
+    }
+    $selectionPrompt += "Enter your selection (e.g., 1, 3, 5-7)"
+    
+    $input = Read-Host -Prompt $selectionPrompt
+    $selectedIndexes = $input -split ",|-" | ForEach-Object { $_.Trim() } | Where-Object { $_ -match "^\d+$" } | ForEach-Object { [int]$_ - 1 }
+    
+    if ($selectedIndexes -contains 0) {
+        Gather-Logs -All
+    }
+    else {
+        $selectedSections = $selectedIndexes | ForEach-Object { $sections[$_] } -ErrorAction SilentlyContinue
+        Gather-Logs -selections $selectedSections
+    }
+}
+

--- a/scripts/windows/remove_windowsMDM.ps1
+++ b/scripts/windows/remove_windowsMDM.ps1
@@ -1,0 +1,91 @@
+<### This script will remove all MDM Entries, as well as their
+  associated scheduled tasks, from a device###>
+
+###Initialize an array to store Enrollment IDs###
+$valueName = "ProviderID"
+$EnrollIDs = @()
+
+###Check if the registry path exists###
+Test-Path -Path "Registry::HKLM:\SOFTWARE\Microsoft\Enrollments\"
+###Get enrollment IDs###
+Get-ChildItem -Path "HKLM:\SOFTWARE\Microsoft\Enrollments\" -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
+    ###Check if the registry key exists and suppress errors###
+    if ($item = Get-ItemProperty -LiteralPath $_.PsPath -ErrorAction SilentlyContinue) {
+        if ($item.PSObject.Properties.Name -contains $valueName) {
+            ###Extracting the last part (GUID) from the path###
+            $pathParts = $_.PsPath -split '\\'
+            $EnrollID = $pathParts[-1]
+
+            ###Add the enrollment ID to the array###
+            $EnrollIDs += $EnrollID
+
+            ###Output the enrollment ID for each iteration###
+            Write-Host "Here is the $EnrollID"
+
+            ###Removing Associated Scheduled Tasks###
+            $Tasks = Get-ScheduledTask | Where-Object { $psitem.TaskPath -like "\Microsoft\Windows\EnterpriseMgmt\*" }
+            if ($EnrollID -match '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}') {
+                Write-Host "Found EnrollID - $EnrollID" -ForegroundColor Green
+            } else {
+                Write-Host "Error parsing EnrollID. Stopping" -ForegroundColor Red
+                Break
+            }
+            Write-Host "Removing scheduledTasks" -ForegroundColor Yellow
+            Try {
+                $Tasks | ForEach-Object { Unregister-ScheduledTask -InputObject $psitem -Verbose -Confirm:$false }
+            } catch {
+                Throw $_.Exception.Message
+            }
+            Write-Host "Done" -ForegroundColor Green
+            Write-Host "Trying to remove tasks folder" -ForegroundColor Yellow
+            $TaskFolder = Test-Path "C:\windows\System32\Tasks\Microsoft\Windows\EnterpriseMgmt\$EnrollID"
+            try {
+                if ($TaskFolder) {
+                    Remove-Item -Path "C:\windows\System32\Tasks\Microsoft\Windows\EnterpriseMgmt\$EnrollID" -Force -Verbose
+                }
+            } catch {
+                Throw $_.Exception.Message
+            }
+
+            ### Removing Associated Reg Keys ###
+            Write-Host "Removing registry keys" -ForegroundColor Yellow
+            $EnrollmentReg = Test-Path -Path HKLM:\SOFTWARE\Microsoft\Enrollments\Status\$EnrollID
+            if ($EnrollmentReg) {
+                Remove-Item -Path HKLM:\SOFTWARE\Microsoft\Enrollments\Status\$EnrollID -Recurse -Force -Verbose
+            }
+            $EnrollmentReg = Test-Path -Path HKLM:\SOFTWARE\Microsoft\EnterpriseResourceManager\Tracked\$EnrollID
+            if ($EnrollmentReg) {
+                Remove-Item -Path HKLM:\SOFTWARE\Microsoft\EnterpriseResourceManager\Tracked\$EnrollID -Recurse -Force -Verbose
+            }
+            $EnrollmentReg = Test-Path -Path HKLM:\SOFTWARE\Microsoft\PolicyManager\AdmxInstalled\$EnrollID
+            if ($EnrollmentReg) {
+                Remove-Item -Path HKLM:\SOFTWARE\Microsoft\PolicyManager\AdmxInstalled\$EnrollID -Recurse -Force -Verbose
+            }
+            $EnrollmentReg = Test-Path -Path HKLM:\SOFTWARE\Microsoft\PolicyManager\Providers\$EnrollID
+            if ($EnrollmentReg) {
+                Remove-Item -Path HKLM:\SOFTWARE\Microsoft\PolicyManager\Providers\$EnrollID -Recurse -Force -Verbose
+            }
+            $EnrollmentReg = Test-Path -Path HKLM:\SOFTWARE\Microsoft\Provisioning\OMADM\Accounts\$EnrollID
+            if ($EnrollmentReg) {
+                Remove-Item -Path HKLM:\SOFTWARE\Microsoft\Provisioning\OMADM\Accounts\$EnrollID -Recurse -Force -Verbose
+            }
+            $EnrollmentReg = Test-Path -Path HKLM:\SOFTWARE\Microsoft\Provisioning\OMADM\Logger\$EnrollID
+            if ($EnrollmentReg) {
+                Remove-Item -Path HKLM:\SOFTWARE\Microsoft\Provisioning\OMADM\Logger\$EnrollID -Recurse -Force -Verbose
+            }
+            $EnrollmentReg = Test-Path -Path HKLM:\SOFTWARE\Microsoft\Provisioning\OMADM\Sessions\$EnrollID
+            if ($EnrollmentReg) {
+                Remove-Item -Path HKLM:\SOFTWARE\Microsoft\Provisioning\OMADM\Sessions\$EnrollID -Recurse -Force -Verbose
+            }
+            $EnrollmentReg = Test-Path -Path HKLM:\SOFTWARE\Microsoft\Enrollments\$EnrollID
+            if ($EnrollmentReg) {
+                Remove-Item -Path HKLM:\SOFTWARE\Microsoft\Enrollments\$EnrollID -Recurse -Force
+            }
+
+            Write-Host "Done removing registry keys forthe Enrollment ID $EnrollID" -ForegroundColor Green
+        }
+    }
+}
+
+###List Removed Enrollment GUIDs###
+Write-Output "Removed the following MDM GUIDs: $($EnrollIDs -join ', ')"


### PR DESCRIPTION
## Issues
* [CUT-4185](https://jumpcloud.atlassian.net/browse/CUT-4185) - CUT-4185-WindowsMacOS log collection for troubleshooting

## What does this solve?
Allow customers to gather all necessary log files at once through Commands (Mac, Windows)
## Is there anything particularly tricky?
n/a
## How should this be tested?
From JC Command:
1. Run mac script to a mac device
2. Validate all necessary log files are in the zip file: /Users/Shared/JumpCloudLogArchive-Timestamp.tar.gz
![image](https://github.com/user-attachments/assets/f93532a8-a32e-4e48-bb5c-6b17f7e9d59d)

## Screenshots
![image](https://github.com/user-attachments/assets/215709eb-62c0-47a6-bd05-ba5150193a69)



[CUT-4185]: https://jumpcloud.atlassian.net/browse/CUT-4185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ