### PR TITLE
Updated saves to more secure locations, reorganized checks and fixed …

### DIFF
--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -157,5 +157,5 @@ if [[ $localuser ]]; then
     echo "Log archive has been saved to the current user's Documents folder."
 else
     echo "Please log in locally on the device and open /var/tmp to locate the log archive.
-You may run the command `open /var/tmp` in the macOS Terminal to do this."
+You may run the command 'open /var/tmp' in the macOS Terminal to do this."
 fi


### PR DESCRIPTION
…couple typos.

## Issues
* [SUP-1351]https://jumpcloud.atlassian.net/browse/SUP-1451 - log collect - secure collected files and written archive

## What does this solve?
Resolves some concerns from security about target directory for collected archive.
Reorganizes some prereq checks
skips runs which require an active user session
Fixed a typo for stderr/stdout redirection.

## Is there anything particularly tricky?
Not really....

## How should this be tested?
Two separate runs from JC Commands:
1) with active user session on macOS device - verify written to user's ~/Documents folder
2) with device sitting at login window / no active user session - verify archive written to /var/tmp/ 

## Screenshots


[SUP-1351]: https://jumpcloud.atlassian.net/browse/SUP-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ