### PR TITLE
Added "install.log*" to collected assets.

### DIFF
--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -101,6 +101,7 @@ sudo -u $localuser defaults read com.github.macadmins.Nudge.plist > $baseDir/com
 ## gather relevent system logs for software installs
 echo "Gathering software installation logs"
 log show --last ${days}d --predicate="process CONTAINS[c] 'appstored'" > $baseDir/systemLogs/appstored.log
+cp /var/log/install.log* $baseDir/systemLogs/
 
 ## list secure tokens and filesystem information
 echo "Gathering filesystem and secure token information"


### PR DESCRIPTION
## Issues
* SUP-1448 https://jumpcloud.atlassian.net/browse/SUP-1448  Add "install.log*" to collected logs

## What does this solve?
Script was missing an installation log that is commonly useful for review

## Is there anything particularly tricky?
nope - just copied files to an already existing collection directory

## How should this be tested?
Send via JC Command to macOS, set the automation variable to "true" and view results.

## Screenshots
![Screenshot 2024-08-09 at 11 21 40 AM](https://github.com/user-attachments/assets/fbcffc90-f938-4597-84a1-e139a462a441)
