### PR TITLE
Update windows install script

### DIFF
--- a/scripts/windows/InstallWindowsAgent.ps1
+++ b/scripts/windows/InstallWindowsAgent.ps1
@@ -10,44 +10,39 @@ Param (
 #--- Modify Below This Line At Your Own Risk ------------------------------
 
 # JumpCloud Agent Installation Variables
-$TempPath = 'C:\Windows\Temp\'
 $AGENT_PATH = Join-Path ${env:ProgramFiles} "JumpCloud"
 $AGENT_BINARY_NAME = "jumpcloud-agent.exe"
 $AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signed.msi"
 $AGENT_INSTALLER_PATH = "C:\windows\Temp\jcagent-msi-signed.msi"
 # JumpCloud Agent Installation Functions
 Function InstallAgent() {
-    msiexec /i $AGENT_INSTALLER_PATH /quiet JCINSTALLERARGUMENTS=`"-k $JumpCloudConnectKey /VERYSILENT /NORESTART /NOCLOSEAPPLICATIONS /L*V "C:\Windows\Temp\jcUpdate.log"`"
+    msiexec /i $AGENT_INSTALLER_PATH /quiet /norestart JCINSTALLERARGUMENTS=`"-k $JumpCloudConnectKey`" /L*V "C:\ProgramData\JumpCloud\Agent\jcUpdate.log"
 }
 Function DownloadAgentInstaller() {
     (New-Object System.Net.WebClient).DownloadFile("${AGENT_INSTALLER_URL}", "${AGENT_INSTALLER_PATH}")
 }
 Function DownloadAndInstallAgent() {
-    If (Test-Path -Path "$($AGENT_PATH)\$($AGENT_BINARY_NAME)") {
-        Write-Output 'JumpCloud Agent Already Installed'
-    } else {
-        Write-Output 'Downloading JCAgent Installer'
-        # Download Installer
-        DownloadAgentInstaller
-        Write-Output 'JumpCloud Agent Download Complete'
-        Write-Output 'Running JCAgent Installer'
-        # Run Installer
-        InstallAgent
+    Write-Output 'Downloading JCAgent Installer'
+    # Download Installer
+    DownloadAgentInstaller
+    Write-Output 'JumpCloud Agent Download Complete'
+    Write-Output 'Running JCAgent Installer'
+    # Run Installer
+    InstallAgent
 
-        # Check if agent is running as a service
-        # Do a loop for 5 minutes to check if the agent is running as a service
-        # The agent pulls cef files during install which may take longer then previously.
-        for ($i = 0; $i -lt 300; $i++) {
-            Start-Sleep -Seconds 1
-            #Output the errors encountered
-            $AgentService = Get-Service -Name "jumpcloud-agent" -ErrorAction SilentlyContinue
-            if ($AgentService.Status -eq 'Running') {
-                Write-Output 'JumpCloud Agent Succesfully Installed'
-                exit
-            }
+    # Check if agent is running as a service
+    # Do a loop for 5 minutes to check if the agent is running as a service
+    # The agent pulls cef files during install which may take longer then previously.
+    for ($i = 0; $i -lt 300; $i++) {
+        Start-Sleep -Seconds 1
+        #Output the errors encountered
+        $AgentService = Get-Service -Name "jumpcloud-agent" -ErrorAction SilentlyContinue
+        if ($AgentService.Status -eq 'Running') {
+            Write-Output 'JumpCloud Agent Succesfully Installed'
+            exit
         }
-        Write-Output 'JumpCloud Agent Failed to Install'
     }
+    Write-Output 'JumpCloud Agent Failed to Install'
 }
 
 #Flush DNS Cache Before Install

--- a/scripts/windows/InstallWindowsAgent.ps1
+++ b/scripts/windows/InstallWindowsAgent.ps1
@@ -16,6 +16,9 @@ $AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signe
 $AGENT_INSTALLER_PATH = "C:\windows\Temp\jcagent-msi-signed.msi"
 # JumpCloud Agent Installation Functions
 Function InstallAgent() {
+    if (!(Test-Path "C:\ProgramData\JumpCloud\Agent")) {
+        New-Item -ItemType Directory -Path "C:\ProgramData\JumpCloud\Agent" -Force
+    }
     msiexec /i $AGENT_INSTALLER_PATH /quiet /norestart JCINSTALLERARGUMENTS=`"-k $JumpCloudConnectKey`" /L*V "C:\ProgramData\JumpCloud\Agent\jcUpdate.log"
 }
 Function DownloadAgentInstaller() {


### PR DESCRIPTION
## Issues
* [UN-2389](https://jumpcloud.atlassian.net/browse/UN-2389) - Updating install script.

## What does this solve?

There is no need to check if JumpCloud is already installed,  we can just install over it.
The MSIEXEC command was wrong.
Removed unused variable.

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots


[UN-2389]: https://jumpcloud.atlassian.net/browse/UN-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ