### PR TITLE
Update Deploy-UserCertificate Functions to generate certs on SHA match

### DIFF
--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
@@ -117,6 +117,7 @@ function Deploy-UserCertificate {
                         $false {
                             if ((-Not $workToBeDone.macOSCommandID) -AND ($maOSRadiusCommand.trigger -eq $certInfo.sha1)) {
                                 # set the existing command IDs:
+                                # There is a potential for this to be a bug, if duplicate commands with the same SHA1 trigger exist, this code just selects the first one and removes the second in the next iteration
                                 $workToBeDone.macOSCommandID = ($radiusCommandsByUser | Where-Object { $_.Name -match "MacOSX" }).Id | Select-Object -First 1
                             } elseif (($workToBeDone.macOSCommandID) -AND ($maOSRadiusCommand.trigger -eq $certInfo.sha1)) {
                                 # add the duplicate command to the list to remove
@@ -142,6 +143,7 @@ function Deploy-UserCertificate {
                         $false {
                             if ((-Not $workToBeDone.windowsCommandID) -AND ($windowsOSRadiusCommands.trigger -eq $certInfo.sha1)) {
                                 # set the existing command IDs:
+                                # There is a potential for this to be a bug, if duplicate commands with the same SHA1 trigger exist, this code just selects the first one and removes the second in the next iteration
                                 $workToBeDone.windowsCommandID = ($radiusCommandsByUser | Where-Object { $_.Name -match "Windows" }).Id | Select-Object -First 1
                             } elseif (($workToBeDone.windowsCommandID) -AND ($windowsOSRadiusCommands.trigger -eq $certInfo.sha1)) {
                                 # add the duplicate command to the list to remove

--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
@@ -254,7 +254,6 @@ function Deploy-UserCertificate {
                 }
             }
             # now clear out the user command associations from users.json
-            # THIS ISN't WORKING
             $user.commandAssociations = @()
 
             If (-Not $certInfo) {
@@ -522,6 +521,23 @@ fi
 
 
             }
+
+            if (-Not ($workToBeDone.forceGenerateMacOSCommands) -And ($workToBeDone.macOSCommandID)) {
+                $systemIds = (Get-SystemsThatNeedCertWork -userData $user -osType "macOS")
+
+                $Command = Get-JcSdkCommand -Filter @("trigger:eq:$($certInfo.sha1)", "commandType:eq:windows")
+                $CommandTable = [PSCustomObject]@{
+                    commandId            = $workToBeDone.macOSCommandID
+                    commandName          = $command.name
+                    commandPreviouslyRun = $false
+                    commandQueued        = $false
+                    systems              = $systemIds
+                }
+
+                $user.commandAssociations += $CommandTable
+
+            }
+
             if (($invokeCommands) -And ($workToBeDone.remainingMacOSDevices)) {
                 try {
                     $commandStart = Start-JcSdkCommand -Id $workToBeDone.macOSCommandID -SystemIds $workToBeDone.remainingMacOSDevices.systemId | Out-Null
@@ -712,6 +728,21 @@ exit 4
                 $user.commandAssociations += $CommandTable
                 # Write-Host "[status] Successfully created $($Command.name): User - $($user.userName); OS - Windows"
                 $status_commandGenerated = $true
+            }
+
+            if (-Not ($workToBeDone.forceGenerateWindowsCommands) -And ($workToBeDone.windowsCommandID)) {
+                $systemIds = (Get-SystemsThatNeedCertWork -userData $user -osType "windows")
+
+                $Command = Get-JcSdkCommand -Filter @("trigger:eq:$($certInfo.sha1)", "commandType:eq:windows")
+                $CommandTable = [PSCustomObject]@{
+                    commandId            = $workToBeDone.windowsCommandID
+                    commandName          = $command.name
+                    commandPreviouslyRun = $false
+                    commandQueued        = $false
+                    systems              = $systemIds
+                }
+
+                $user.commandAssociations += $CommandTable
 
             }
             if (($invokeCommands) -AND ($workToBeDone.remainingWindowsSDevices)) {

--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
@@ -109,10 +109,10 @@ function Deploy-UserCertificate {
                 foreach ($maOSRadiusCommand in $macOSCommands) {
                     if ((-Not $workToBeDone.macOSCommandID) -AND ($maOSRadiusCommand.trigger -eq $certInfo.sha1)) {
                         # set the existing command IDs:
-                        $workToBeDone.macOSCommandID = ($radiusCommandsByUser | Where-Object { $_.Name -match "MacOSX" }).Id
+                        $workToBeDone.macOSCommandID = ($radiusCommandsByUser | Where-Object { $_.Name -match "MacOSX" }).Id | Select-Object -First 1
                     } elseif (($workToBeDone.macOSCommandID) -AND ($maOSRadiusCommand.trigger -eq $certInfo.sha1)) {
                         # add the duplicate command to the list to remove
-                        $workToBeDone.commandIDsToRemove.Add($windowsOSRadiusCommands.Id) | Out-Null
+                        $workToBeDone.commandIDsToRemove.Add($maOSRadiusCommand.Id) | Out-Null
                     } else {
                         # add the command to the list to remove
                         $workToBeDone.commandIDsToRemove.Add($maOSRadiusCommand.Id) | Out-Null
@@ -126,7 +126,7 @@ function Deploy-UserCertificate {
                 foreach ($windowsOSRadiusCommands in $windowsOSCommands) {
                     if ((-Not $workToBeDone.windowsCommandID) -AND ($windowsOSRadiusCommands.trigger -eq $certInfo.sha1)) {
                         # set the existing command IDs:
-                        $workToBeDone.windowsCommandID = ($radiusCommandsByUser | Where-Object { $_.Name -match "Windows" }).Id
+                        $workToBeDone.windowsCommandID = ($radiusCommandsByUser | Where-Object { $_.Name -match "Windows" }).Id | Select-Object -First 1
                     } elseif (($workToBeDone.windowsCommandID) -AND ($windowsOSRadiusCommands.trigger -eq $certInfo.sha1)) {
                         # add the duplicate command to the list to remove
                         $workToBeDone.commandIDsToRemove.Add($windowsOSRadiusCommands.Id) | Out-Null

--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
@@ -9,6 +9,10 @@ function Deploy-UserCertificate {
         [Parameter(HelpMessage = 'When specified, this parameter will invoke commands on systems associated to the user from the "userObject" parameter')]
         [bool]
         $forceInvokeCommands,
+        # when specified will generated a new command for the given user
+        [Parameter(HelpMessage = 'When specified, this parameter will generate new commands for the user from the "userObject" parameter')]
+        [bool]
+        $forceGenerateCommands,
         # prompt replace existing certificate
         [Parameter(HelpMessage = 'When specified, this parameter will prompt for user imput and ask if generated commands should be invoked on associated systems')]
         [switch]
@@ -16,12 +20,39 @@ function Deploy-UserCertificate {
     )
 
     begin {
+        $workToBeDone = [PSCustomObject]@{
+            remainingMacOSDevices        = $null
+            remainingWindowsSDevices     = $null
+            removeQueuedCommands         = $null
+            removeCommands               = $null
+            forceGenerateMacOSCommands   = $false
+            forceGenerateWindowsCommands = $false
+            macOSCommandID               = $null
+            windowsCommandID             = $null
+            commandIDsToRemove           = New-Object System.Collections.ArrayList
+            commandQueueIDsToRemove      = New-Object System.Collections.ArrayList
+            commandQueueIDsDuplicates    = New-Object System.Collections.ArrayList
+        }
+
+        $status_commandGenerated = $false
+        $result_deployed = $false
+
         switch ($forceInvokeCommands) {
             $true {
                 $invokeCommands = $true
             }
             $false {
                 $invokeCommands = $false
+            }
+        }
+        switch ($forceGenerateCommands) {
+            $true {
+                $workToBeDone.forceGenerateMacOSCommands = $true
+                $workToBeDone.forceGenerateWindowsCommands = $true
+            }
+            $false {
+                $workToBeDone.forceGenerateMacOSCommands = $false
+                $workToBeDone.forceGenerateWindowsCommands = $false
             }
         }
         switch ($prompt) {
@@ -42,20 +73,38 @@ function Deploy-UserCertificate {
     process {
         foreach ($user in $userObject) {
 
-            #### Begin removal of queued commands + existing command:
-            # remove commands
+            # Determine the work to be done:
+            ## Does the user have all their certs already distributed
+            ### if so delete their queued commands, commands
+            ## Which types of systems does the user need commands for?
+            ### If only one type, delete the other
+            ## If the user's certs are not all distributed, does the SHA1 value of the current command match the SHA1 of their current cert?
+            ### If yes, skip to association update
+            ### If no, delete the command and create with new cert
+
+
+
+
+            ## first determine if the local cert sha is the same as the cert sha in the admin console:
+
+            # Get the commands for this user:
             $radiusCommandsByUser = Get-CommandByUsername -username $user.username
-            foreach ($command in $radiusCommandsByUser) {
-                Remove-JcSdkCommand -Id $command.id | Out-Null
+            if ($radiusCommandsByUser) {
+                $macOSCommands = ($radiusCommandsByUser | Where-Object { $_.Name -match "MacOSX" })
+                $windowsOSCommands = ($radiusCommandsByUser | Where-Object { $_.Name -match "Windows" })
             }
-            # remove queued commands
+
+            # Get the queued commands for the user
             $queuedRadiusCommandsByUser = Get-queuedCommandByUser -username $user.username
-            foreach ($queuedCommand in $queuedRadiusCommandsByUser) {
-                Clear-JCQueuedCommand -workflowId $queuedCommand.id | Out-Null
+            if ($queuedRadiusCommandsByUser) {
+                $windowsQueuedCommands = $queuedRadiusCommandsByUser | Where-Object { $_.name -match "Windows" }
+                $macOSQueuedCommands = $queuedRadiusCommandsByUser | Where-Object { $_.name -match "macOS" }
+            } else {
+                $windowsQueuedCommands = $null
+                $macOSQueuedCommands = $null
             }
-            # now clear out the user command associations from users.json
-            $User.commandAssociations = @()
-            #### End removal of queued commands + existing command
+
+            # Get the users certificate Details:
             # Get certificate and zip to upload to Commands
             $userCertFiles = Get-ChildItem -Path "$JCScriptRoot/UserCerts" -Filter "$($user.userName)-*"
             # set crt and pfx filepaths
@@ -65,7 +114,188 @@ function Deploy-UserCertificate {
             $userPfxZip = "$JCScriptRoot/UserCerts/$($user.userName)-client-signed.zip"
             # get certInfo for commands:
             $certInfo = Get-CertInfo -UserCerts -username $user.username
+            # Determine if the commands have matching SHA1 values:
 
+
+            if ($macOSCommands) {
+                # verify the certs match for macOS systems:
+                foreach ($maOSRadiusCommand in $macOSCommands) {
+                    if ((-Not $workToBeDone.macOSCommandID) -AND ($maOSRadiusCommand.trigger -eq $certInfo.sha1)) {
+                        # set the existing command IDs:
+                        $workToBeDone.macOSCommandID = ($radiusCommandsByUser | Where-Object { $_.Name -match "MacOSX" }).Id
+                    } elseif (($workToBeDone.macOSCommandID) -AND ($maOSRadiusCommand.trigger -eq $certInfo.sha1)) {
+                        # add the duplicate command to the list to remove
+                        $workToBeDone.commandIDsToRemove.Add($windowsOSRadiusCommands.Id) | Out-Null
+                    } else {
+                        # add the command to the list to remove
+                        $workToBeDone.commandIDsToRemove.Add($maOSRadiusCommand.Id) | Out-Null
+                    }
+                }
+            } else {
+                $workToBeDone.macOSCommandID = $null
+            }
+            if ($windowsOSCommands) {
+                # verify the certs match for windows systems:
+                foreach ($windowsOSRadiusCommands in $windowsOSCommands) {
+                    if ((-Not $workToBeDone.windowsCommandID) -AND ($windowsOSRadiusCommands.trigger -eq $certInfo.sha1)) {
+                        # set the existing command IDs:
+                        $workToBeDone.windowsCommandID = ($radiusCommandsByUser | Where-Object { $_.Name -match "Windows" }).Id
+                    } elseif (($workToBeDone.windowsCommandID) -AND ($windowsOSRadiusCommands.trigger -eq $certInfo.sha1)) {
+                        # add the duplicate command to the list to remove
+                        $workToBeDone.commandIDsToRemove.Add($windowsOSRadiusCommands.Id) | Out-Null
+                    } else {
+                        # add the command to the list to remove
+                        $workToBeDone.commandIDsToRemove.Add($windowsOSRadiusCommands.Id) | Out-Null
+                    }
+                }
+            } else {
+                $workToBeDone.windowsCommandID = $null
+            }
+
+
+
+            if ($windowsQueuedCommands) {
+                if ($workToBeDone.windowsCommandID) {
+
+                    # Get queued commands that are from a previous command; delete those
+                    foreach ($queuedCommand in $windowsQueuedCommands) {
+                        if ($queuedCommand.command -eq $workToBeDone.windowsCommandID) {
+                            # TODO: nothing to do here?
+                            $workToBeDone.commandQueueIDsDuplicates.Add($queuedCommand.Id) | Out-Null
+                        } else {
+                            # if the queued commands does not match the cert command, remove all these queued commands
+                            $workToBeDone.commandQueueIDsToRemove.Add($queuedCommand.Id) | Out-Null
+                        }
+                    }
+                } else {
+                    foreach ($queuedCommand in $windowsQueuedCommands) {
+                        # if there are commands in queue for the user but no matching cert command, remove all the items in the queue
+                        $workToBeDone.commandQueueIDsToRemove.Add($queuedCommand.Id) | Out-Null
+                    }
+                }
+            }
+            if ($macOSQueuedCommands) {
+                if ($workToBeDone.windowsCommandID) {
+
+                    foreach ($queuedCommand in $macOSQueuedCommands) {
+                        if ($queuedCommand.command -eq $workToBeDone.macOSCommandID) {
+                            # TODO: nothing to do here?
+                            $workToBeDone.commandQueueIDsDuplicates.Add($queuedCommand.Id) | Out-Null
+                        } else {
+                            # if the queued commands does not match the cert command, remove all these queued commands
+                            $workToBeDone.commandQueueIDsToRemove.Add($queuedCommand.Id) | Out-Null
+                        }
+                    }
+                } else {
+                    foreach ($queuedCommand in $macOSQueuedCommands) {
+                        # if there are commands in queue for the user but no matching cert command, remove all the items in the queue
+                        $workToBeDone.commandQueueIDsToRemove.Add($queuedCommand.Id) | Out-Null
+                    }
+                }
+            }
+
+            # remove the commands:
+            if ($workToBeDone.commandIDsToRemove) {
+                foreach ($commandIDToRemove in $workToBeDone.commandIDsToRemove) {
+                    Remove-JcSdkCommand -Id $commandIDToRemove | Out-Null
+                }
+            }
+            # remove queued commands:
+            if ($workToBeDone.commandQueueIDsToRemove) {
+                foreach ($commandQueueIDToRemove in $workToBeDone.commandQueueIDsToRemove) {
+                    Clear-JCQueuedCommand -workflowId $commandQueueIDToRemove | Out-Null
+                }
+            }
+            # remove queued commands:
+            if ($workToBeDone.commandQueueIDsDuplicates) {
+                foreach ($commandQueueIDToRemove in $workToBeDone.commandQueueIDsDuplicates) {
+                    Clear-JCQueuedCommand -workflowId $commandQueueIDToRemove | Out-Null
+                }
+            }
+            # # determine if we need to remove commands/ queued commands if the certs match:
+            # if ($certsMatch) {
+            #     $workToBeDone.removeCommands = $false
+            #     $workToBeDone.removeQueuedCommands = $false
+
+            #     # if there's no commands/ queued commands to remove, set the command Generated status to false
+            #     $status_commandGenerated = $false
+            # } else {
+            #     $workToBeDone.removeCommands = $true
+            #     $workToBeDone.removeQueuedCommands = $true
+            # }
+
+            ## determine the systems that need the cert
+            try {
+                $userCertHashData = $Global:JCRCertHash["$($user.certInfo.sha1)"]
+
+            } catch {
+                $userCertHashData = $null
+            }
+            if ($userCertHashData) {
+                # set the remaining systems that don't have the cert:
+                # macOS
+                $workToBeDone.remainingMacOSDevices = $user.systemAssociations | Where-Object { ($_.systemID -notin $userCertHashData.systemId ) -And ($_.osFamily) -eq "macOS" }
+                # windows
+                $workToBeDone.remainingWindowsSDevices = $user.systemAssociations | Where-Object { ($_.systemID -notin $userCertHashData.systemId ) -And ($_.osFamily) -eq "Windows" }
+
+                # if there's work to be done but not a valid cert command, generate the command
+                if (($workToBeDone.remainingMacOSDevices) -AND (-Not $workToBeDone.macOSCommandID)) {
+                    $workToBeDone.forceGenerateMacOSCommands = $true
+                }
+                # if there's work to be done but not a valid cert command, generate the command
+                if (($workToBeDone.remainingWindowsSDevices) -AND (-Not $workToBeDone.windowsCommandID)) {
+                    $workToBeDone.forceGenerateWindowsCommands = $true
+                }
+            } else {
+                # set the remaining devices to the association list from users.json
+                # macOS
+                $workToBeDone.remainingMacOSDevices = $user.systemAssociations | Where-Object { ($_.osFamily) -eq "macOS" }
+                # Windows
+                $workToBeDone.remainingWindowsSDevices = $user.systemAssociations | Where-Object { ($_.osFamily) -eq "Windows" }
+                # if there's work to be done but not a valid cert command, generate the command
+                if (($workToBeDone.remainingMacOSDevices) -AND (-Not $workToBeDone.macOSCommandID)) {
+                    $workToBeDone.forceGenerateMacOSCommands = $true
+                }
+                # if there's work to be done but not a valid cert command, generate the command
+                if (($workToBeDone.remainingWindowsSDevices) -AND (-Not $workToBeDone.windowsCommandID)) {
+                    $workToBeDone.forceGenerateWindowsCommands = $true
+                }
+            }
+
+            # ## determine which OS commands to generate:
+            # if ($workToBeDone.removeCommands) {
+            #     # if we remove commands, which os type should be generated
+            #     if ($workToBeDone.remainingMacOSDevices) {
+            #         # generate macOS commands
+            #         $workToBeDone.generateMacOSCommands = $true
+            #     }
+            #     if ($workToBeDone.remainingWindowsSDevices) {
+            #         # generate windows commands
+            #         $workToBeDone.generateWindowsCommands = $true
+            #     }
+            # }
+
+
+            ## Begin removal of queued commands + existing command:
+            # remove commands if necessary
+            # If ($workToBeDone.removeCommands) {
+            #     foreach ($command in $radiusCommandsByUser) {
+            #         Remove-JcSdkCommand -Id $command.id | Out-Null
+            #     }
+            # }
+            # # remove queued commands if necessary
+            # if ($workToBeDone.removeQueuedCommands) {
+            #     foreach ($queuedCommand in $queuedRadiusCommandsByUser) {
+            #         Clear-JCQueuedCommand -workflowId $queuedCommand.id | Out-Null
+            #     }
+            # }
+            # now clear out the user command associations from users.json
+            $User.commandAssociations = @()
+            #### End removal of queued commands + existing command
+
+            # write-host "____"
+            # write-host $certInfo
+            # write-host "____"
             # validate the certIfo required for installing commands:
             If (-Not $certInfo) {
                 Write-host "$($user.username) did not have a certificate generated"
@@ -73,13 +303,14 @@ function Deploy-UserCertificate {
                 $result_deployed = $false
                 continue
             } else {
-                # explicitly validate that the serial number
+                # explicitly validate that the subject header exists
                 if (-Not $certInfo.subject) {
                     Write-host "$($user.username) has a certificate file but no subject was found"
                     $status_commandGenerated = $false
                     $result_deployed = $false
                     continue
                 }
+                # explicitly validate that the serial number exists
                 if (-Not $certInfo.serial) {
                     Write-host "$($user.username) has a certificate file but no serial number was found"
                     $status_commandGenerated = $false
@@ -88,58 +319,71 @@ function Deploy-UserCertificate {
                 }
             }
 
-            # determine certType
-            switch ($JCR_CERT_TYPE) {
-                'EmailSAN' {
-                    # set cert identifier to SAN email of cert
-                    $sanID = Invoke-Expression "$JCR_OPENSSL x509 -in $($userCrt) -ext subjectAltName -noout"
-                    $regex = 'email:(.*?)$'
-                    $JCR_SUBJECT_HEADERSMatch = Select-String -InputObject "$($sanID)" -Pattern $regex
-                    $certIdentifier = $JCR_SUBJECT_HEADERSMatch.matches.Groups[1].value
-                    # in macOS search user certs by email
-                    $macCertSearch = 'e'
+            ## If we need to generate commands:
+            # Get the cert type
+            # compress the CERT
+            # upload the command
+            # Get the command ID
+            # Set the command associations
+
+            ## If we are skipping the command generation
+            # update the command associations
+
+            # Report status
+
+
+            if (($workToBeDone.forcegenerateMacOSCommands) -OR ($workToBeDone.forceGenerateWindowsCommands)) {
+                # determine certType
+                switch ($JCR_CERT_TYPE) {
+                    'EmailSAN' {
+                        # set cert identifier to SAN email of cert
+                        $sanID = Invoke-Expression "$JCR_OPENSSL x509 -in $($userCrt) -ext subjectAltName -noout"
+                        $regex = 'email:(.*?)$'
+                        $JCR_SUBJECT_HEADERSMatch = Select-String -InputObject "$($sanID)" -Pattern $regex
+                        $certIdentifier = $JCR_SUBJECT_HEADERSMatch.matches.Groups[1].value
+                        # in macOS search user certs by email
+                        $macCertSearch = 'e'
+                    }
+                    'EmailDN' {
+                        # Else set cert identifier to email of cert subject
+                        $regex = 'emailAddress=(.*?)$'
+                        $JCR_SUBJECT_HEADERSMatch = Select-String -InputObject "$($certInfo.Subject)" -Pattern $regex
+                        $certIdentifier = $JCR_SUBJECT_HEADERSMatch.matches.Groups[1].value
+                        # in macOS search user certs by email
+                        $macCertSearch = 'e'
+                    }
+                    'UsernameCn' {
+                        # if username just set cert identifier to username
+                        $certIdentifier = $($user.userName)
+                        # in macOS search user certs by common name (username)
+                        $macCertSearch = 'c'
+                    }
                 }
-                'EmailDN' {
-                    # Else set cert identifier to email of cert subject
-                    $regex = 'emailAddress=(.*?)$'
-                    $JCR_SUBJECT_HEADERSMatch = Select-String -InputObject "$($certInfo.Subject)" -Pattern $regex
-                    $certIdentifier = $JCR_SUBJECT_HEADERSMatch.matches.Groups[1].value
-                    # in macOS search user certs by email
-                    $macCertSearch = 'e'
-                }
-                'UsernameCn' {
-                    # if username just set cert identifier to username
-                    $certIdentifier = $($user.userName)
-                    # in macOS search user certs by common name (username)
-                    $macCertSearch = 'c'
-                }
+                # Create the zip
+                Compress-Archive -Path $userPfx -DestinationPath $userPfxZip -CompressionLevel NoCompression -Force
             }
-            # Create the zip
-            Compress-Archive -Path $userPfx -DestinationPath $userPfxZip -CompressionLevel NoCompression -Force
-            # Find OS of System
-            $systemTypes = $user.systemAssociations.osFamily | sort | Get-Unique
-            foreach ($systemType in $systemTypes) {
-                switch ($systemType) {
-                    'macOS' {
-                        # Get the macOS system ids
-                        $systemIds = (Get-SystemsThatNeedCertWork -userData $user -osType "macOS")
-                        if ($systemIds.count -eq 0) {
-                            continue
-                        }
-                        # Check to see if previous commands exist
-                        $Command = Get-JCCommand -name "RadiusCert-Install:$($user.userName):MacOSX"
 
-                        if ($Command.Count -ge 1) {
-                            # $confirmation = Write-Host "[status] RadiusCert-Install:$($user.userName):MacOSX command already exists, skipping..."
-                            $status_commandGenerated = $false
-                            continue
-                        }
 
-                        # Create new Command and upload the signed pfx
-                        try {
-                            $CommandBody = @{
-                                Name              = "RadiusCert-Install:$($user.userName):MacOSX"
-                                Command           = @"
+            if ($workToBeDone.forcegenerateMacOSCommands) {
+                # Get the macOS system ids
+                $systemIds = (Get-SystemsThatNeedCertWork -userData $user -osType "macOS")
+                if ($systemIds.count -eq 0) {
+                    continue
+                }
+                # # Check to see if previous commands exist
+                # $Command = Get-JCCommand -name "RadiusCert-Install:$($user.userName):MacOSX"
+
+                # if ($Command.Count -ge 1) {
+                #     # $confirmation = Write-Host "[status] RadiusCert-Install:$($user.userName):MacOSX command already exists, skipping..."
+                #     $status_commandGenerated = $false
+                #     continue
+                # }
+
+                # Create new Command and upload the signed pfx
+                try {
+                    $CommandBody = @{
+                        Name              = "RadiusCert-Install:$($user.userName):MacOSX"
+                        Command           = @"
 unzip -o /tmp/$($user.userName)-client-signed.zip -d /tmp
 chmod 755 /tmp/$($user.userName)-client-signed.pfx
 currentUser=`$(/usr/bin/stat -f%Su /dev/console)
@@ -152,413 +396,459 @@ caseMatchOrigValue=`$(shopt -p nocasematch; true)
 shopt -s nocasematch
 userCompare="$($user.localUsername)"
 if [[ "`$currentUser" ==  "`$userCompare" ]]; then
-    # restore case match type
-    `$caseMatchOrigValue
-    certs=`$(security find-certificate -a -$($macCertSearch) "$($certIdentifier)" -Z /Users/$($user.localUsername)/Library/Keychains/login.keychain)
-    regexSHA='SHA-1 hash: ([0-9A-F]{5,40})'
-    regexSN='"snbr"<blob>=0x([0-9A-F]{5,40})'
-    global_rematch() {
-        # Set local variables
-        local s=`$1 regex=`$2
-        # While string matches regex expression
-        while [[ `$s =~ `$regex ]]; do
-            # Echo out the match
-            echo "`${BASH_REMATCH[1]}"
-            # Remove the string
-            s=`${s#*"`${BASH_REMATCH[1]}"}
-        done
-    }
-    # Save results
-    # Get Text Results
-    textSHA=`$(global_rematch "`$certs" "`$regexSHA")
-    # Set as array for SHA results
-    arraySHA=(`$textSHA)
-    # Get Text Results
-    textSN=`$(global_rematch "`$certs" "`$regexSN")
-    # Set as array for SN results
-    arraySN=(`$textSN)
-    # set import var
-    import=true
-    if [[ `${#arraySN[@]} == `${#arraySHA[@]} ]]; then
-        len=`${#arraySN[@]}
-        for (( i=0; i<`$len; i++ )); do
-            if [[ `$currentCertSN == `${arraySN[`$i]} ]]; then
-                echo "Found Cert: SN: `${arraySN[`$i]} SHA: `${arraySHA[`$i]}"
-                installedCertSN=`${arraySN[`$i]}
-                installedCertSHA=`${arraySHA[`$i]}
-                # if cert is installed, no need to update
-                import=false
-            else
-                echo "Removing previously installed radius cert:"
-                echo "SN: `${arraySN[`$i]} SHA: `${arraySHA[`$i]}"
-                security delete-certificate -Z "`${arraySHA[`$i]}" /Users/$($user.localUsername)/Library/Keychains/login.keychain
-            fi
-        done
-
-    else
-        echo "array length mismatch, will not delete old certs"
-    fi
-
-    if [[ `$import == true ]]; then
-        /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security import /tmp/$($user.userName)-client-signed.pfx -x -k /Users/$($user.localUsername)/Library/Keychains/login.keychain -P $JCR_USER_CERT_PASS -T "/System/Library/SystemConfiguration/EAPOLController.bundle/Contents/Resources/eapolclient"
-        if [[ `$? -eq 0 ]]; then
-            echo "Import Success"
-            # get the SHA hash of the newly imported cert
-            installedCertSN=`$(/bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security find-certificate -$($macCertSearch) "$($certIdentifier)" -Z /Users/$($user.localUsername)/Library/Keychains/login.keychain | grep snbr | awk '{print `$1}' | sed 's/"snbr"<blob>=0x//g')
-            if [[ `$installedCertSN == `$currentCertSN ]]; then
-                installedCertSHA=`$(/bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security find-certificate -$($macCertSearch) "$($certIdentifier)" -Z /Users/$($user.localUsername)/Library/Keychains/login.keychain | grep SHA-1 | awk '{print `$3}')
-            fi
-
+# restore case match type
+`$caseMatchOrigValue
+certs=`$(security find-certificate -a -$($macCertSearch) "$($certIdentifier)" -Z /Users/$($user.localUsername)/Library/Keychains/login.keychain)
+regexSHA='SHA-1 hash: ([0-9A-F]{5,40})'
+regexSN='"snbr"<blob>=0x([0-9A-F]{5,40})'
+global_rematch() {
+    # Set local variables
+    local s=`$1 regex=`$2
+    # While string matches regex expression
+    while [[ `$s =~ `$regex ]]; do
+        # Echo out the match
+        echo "`${BASH_REMATCH[1]}"
+        # Remove the string
+        s=`${s#*"`${BASH_REMATCH[1]}"}
+    done
+}
+# Save results
+# Get Text Results
+textSHA=`$(global_rematch "`$certs" "`$regexSHA")
+# Set as array for SHA results
+arraySHA=(`$textSHA)
+# Get Text Results
+textSN=`$(global_rematch "`$certs" "`$regexSN")
+# Set as array for SN results
+arraySN=(`$textSN)
+# set import var
+import=true
+if [[ `${#arraySN[@]} == `${#arraySHA[@]} ]]; then
+    len=`${#arraySN[@]}
+    for (( i=0; i<`$len; i++ )); do
+        if [[ `$currentCertSN == `${arraySN[`$i]} ]]; then
+            echo "Found Cert: SN: `${arraySN[`$i]} SHA: `${arraySHA[`$i]}"
+            installedCertSN=`${arraySN[`$i]}
+            installedCertSHA=`${arraySHA[`$i]}
+            # if cert is installed, no need to update
+            import=false
         else
-            echo "import failed"
-            exit 4
-        fi
-    else
-        echo "cert already imported"
-    fi
-
-    # check if the cert secruity preference is set:
-    IFS=';' read -ra network <<< "`$JCR_NETWORKSSID"
-    for i in "`${network[@]}"; do
-        echo "begin setting network SSID: `$i"
-        if /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security get-identity-preference -s "com.apple.network.eap.user.identity.wlan.ssid.`$i" -Z "`$installedCertSHA"; then
-            echo "it was already set"
-        else
-            echo "certificate not linked from SSID: `$i to certSN: `$currentCertSN, setting now"
-            /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security set-identity-preference -s "com.apple.network.eap.user.identity.wlan.ssid.`$i" -Z "`$installedCertSHA"
-            if [[ `$? -eq 0 ]]; then
-            echo "SSID: `$i and certificate linked"
-            else
-                echo "Could not associate SSID: `$i and certifiacte"
-            fi
+            echo "Removing previously installed radius cert:"
+            echo "SN: `${arraySN[`$i]} SHA: `${arraySHA[`$i]}"
+            security delete-certificate -Z "`${arraySHA[`$i]}" /Users/$($user.localUsername)/Library/Keychains/login.keychain
         fi
     done
 
-    # print results
-    echo "################## Cert Install Results ##################"
-    echo "Installed Cert SN: `$installedCertSN"
-    echo "Installed Cert SHA1: `$installedCertSHA"
-    echo "##########################################################"
+else
+    echo "array length mismatch, will not delete old certs"
+fi
 
-    # Finally clean up files
-    if [[ -f "/tmp/$($user.userName)-client-signed.zip" ]]; then
-        echo "Removing Temp Zip"
-        rm "/tmp/$($user.userName)-client-signed.zip"
+if [[ `$import == true ]]; then
+    /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security import /tmp/$($user.userName)-client-signed.pfx -x -k /Users/$($user.localUsername)/Library/Keychains/login.keychain -P $JCR_USER_CERT_PASS -T "/System/Library/SystemConfiguration/EAPOLController.bundle/Contents/Resources/eapolclient"
+    if [[ `$? -eq 0 ]]; then
+        echo "Import Success"
+        # get the SHA hash of the newly imported cert
+        installedCertSN=`$(/bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security find-certificate -$($macCertSearch) "$($certIdentifier)" -Z /Users/$($user.localUsername)/Library/Keychains/login.keychain | grep snbr | awk '{print `$1}' | sed 's/"snbr"<blob>=0x//g')
+        if [[ `$installedCertSN == `$currentCertSN ]]; then
+            installedCertSHA=`$(/bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security find-certificate -$($macCertSearch) "$($certIdentifier)" -Z /Users/$($user.localUsername)/Library/Keychains/login.keychain | grep SHA-1 | awk '{print `$3}')
+        fi
+
+    else
+        echo "import failed"
+        exit 4
     fi
-    if [[ -f "/tmp/$($user.userName)-client-signed.pfx" ]]; then
-        echo "Removing Temp Pfx"
-        rm "/tmp/$($user.userName)-client-signed.pfx"
+else
+    echo "cert already imported"
+fi
+
+# check if the cert secruity preference is set:
+IFS=';' read -ra network <<< "`$JCR_NETWORKSSID"
+for i in "`${network[@]}"; do
+    echo "begin setting network SSID: `$i"
+    if /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security get-identity-preference -s "com.apple.network.eap.user.identity.wlan.ssid.`$i" -Z "`$installedCertSHA"; then
+        echo "it was already set"
+    else
+        echo "certificate not linked from SSID: `$i to certSN: `$currentCertSN, setting now"
+        /bin/launchctl asuser "`$currentUserUID" sudo -iu "`$currentUser" /usr/bin/security set-identity-preference -s "com.apple.network.eap.user.identity.wlan.ssid.`$i" -Z "`$installedCertSHA"
+        if [[ `$? -eq 0 ]]; then
+        echo "SSID: `$i and certificate linked"
+        else
+            echo "Could not associate SSID: `$i and certifiacte"
+        fi
     fi
+done
 
-    # update si table
-    # The conf file is JSON and can be parsed using JSON.parse() in a supported language.
-    conf="`$(cat /opt/jc/jcagent.conf)"
-    regex='\"systemKey\":\"([a-zA-Z0-9_]+)\"'
-    if [[ `${conf} =~ `$regex ]] ; then
-    systemKey="`${BASH_REMATCH[1]}"
-    fi
-    # get the certUUID
-    regex='\"certuuid\":\"([a-zA-Z0-9_]+)\"'
-    if [[ `${conf} =~ `$regex ]] ; then
-    certUUID="`${BASH_REMATCH[1]}"
-    fi
+# print results
+echo "################## Cert Install Results ##################"
+echo "Installed Cert SN: `$installedCertSN"
+echo "Installed Cert SHA1: `$installedCertSHA"
+echo "##########################################################"
 
-    # get the key /cert locations
-    keyLocation="/opt/jc/client.key"
-    certLocation="/opt/jc/client.crt"
-    caCertLocation="/opt/jc/ca.crt"
+# Finally clean up files
+if [[ -f "/tmp/$($user.userName)-client-signed.zip" ]]; then
+    echo "Removing Temp Zip"
+    rm "/tmp/$($user.userName)-client-signed.zip"
+fi
+if [[ -f "/tmp/$($user.userName)-client-signed.pfx" ]]; then
+    echo "Removing Temp Pfx"
+    rm "/tmp/$($user.userName)-client-signed.pfx"
+fi
 
-    # Get json certificate data from osquery and add missing windows certificate columns
-    certJson=`$(/opt/jc/bin/jcosqueryi --json "select *, '' AS sid, '' AS store, '' AS store_id, '' AS store_location, '' AS username from certificates;")
+# update si table
+# The conf file is JSON and can be parsed using JSON.parse() in a supported language.
+conf="`$(cat /opt/jc/jcagent.conf)"
+regex='\"systemKey\":\"([a-zA-Z0-9_]+)\"'
+if [[ `${conf} =~ `$regex ]] ; then
+systemKey="`${BASH_REMATCH[1]}"
+fi
+# get the certUUID
+regex='\"certuuid\":\"([a-zA-Z0-9_]+)\"'
+if [[ `${conf} =~ `$regex ]] ; then
+certUUID="`${BASH_REMATCH[1]}"
+fi
 
-    # post
-    curl --cert `$certLocation --key `$keyLocation --cacert `$caCertLocation \
-    -X POST 'https://agent.jumpcloud.com/systeminsights/snapshots/certificates' \
-    -H "x-system-id: `$systemKey" \
-    -H "x-ssl-client-dn: /CN=`$certUUID/O=JumpCloud" \
-    -H 'Content-Type: application/json' \
-    --data-raw '{
-        "data": '"`$certJson"'
-    }'
+# get the key /cert locations
+keyLocation="/opt/jc/client.key"
+certLocation="/opt/jc/client.crt"
+caCertLocation="/opt/jc/ca.crt"
+
+# Get json certificate data from osquery and add missing windows certificate columns
+certJson=`$(/opt/jc/bin/jcosqueryi --json "select *, '' AS sid, '' AS store, '' AS store_id, '' AS store_location, '' AS username from certificates;")
+
+# post
+curl --cert `$certLocation --key `$keyLocation --cacert `$caCertLocation \
+-X POST 'https://agent.jumpcloud.com/systeminsights/snapshots/certificates' \
+-H "x-system-id: `$systemKey" \
+-H "x-ssl-client-dn: /CN=`$certUUID/O=JumpCloud" \
+-H 'Content-Type: application/json' \
+--data-raw '{
+    "data": '"`$certJson"'
+}'
 
 else
-    # restore case match type
-    `$caseMatchOrigValue
-    echo "Current logged in user, `$currentUser, does not match expected certificate user. Please ensure $($user.localUsername) is signed in and retry"
-    # Finally clean up files
-    if [[ -f "/tmp/$($user.userName)-client-signed.zip" ]]; then
-        echo "Removing Temp Zip"
-        rm "/tmp/$($user.userName)-client-signed.zip"
-    fi
-    if [[ -f "/tmp/$($user.userName)-client-signed.pfx" ]]; then
-        echo "Removing Temp Pfx"
-        rm "/tmp/$($user.userName)-client-signed.pfx"
-    fi
-    exit 4
+# restore case match type
+`$caseMatchOrigValue
+echo "Current logged in user, `$currentUser, does not match expected certificate user. Please ensure $($user.localUsername) is signed in and retry"
+# Finally clean up files
+if [[ -f "/tmp/$($user.userName)-client-signed.zip" ]]; then
+    echo "Removing Temp Zip"
+    rm "/tmp/$($user.userName)-client-signed.zip"
+fi
+if [[ -f "/tmp/$($user.userName)-client-signed.pfx" ]]; then
+    echo "Removing Temp Pfx"
+    rm "/tmp/$($user.userName)-client-signed.pfx"
+fi
+exit 4
 fi
 
 "@
-                                launchType        = "trigger"
-                                User              = "000000000000000000000000"
-                                trigger           = "RadiusCertInstall"
-                                commandType       = "mac"
-                                timeout           = 600
-                                TimeToLiveSeconds = 864000
-                                files             = (New-JCCommandFile -certFilePath $userPfxZip -FileName "$($user.userName)-client-signed.zip" -FileDestination "/tmp/$($user.userName)-client-signed.zip")
-                            }
-                            $NewCommand = New-JcSdkCommand @CommandBody
-
-                            # Find newly created command and add system as target
-                            $Command = Get-JCCommand -name "RadiusCert-Install:$($user.userName):MacOSX"
-                            $systemIds | ForEach-Object { Set-JcSdkCommandAssociation -CommandId:("$($Command._id)") -Op 'add' -Type:('system') -Id:("$($_.systemId)") | Out-Null }
-                        } catch {
-                            $status_commandGenerated = $false
-                            # throw $_
-                        }
-
-                        $CommandTable = [PSCustomObject]@{
-                            commandId            = $command._id
-                            commandName          = $command.name
-                            commandPreviouslyRun = $false
-                            commandQueued        = $false
-                            systems              = $systemIds
-                        }
-
-                        $user.commandAssociations += $CommandTable
-
-                        # Write-Host "[status] Successfully created $($Command.name): User - $($user.userName); OS - Mac OS X"
-                        $status_commandGenerated = $true
-
+                        launchType        = "trigger"
+                        User              = "000000000000000000000000"
+                        trigger           = "$($certInfo.sha1)"
+                        commandType       = "mac"
+                        timeout           = 600
+                        TimeToLiveSeconds = 864000
+                        files             = (New-JCCommandFile -certFilePath $userPfxZip -FileName "$($user.userName)-client-signed.zip" -FileDestination "/tmp/$($user.userName)-client-signed.zip")
                     }
-                    'windows' {
-                        # Get the Windows system ids
-                        $systemIds = (Get-SystemsThatNeedCertWork -userData $user -osType "windows")
-                        # If there are no systemIds to process, skip generating the command:
-                        if ($systemIds.count -eq 0) {
-                            continue
-                        }
-                        # Check to see if previous commands exist
-                        $Command = Get-JCCommand -name "RadiusCert-Install:$($user.userName):Windows"
+                    $NewCommand = New-JcSdkCommand @CommandBody
 
-                        if ($Command.Count -ge 1) {
-                            # $confirmation = Write-Host "[status] RadiusCert-Install:$($user.userName):Windows command already exists, skipping..."
-                            $status_commandGenerated = $false
-                            continue
-                        }
+                    # Find newly created command and add system as target
+                    $Command = Get-JcSdkCommand -Filter @("trigger:eq:$($certInfo.sha1)", "commandType:eq:mac")
+                    $workToBeDone.macOSCommandID = $Command.Id
+                    # $systemIds | ForEach-Object {
+                    # Set-JcSdkCommandAssociation -CommandId:("$($Command.Id)") -Op 'add' -Type:('system') -Id:("$($_.systemId)") | Out-Null }
+                } catch {
+                    $status_commandGenerated = $false
+                    # throw $_
+                }
 
-                        # Create new Command and upload the signed pfx
-                        try {
-                            $CommandBody = @{
-                                Name              = "RadiusCert-Install:$($user.userName):Windows"
-                                Command           = @"
+                $CommandTable = [PSCustomObject]@{
+                    commandId            = $command.Id
+                    commandName          = $command.name
+                    commandPreviouslyRun = $false
+                    commandQueued        = $false
+                    systems              = $systemIds
+                }
+
+                $user.commandAssociations += $CommandTable
+
+                # Write-Host "[status] Successfully created $($Command.name): User - $($user.userName); OS - Mac OS X"
+                $status_commandGenerated = $true
+
+
+            }
+            if (($invokeCommands) -And ($workToBeDone.remainingMacOSDevices)) {
+                try {
+                    $commandStart = Start-JcSdkCommand -Id $workToBeDone.macOSCommandID -SystemIds $workToBeDone.remainingMacOSDevices.systemId | Out-Null
+                    $result_deployed = $true
+                } catch {
+                    $result_deployed = $false
+                }
+            }
+            # set the command associations
+            if (($workToBeDone.remainingMacOSDevices) -And ($workToBeDone.macOSCommandID)) {
+
+                $workToBeDone.remainingMacOSDevices | ForEach-Object {
+                    try {
+
+                        $commandAssociation = Set-JcSdkCommandAssociation -CommandId:("$($workToBeDone.macOSCommandID)") -Op 'add' -Type:('system') -Id:("$($_.systemId)") | Out-Null
+                    } catch {
+                        "already exists/ couldn't add" | Out-Null
+                    }
+                }
+
+            }
+            if ($workToBeDone.forceGenerateWindowsCommands) {
+                # Get the Windows system ids
+                $systemIds = (Get-SystemsThatNeedCertWork -userData $user -osType "windows")
+                # If there are no systemIds to process, skip generating the command:
+                if ($systemIds.count -eq 0) {
+                    continue
+                }
+                # Check to see if previous commands exist
+                # $Command = Get-JCCommand -name "RadiusCert-Install:$($user.userName):Windows"
+
+                # if ($Command.Count -ge 1) {
+                #     # $confirmation = Write-Host "[status] RadiusCert-Install:$($user.userName):Windows command already exists, skipping..."
+                #     $status_commandGenerated = $false
+                #     continue
+                # }
+
+                # Create new Command and upload the signed pfx
+                try {
+                    $CommandBody = @{
+                        Name              = "RadiusCert-Install:$($user.userName):Windows"
+                        Command           = @"
 `$ErrorActionPreference = "Stop"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 `$PkgProvider = Get-PackageProvider
 If ("Nuget" -notin `$PkgProvider.Name){
-    Install-PackageProvider -Name NuGet -Force
+Install-PackageProvider -Name NuGet -Force
 }
 `$CurrentUser = (Get-WMIObject -ClassName Win32_ComputerSystem).Username
 if ( -Not [string]::isNullOrEmpty(`$CurrentUser) ){
-    `$CurrentUser = `$CurrentUser.Split('\')[1]
+`$CurrentUser = `$CurrentUser.Split('\')[1]
 } else {
-    `$CurrentUser = `$null
+`$CurrentUser = `$null
 }
 if (`$CurrentUser -eq "$($user.localUsername)") {
-    if (-not(Get-InstalledModule -Name RunAsUser -errorAction "SilentlyContinue")) {
-        Write-Host "RunAsUser Module not installed, Installing..."
-        Install-Module RunAsUser -Force
-        Import-Module RunAsUser -Force
-    } else {
-        Write-Host "RunAsUser Module installed, importing into session..."
-        Import-Module RunAsUser -Force
-    }
-    # create temp new radius directory
-    If (Test-Path "C:\RadiusCert"){
-        Write-Host "Radius Temp Cert Directory Exists"
-    } else {
-        New-Item "C:\RadiusCert" -itemType Directory
-    }
-    # expand archive as root and copy to temp location
-    Expand-Archive -LiteralPath C:\Windows\Temp\$($user.userName)-client-signed.zip -DestinationPath C:\RadiusCert -Force
-    `$password = ConvertTo-SecureString -String $JCR_USER_CERT_PASS -AsPlainText -Force
-    `$ScriptBlockInstall = { `$password = ConvertTo-SecureString -String $JCR_USER_CERT_PASS -AsPlainText -Force
-    Import-PfxCertificate -Password `$password -FilePath "C:\RadiusCert\$($user.userName)-client-signed.pfx" -CertStoreLocation Cert:\CurrentUser\My
-    }
-    `$imported = Get-PfxData -Password `$password -FilePath "C:\RadiusCert\$($user.userName)-client-signed.pfx"
-    # Get Current Certs As User
-    `$ScriptBlockCleanup = {
-        `$certs = Get-ChildItem Cert:\CurrentUser\My\
+if (-not(Get-InstalledModule -Name RunAsUser -errorAction "SilentlyContinue")) {
+    Write-Host "RunAsUser Module not installed, Installing..."
+    Install-Module RunAsUser -Force
+    Import-Module RunAsUser -Force
+} else {
+    Write-Host "RunAsUser Module installed, importing into session..."
+    Import-Module RunAsUser -Force
+}
+# create temp new radius directory
+If (Test-Path "C:\RadiusCert"){
+    Write-Host "Radius Temp Cert Directory Exists"
+} else {
+    New-Item "C:\RadiusCert" -itemType Directory
+}
+# expand archive as root and copy to temp location
+Expand-Archive -LiteralPath C:\Windows\Temp\$($user.userName)-client-signed.zip -DestinationPath C:\RadiusCert -Force
+`$password = ConvertTo-SecureString -String $JCR_USER_CERT_PASS -AsPlainText -Force
+`$ScriptBlockInstall = { `$password = ConvertTo-SecureString -String $JCR_USER_CERT_PASS -AsPlainText -Force
+Import-PfxCertificate -Password `$password -FilePath "C:\RadiusCert\$($user.userName)-client-signed.pfx" -CertStoreLocation Cert:\CurrentUser\My
+}
+`$imported = Get-PfxData -Password `$password -FilePath "C:\RadiusCert\$($user.userName)-client-signed.pfx"
+# Get Current Certs As User
+`$ScriptBlockCleanup = {
+    `$certs = Get-ChildItem Cert:\CurrentUser\My\
 
-        foreach (`$cert in `$certs){
-            if (`$cert.subject -match "$($certIdentifier)") {
-                if (`$(`$cert.serialNumber) -eq "$($certInfo.serial)"){
-                    write-host "Found Cert:``nCert SN: `$(`$cert.serialNumber)"
-                } else {
-                    write-host "Removing Cert:``nCert SN: `$(`$cert.serialNumber)"
-                    Get-ChildItem "Cert:\CurrentUser\My\`$(`$cert.thumbprint)" | remove-item
-                }
+    foreach (`$cert in `$certs){
+        if (`$cert.subject -match "$($certIdentifier)") {
+            if (`$(`$cert.serialNumber) -eq "$($certInfo.serial)"){
+                write-host "Found Cert:``nCert SN: `$(`$cert.serialNumber)"
+            } else {
+                write-host "Removing Cert:``nCert SN: `$(`$cert.serialNumber)"
+                Get-ChildItem "Cert:\CurrentUser\My\`$(`$cert.thumbprint)" | remove-item
             }
         }
     }
-    `$scriptBlockValidate = {
-        if (Get-ChildItem Cert:\CurrentUser\My\`$(`$imported.thumbrprint)){
-            return `$true
-        } else {
-            return `$false
-        }
-    }
-    Write-Host "Importing Pfx Certificate for $($user.userName)"
-    `$certInstall = Invoke-AsCurrentUser -ScriptBlock `$ScriptBlockInstall -CaptureOutput
-    `$certInstall
-    Write-Host "Cleaning Up Previously Installed Certs for $($user.userName)"
-    `$certCleanup = Invoke-AsCurrentUser -ScriptBlock `$ScriptBlockCleanup -CaptureOutput
-    `$certCleanup
-    Write-Host "Validating Installed Certs for $($user.userName)"
-    `$certValidate = Invoke-AsCurrentUser -ScriptBlock `$scriptBlockValidate -CaptureOutput
-    write-host `$certValidate
-
-    # finally clean up temp files:
-    If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.zip"){
-        Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.zip"
-    }
-    If (Test-Path "C:\RadiusCert\$($user.userName)-client-signed.pfx"){
-        Remove-Item "C:\RadiusCert\$($user.userName)-client-signed.pfx"
-    }
-
-    # Lastly validate if the cert was installed
-    if (`$certValidate.Trim() -eq "True"){
-        Write-Host "Cert was installed"
+}
+`$scriptBlockValidate = {
+    if (Get-ChildItem Cert:\CurrentUser\My\`$(`$imported.thumbrprint)){
+        return `$true
     } else {
-        Throw "Cert was not installed"
+        return `$false
     }
+}
+Write-Host "Importing Pfx Certificate for $($user.userName)"
+`$certInstall = Invoke-AsCurrentUser -ScriptBlock `$ScriptBlockInstall -CaptureOutput
+`$certInstall
+Write-Host "Cleaning Up Previously Installed Certs for $($user.userName)"
+`$certCleanup = Invoke-AsCurrentUser -ScriptBlock `$ScriptBlockCleanup -CaptureOutput
+`$certCleanup
+Write-Host "Validating Installed Certs for $($user.userName)"
+`$certValidate = Invoke-AsCurrentUser -ScriptBlock `$scriptBlockValidate -CaptureOutput
+write-host `$certValidate
 
-    # update si table
-    # define curl path:
-    `$curlPath = "C:\ProgramData\chocolatey\bin\curl.exe"
-    if (Test-Path -Path `$curlPath) {
+# finally clean up temp files:
+If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.zip"){
+    Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.zip"
+}
+If (Test-Path "C:\RadiusCert\$($user.userName)-client-signed.pfx"){
+    Remove-Item "C:\RadiusCert\$($user.userName)-client-signed.pfx"
+}
 
-        # Parse the systemKey from the cong file.
-        `$config = get-content 'C:\Program Files\JumpCloud\Plugins\Contrib\jcagent.conf'
-        `$regex = 'systemKey\":\"(\w+)\"'
-        `$systemKey = [regex]::Match(`$config, `$regex).Groups[1].Value
-        # get the certUUID
-        `$regex = 'certuuid\":\"(\w+)\"'
-        `$certUUID = [regex]::Match(`$config, `$regex).Groups[1].Value
-
-        # Get the key/ cert location
-        `$keyLocation = "C:\Program Files\JumpCloud\Plugins\Contrib\client.key"
-        `$certLocation = "C:\Program Files\JumpCloud\Plugins\Contrib\client.crt"
-        `$caCertLocation = "C:\Program Files\JumpCloud\Plugins\Contrib\ca.crt"
-
-        # Get json certificate data from osquery
-        `$certs = . "C:\Program Files\JumpCloud\jcosqueryi" --json "select * from certificates"
-        # format the data
-        `$certsText = "{``"data``":`$certs}"
-        # save the data to a temp file
-        `$certJsonFile = "C:\Windows\Temp\jsonFile.txt"
-        `$certsText | Out-File -FilePath `$certJsonFile -Force -Encoding utf8
-        # submit the request
-        C:\ProgramData\chocolatey\bin\curl.exe --cert "`$certLocation" --key "`$keyLocation" --cacert "`$caCertLocation" --header "x-system-id: `$systemKey" --header "x-ssl-client-dn: /CN=`$certUUID/O=JumpCloud" --header "Content-type:application/json " -d @C:\Windows\Temp\jsonFile.txt --url 'https://agent.jumpcloud.com/systeminsights/snapshots/certificates'
-        # remove the temp file
-        Remove-Item -Path `$certJsonFile
-    } else {
-        Write-Host "Curl might not be installed, system insights will update certificate information on this device within an hour"
-    }
+# Lastly validate if the cert was installed
+if (`$certValidate.Trim() -eq "True"){
+    Write-Host "Cert was installed"
 } else {
-    if (`$CurrentUser -eq `$null){
-        Write-Host "No users are signed into the system. Please ensure $($user.userName) is signed in and retry."
-    } else {
-        Write-Host "Current logged in user, `$CurrentUser, does not match expected certificate user. Please ensure $($user.localUsername) is signed in and retry."
-    }
-    # finally clean up temp files:
-    If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.zip"){
-        Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.zip"
-    }
-    If (Test-Path "C:\RadiusCert\$($user.userName)-client-signed.pfx"){
-        Remove-Item "C:\RadiusCert\$($user.userName)-client-signed.pfx"
-    }
-    exit 4
+    Throw "Cert was not installed"
+}
+
+# update si table
+# define curl path:
+`$curlPath = "C:\ProgramData\chocolatey\bin\curl.exe"
+if (Test-Path -Path `$curlPath) {
+
+    # Parse the systemKey from the cong file.
+    `$config = get-content 'C:\Program Files\JumpCloud\Plugins\Contrib\jcagent.conf'
+    `$regex = 'systemKey\":\"(\w+)\"'
+    `$systemKey = [regex]::Match(`$config, `$regex).Groups[1].Value
+    # get the certUUID
+    `$regex = 'certuuid\":\"(\w+)\"'
+    `$certUUID = [regex]::Match(`$config, `$regex).Groups[1].Value
+
+    # Get the key/ cert location
+    `$keyLocation = "C:\Program Files\JumpCloud\Plugins\Contrib\client.key"
+    `$certLocation = "C:\Program Files\JumpCloud\Plugins\Contrib\client.crt"
+    `$caCertLocation = "C:\Program Files\JumpCloud\Plugins\Contrib\ca.crt"
+
+    # Get json certificate data from osquery
+    `$certs = . "C:\Program Files\JumpCloud\jcosqueryi" --json "select * from certificates"
+    # format the data
+    `$certsText = "{``"data``":`$certs}"
+    # save the data to a temp file
+    `$certJsonFile = "C:\Windows\Temp\jsonFile.txt"
+    `$certsText | Out-File -FilePath `$certJsonFile -Force -Encoding utf8
+    # submit the request
+    C:\ProgramData\chocolatey\bin\curl.exe --cert "`$certLocation" --key "`$keyLocation" --cacert "`$caCertLocation" --header "x-system-id: `$systemKey" --header "x-ssl-client-dn: /CN=`$certUUID/O=JumpCloud" --header "Content-type:application/json " -d @C:\Windows\Temp\jsonFile.txt --url 'https://agent.jumpcloud.com/systeminsights/snapshots/certificates'
+    # remove the temp file
+    Remove-Item -Path `$certJsonFile
+} else {
+    Write-Host "Curl might not be installed, system insights will update certificate information on this device within an hour"
+}
+} else {
+if (`$CurrentUser -eq `$null){
+    Write-Host "No users are signed into the system. Please ensure $($user.userName) is signed in and retry."
+} else {
+    Write-Host "Current logged in user, `$CurrentUser, does not match expected certificate user. Please ensure $($user.localUsername) is signed in and retry."
+}
+# finally clean up temp files:
+If (Test-Path "C:\Windows\Temp\$($user.userName)-client-signed.zip"){
+    Remove-Item "C:\Windows\Temp\$($user.userName)-client-signed.zip"
+}
+If (Test-Path "C:\RadiusCert\$($user.userName)-client-signed.pfx"){
+    Remove-Item "C:\RadiusCert\$($user.userName)-client-signed.pfx"
+}
+exit 4
 }
 "@
-                                launchType        = "trigger"
-                                trigger           = "RadiusCertInstall"
-                                commandType       = "windows"
-                                shell             = "powershell"
-                                timeout           = 600
-                                TimeToLiveSeconds = 864000
-                                files             = (New-JCCommandFile -certFilePath $userPfxZip -FileName "$($user.userName)-client-signed.zip" -FileDestination "C:\Windows\Temp\$($user.userName)-client-signed.zip")
-                            }
-                            $NewCommand = New-JcSdkCommand @CommandBody
-
-                            # Find newly created command and add system as target
-                            $Command = Get-JCCommand -name "RadiusCert-Install:$($user.userName):Windows"
-                            $systemIds | ForEach-Object {
-                                Set-JcSdkCommandAssociation -CommandId:("$($Command._id)") -Op 'add' -Type:('system') -Id:("$($_.systemId)") | Out-Null
-                            }
-                        } catch {
-                            $status_commandGenerated = $false
-                            # throw $_
-                        }
-
-                        $CommandTable = [PSCustomObject]@{
-                            commandId            = $command._id
-                            commandName          = $command.name
-                            commandPreviouslyRun = $false
-                            commandQueued        = $false
-                            systems              = $systemIds
-                        }
-
-                        $user.commandAssociations += $CommandTable
-                        # Write-Host "[status] Successfully created $($Command.name): User - $($user.userName); OS - Windows"
-                        $status_commandGenerated = $true
-
+                        launchType        = "trigger"
+                        trigger           = "$($certInfo.sha1)"
+                        commandType       = "windows"
+                        shell             = "powershell"
+                        timeout           = 600
+                        TimeToLiveSeconds = 864000
+                        files             = (New-JCCommandFile -certFilePath $userPfxZip -FileName "$($user.userName)-client-signed.zip" -FileDestination "C:\Windows\Temp\$($user.userName)-client-signed.zip")
                     }
-                    $null {
-                        Write-host "$($user.username) is not associated with any systems, skipping command generation"
-                        $status_commandGenerated = $false
-                        $result_deployed = $false
-                    }
+                    $NewCommand = New-JcSdkCommand @CommandBody
+
+                    # Find newly created command and add system as target
+                    $Command = Get-JcSdkCommand -Filter @("trigger:eq:$($certInfo.sha1)", "commandType:eq:windows")
+                    $workToBeDone.windowsCommandID = $command.Id
+                    # $systemIds | ForEach-Object {
+                    #     Set-JcSdkCommandAssociation -CommandId:("$($workToBeDone.windowsCommandID)") -Op 'add' -Type:('system') -Id:("$($_.systemId)") | Out-Null }
+                } catch {
+                    $status_commandGenerated = $false
+                    # throw $_
                 }
+
+                $CommandTable = [PSCustomObject]@{
+                    commandId            = $workToBeDone.windowsCommandID
+                    commandName          = $command.name
+                    commandPreviouslyRun = $false
+                    commandQueued        = $false
+                    systems              = $systemIds
+                }
+
+                $user.commandAssociations += $CommandTable
+                # Write-Host "[status] Successfully created $($Command.name): User - $($user.userName); OS - Windows"
+                $status_commandGenerated = $true
+
             }
-            # Update the user table with the information from the generated commands:
-            $userObjectFromTable, $userIndex = Get-UserFromTable -userid $user.userid
-
-            Set-UserTable -index $userIndex -commandAssociationsObject $user.commandAssociations
-            switch ($invokeCommands) {
-                $true {
-                    # finally update the user table to note that the command has been run, the cert has been deployed
-                    # get the object once more:
-                    $userObjectFromTable, $userIndex = Get-UserFromTable -userid $user.userid
-                    # Set commandPreviouslyRun property to true if there are command associations to set
-                    if ($userObjectFromTable.commandAssociations) {
-                        $userObjectFromTable.commandAssociations | ForEach-Object { $_.commandPreviouslyRun = $true }
-                        # set the deployed status to true, set the date
-                        if (Get-Member -inputObject $userObjectFromTable.certInfo -name "deployed" -MemberType Properties) {
-                            # if ($userObjectFromTable.certInfo.deployed) {
-                            $userObjectFromTable.certInfo.deployed = $true
-                        } else {
-                            $userObjectFromTable.certInfo | Add-Member -Name 'deployed' -Type NoteProperty -Value $false
-
-                        }
-                        if (Get-Member -inputObject $userObjectFromTable.certInfo -name "deploymentDate" -MemberType Properties) {
-                            # if ($userObjectFromTable.certInfo.deploymentDate) {
-                            $userObjectFromTable.certInfo.deploymentDate = (Get-Date)
-
-                        } else {
-
-                            $userObjectFromTable.certInfo | Add-Member -Name 'deploymentDate' -Type NoteProperty -Value (Get-Date)
-                        }
-                        Set-UserTable -index $userIndex -commandAssociationsObject $userObjectFromTable.commandAssociations -certInfoObject $userObjectFromTable.certInfo
-                        $invokeCommands = invoke-commandByUserId -userID $user.userId
-                        $result_deployed = $true
-                    }
-                }
-                $false {
+            if (($invokeCommands) -AND ($workToBeDone.remainingWindowsSDevices)) {
+                try {
+                    $commandStart = Start-JcSdkCommand -Id $workToBeDone.windowsCommandID -SystemIds $workToBeDone.remainingWindowsSDevices.systemId | Out-Null
+                    $result_deployed = $true
+                } catch {
                     $result_deployed = $false
                 }
-                Default {
+            }
+            # set the command associations
+            if (($workToBeDone.remainingWindowsSDevices) -And ($workToBeDone.windowsCommandID)) {
+                $workToBeDone.remainingWindowsSDevices | ForEach-Object {
+                    try {
+                        $commandAssociation = Set-JcSdkCommandAssociation -CommandId:("$($workToBeDone.windowsCommandID)") -Op 'add' -Type:('system') -Id:("$($_.systemId)") | Out-Null
+                    } catch {
+                        "already exists/ couldn't add" | Out-Null
+                    }
+                }
+
+            }
+        }
+        # if (($workToBeDone.generateMacOSCommands -eq $false) -AND ($workToBeDone.generateWindowsCommands -eq $false)) {
+        #     Write-host "$($user.username) is not associated with any systems, skipping command generation"
+        #     $status_commandGenerated = $false
+        #     $result_deployed = $false
+        # }
+        # TODO: return this object along with results:
+        # Update the user table with the information from the generated commands:
+        $userObjectFromTable, $userIndex = Get-UserFromTable -userid $user.userid
+
+        # Set-UserTable -index $userIndex -commandAssociationsObject $user.commandAssociations
+        switch ($invokeCommands) {
+            $true {
+                # finally update the user table to note that the command has been run, the cert has been deployed
+                # get the object once more:
+                # $userObjectFromTable, $userIndex = Get-UserFromTable -userid $user.userid
+                # Set commandPreviouslyRun property to true if there are command associations to set
+                if ($user.commandAssociations) {
+                    $user.commandAssociations | ForEach-Object { $_.commandPreviouslyRun = $true }
+                    # set the deployed status to true, set the date
+                    if (Get-Member -inputObject $user.certInfo -name "deployed" -MemberType Properties) {
+                        # if ($userObjectFromTable.certInfo.deployed) {
+                        $user.certInfo.deployed = $true
+                    } else {
+                        $user.certInfo | Add-Member -Name 'deployed' -Type NoteProperty -Value $false
+
+                    }
+                    if (Get-Member -inputObject $user.certInfo -name "deploymentDate" -MemberType Properties) {
+                        # if ($userObjectFromTable.certInfo.deploymentDate) {
+                        $user.certInfo.deploymentDate = (Get-Date)
+
+                    } else {
+                        $user.certInfo | Add-Member -Name 'deploymentDate' -Type NoteProperty -Value (Get-Date)
+                    }
+
+
+                    # Set-UserTable -index $userIndex -commandAssociationsObject $userObjectFromTable.commandAssociations -certInfoObject $userObjectFromTable.certInfo
+                    # $invokeCommands = invoke-commandByUserId -userID $user.userId -commandAssociationsObject $($user.commandAssociations)
+
+                    # Start-JcSdkCommand -Id
+                    # $result_deployed = $true
                 }
             }
+            $false {
+                $result_deployed = $false
+            }
+            Default {
+            }
+
 
 
         }
@@ -567,12 +857,23 @@ if (`$CurrentUser -eq "$($user.localUsername)") {
 
     end {
         #TODO: eventually add message if we fail to generate a command
+        # if (($status_commandGenerated)::isNullOrEmpty) {
+        #     $status_commandGenerated = $false
+        # }
+        # if (($result_deployed)::isNullOrEmpty) {
+        #     $result_deployed = $false
+        # }
         $resultTable = [ordered]@{
             'Username'          = $user.username;
             'Command Generated' = $status_commandGenerated;
             'Command Deployed'  = $result_deployed
         }
+        $workDone = [PSCustomObject]@{
+            userIndex                 = $userIndex
+            commandAssociationsObject = $user.commandAssociations
+            certInfoObject            = $user.certInfo
+        }
 
-        return $resultTable
+        return $resultTable, $workDone
     }
 }

--- a/scripts/automation/Radius/Functions/Private/Commands/Get-CommandByUsername.ps1
+++ b/scripts/automation/Radius/Functions/Private/Commands/Get-CommandByUsername.ps1
@@ -11,14 +11,14 @@ function Get-CommandByUsername {
         # define searchFilter
         $SearchFilter = @{
             searchTerm = "RadiusCert-Install:${username}:"
-            fields     = @('name')
+            fields     = @('name', 'trigger', 'commandType')
         }
 
     }
 
     process {
         # Get command Results
-        $commandResults = Search-JcSdkCommand -SearchFilter $SearchFilter -Fields name
+        $commandResults = Search-JcSdkCommand -SearchFilter $SearchFilter -Fields "name trigger commandType"
     }
 
     end {

--- a/scripts/automation/Radius/Functions/Public/Start-DeployUserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-DeployUserCerts.ps1
@@ -32,6 +32,16 @@ function Start-DeployUserCerts {
                 Show-DistributionMenu -CertObjectArray $userArray.certInfo -usersThatNeedCert $usersWithoutLatestCert.count -totalUserCount $userArray.count
                 $confirmation = Read-Host "Please make a selection"
 
+                # This can be updated later if necessary but for now if using the GUI, the $forceGenerateCommands switch will always be false
+                # Thus the GUI will never overwrite commands unless the SHA1 value does not match the local cert SHA1
+                switch ($forceGenerateCommands) {
+                    $true {
+                        $generateCommands = $true
+                    }
+                    $false {
+                        $generateCommands = $false
+                    }
+                }
             }
             'cli' {
                 $confirmationMap = @{

--- a/scripts/automation/Radius/Functions/Public/Start-DeployUserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-DeployUserCerts.ps1
@@ -60,7 +60,11 @@ function Start-DeployUserCerts {
                     }
                 }
                 for ($i = 0; $i -lt $userArray.Count; $i++) {
-                    $result = Deploy-UserCertificate -userObject $userArray[$i] -forceInvokeCommands $invokeCommands
+                    $result, $workDone = Deploy-UserCertificate -userObject $userArray[$i] -forceInvokeCommands $invokeCommands
+                    # update user json
+                    Set-UserTable -index $workDone.userIndex -commandAssociationsObject $workDone.commandAssociationsObject -certInfoObject $workDone.certInfoObject
+
+                    # show progress
                     Show-RadiusProgress -completedItems ($i + 1) -totalItems $userArray.Count -ActionText "Distributing Radius Certificates" -previousOperationResult $result
                 }
                 # return after an action if cli, else stay in function
@@ -87,7 +91,12 @@ function Start-DeployUserCerts {
                     $usersWithoutLatestCert = Get-UsersThatNeedCertWork -userData $userArray
                 }
                 for ($i = 0; $i -lt $usersWithoutLatestCert.Count; $i++) {
-                    $result = Deploy-UserCertificate -userObject $usersWithoutLatestCert[$i] -forceInvokeCommands $invokeCommands
+                    $result, $workDone = Deploy-UserCertificate -userObject $usersWithoutLatestCert[$i] -forceInvokeCommands $invokeCommands
+
+                    # update user json
+                    Set-UserTable -index $workDone.userIndex -commandAssociationsObject $workDone.commandAssociationsObject -certInfoObject $workDone.certInfoObject
+
+                    # show progress
                     Show-RadiusProgress -completedItems ($i + 1) -totalItems $usersWithoutLatestCert.Count -ActionText "Distributing Radius Certificates" -previousOperationResult $result
                 }
                 # return after an action if cli, else stay in function
@@ -133,12 +142,16 @@ function Start-DeployUserCerts {
                     # Process existing commands/ Generate new commands/ Deploy new Certificate
                     switch ($PSCmdlet.ParameterSetName) {
                         'gui' {
-                            $result = Deploy-UserCertificate -userObject $UserSelectionArray -prompt
+                            $result, $workDone = Deploy-UserCertificate -userObject $UserSelectionArray -prompt
                         }
                         'cli' {
-                            $result = Deploy-UserCertificate -userObject $UserSelectionArray -forceInvokeCommands $invokeCommands
+                            $result, $workDone = Deploy-UserCertificate -userObject $UserSelectionArray -forceInvokeCommands $invokeCommands
                         }
                     }
+                    # update user json
+                    Set-UserTable -index $workDone.userIndex -commandAssociationsObject $workDone.commandAssociationsObject -certInfoObject $workDone.certInfoObject
+
+                    # show progress
                     Show-RadiusProgress -completedItems $UserSelectionArray.count -totalItems $UserSelectionArray.Count -ActionText "Distributing Radius Certificates" -previousOperationResult $result
                 }
                 # return after an action if cli, else stay in function

--- a/scripts/automation/Radius/Functions/Public/Start-DeployUserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-DeployUserCerts.ps1
@@ -86,7 +86,7 @@ function Start-DeployUserCerts {
                 $resultArray = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
                 $workDoneArray = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
 
-                $userArray| Foreach-Object -ThrottleLimit 5 -Parallel {
+                $userArray | Foreach-Object -ThrottleLimit 20 -Parallel {
                     # set the required variables
                     $JCAPIKEY = $using:JCAPIKEY
                     $JCORGID = $using:JCORGID
@@ -118,7 +118,6 @@ function Start-DeployUserCerts {
                     # keep track of results & work done
                     $resultArray.Add($result)
                     $WorkDoneArray.Add($workDone)
-
                 }
 
                 # update the userTable:
@@ -162,7 +161,7 @@ function Start-DeployUserCerts {
                 $resultArray = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
                 $workDoneArray = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
                 # foreach user:
-                $usersWithoutLatestCert | Foreach-Object -ThrottleLimit 5 -Parallel {
+                $usersWithoutLatestCert | Foreach-Object -ThrottleLimit 20 -Parallel {
                     # set the required variables
                     $JCAPIKEY = $using:JCAPIKEY
                     $JCORGID = $using:JCORGID

--- a/scripts/automation/Radius/Functions/Public/Start-DeployUserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-DeployUserCerts.ps1
@@ -134,14 +134,6 @@ function Start-DeployUserCerts {
                     $resultItemCount++
                 }
 
-                # for ($i = 0; $i -lt $userArray.Count; $i++) {
-                #     $result, $workDone = Deploy-UserCertificate -userObject $userArray[$i] -forceInvokeCommands $invokeCommands -forceGenerateCommands $generateCommands
-                #     # update user json
-                #     Set-UserTable -index $workDone.userIndex -commandAssociationsObject $workDone.commandAssociationsObject -certInfoObject $workDone.certInfoObject
-
-                #     # show progress
-                #     Show-RadiusProgress -completedItems ($i + 1) -totalItems $userArray.Count -ActionText "Distributing Radius Certificates" -previousOperationResult $result
-                # }
                 # return after an action if cli, else stay in function
                 switch ($PSCmdlet.ParameterSetName) {
                     'gui' {

--- a/scripts/automation/Radius/Functions/Public/Start-DeployUserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-DeployUserCerts.ps1
@@ -14,7 +14,11 @@ function Start-DeployUserCerts {
         # Force invoke commands after generation
         [Parameter(HelpMessage = 'Switch to force invoke generated commands on systems', ParameterSetName = 'cli')]
         [switch]
-        $forceInvokeCommands
+        $forceInvokeCommands,
+        # Force invoke commands after generation
+        [Parameter(HelpMessage = 'Switch to force generate new commands on systems', ParameterSetName = 'cli')]
+        [switch]
+        $forceGenerateCommands
     )
 
     # Import the users.json file and convert to PSObject
@@ -45,6 +49,14 @@ function Start-DeployUserCerts {
                         $invokeCommands = $false
                     }
                 }
+                switch ($forceGenerateCommands) {
+                    $true {
+                        $generateCommands = $true
+                    }
+                    $false {
+                        $generateCommands = $false
+                    }
+                }
             }
         }
 
@@ -60,7 +72,7 @@ function Start-DeployUserCerts {
                     }
                 }
                 for ($i = 0; $i -lt $userArray.Count; $i++) {
-                    $result, $workDone = Deploy-UserCertificate -userObject $userArray[$i] -forceInvokeCommands $invokeCommands
+                    $result, $workDone = Deploy-UserCertificate -userObject $userArray[$i] -forceInvokeCommands $invokeCommands -forceGenerateCommands $generateCommands
                     # update user json
                     Set-UserTable -index $workDone.userIndex -commandAssociationsObject $workDone.commandAssociationsObject -certInfoObject $workDone.certInfoObject
 
@@ -91,7 +103,7 @@ function Start-DeployUserCerts {
                     $usersWithoutLatestCert = Get-UsersThatNeedCertWork -userData $userArray
                 }
                 for ($i = 0; $i -lt $usersWithoutLatestCert.Count; $i++) {
-                    $result, $workDone = Deploy-UserCertificate -userObject $usersWithoutLatestCert[$i] -forceInvokeCommands $invokeCommands
+                    $result, $workDone = Deploy-UserCertificate -userObject $usersWithoutLatestCert[$i] -forceInvokeCommands $invokeCommands -forceGenerateCommands $generateCommands
 
                     # update user json
                     Set-UserTable -index $workDone.userIndex -commandAssociationsObject $workDone.commandAssociationsObject -certInfoObject $workDone.certInfoObject
@@ -145,7 +157,7 @@ function Start-DeployUserCerts {
                             $result, $workDone = Deploy-UserCertificate -userObject $UserSelectionArray -prompt
                         }
                         'cli' {
-                            $result, $workDone = Deploy-UserCertificate -userObject $UserSelectionArray -forceInvokeCommands $invokeCommands
+                            $result, $workDone = Deploy-UserCertificate -userObject $UserSelectionArray -forceInvokeCommands $invokeCommands -forceGenerateCommands $generateCommands
                         }
                     }
                     # update user json

--- a/scripts/automation/Radius/JumpCloud-Radius.psm1
+++ b/scripts/automation/Radius/JumpCloud-Radius.psm1
@@ -28,7 +28,7 @@ $global:JCScriptRoot = "$PSScriptRoot"
 # try to get the settings file, create new one if it does not exist:
 $global:JCRConfig = Get-JCRSettingsFile
 
-# if the Certs / UserCerts directories do not exist, create thenm
+# if the Certs / UserCerts directories do not exist, create them
 if (-Not (Test-Path -Path "$JCScriptRoot/Cert" -PathType Container)) {
     New-Item -Path "$JCScriptRoot/Cert" -ItemType Directory
 }

--- a/scripts/automation/Radius/Tests/Public/Get-JCRGlobalVars.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Get-JCRGlobalVars.Tests.ps1
@@ -17,6 +17,7 @@ Describe "Get Global Variable Data Tests" -Tag "Cache" {
                 Write-Error -Message "Failed to import function $($Import.FullName): $_"
             }
         }
+        Start-GenerateRootCert -certKeyPassword "TestCertificate123!@#"
     }
     Context "When no 'data' directory exists" {
         BeforeAll {

--- a/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
@@ -315,8 +315,175 @@ Describe 'Distribute User Cert Tests' -Tag 'Distribute' {
         }
     }
     Context 'Duplicate Command / Command Result Tests' {
-        It 'When a duplicate commands with differing trigger SHA1 hashes exists, the command with the old SHA1 hash should be removed' {}
-        It 'When a duplicate commands with the same trigger SHA1 hashes exists, duplicate commands should be removed, only one should remain' {}
+        It 'When a duplicate commands with differing trigger SHA1 hashes exists, the command with the old SHA1 hash should be removed' {
+            # create a user that has both a mac and windows association
+            $user = New-RandomUser -Domain "pesterRadius" | New-JCUser
+            $dateBefore = (Get-Date).ToString('MM/dd/yyyy HH:mm:ss')
+            # add user to membership group
+            Add-JCUserGroupMember -GroupID $Global:JCR_USER_GROUP -UserID $user.id
+            # get random system
+            $windowsSystem = Get-JCSystem -os windows | Get-Random -Count 1
+            $macSystem = Get-JCSystem -os "Mac OS X" | Get-Random -Count 1
+            Add-JCSystemUser -UserID $user.id -SystemID $windowsSystem.id
+            Add-JCSystemUser -UserID $user.id -SystemID $macSystem.id
+
+            # update membership
+            Get-JCRGlobalVars -skipAssociation -force
+            # todo: manually update association table to account for new membership
+            Set-JCRAssociationHash -userId $user.id
+            Update-JCRUsersJson
+
+            # Generate a user certificate for the user:
+            Start-GenerateUserCerts -type ByUsername -username $user.username
+
+            # Get the SHA1 hash for the user's cert:
+            $certData = Get-CertInfo -userCerts -username $user.username
+
+            $oldSha = "$($certData.sha1)1111"
+            # Mock some commands with the trigger to already exist if they do not exist
+            $macCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):MacOSX"
+                Command           = "sha1234"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($oldSha)"
+                commandType       = "mac"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newMacCommand = New-JcSdkCommand @macCommandBody
+            $macCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($oldSha)", "commandType:eq:mac")
+
+            # invoke the commands manually to simulate the command queue containing items:
+            Start-JcSdkCommand -Id $macCmdBefore.Id -SystemIds $macSystem.id
+
+            $windowsCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):Windows"
+                Command           = "sha1234"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($oldSha)"
+                commandType       = "windows"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newWindowsCommand = New-JcSdkCommand @windowsCommandBody
+            $windowsCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($oldSha)", "commandType:eq:windows")
+
+            # invoke the commands manually to simulate the command queue containing items:
+            Start-JcSdkCommand -Id $WindowsCmdBefore.Id -SystemIds $windowsSystem.id
+
+            # Get the queued commands:
+            $queuedCmdsBefore = Get-QueuedCommandByUser -username $user.username
+
+            # Run Start Deploy User Certs by username
+            Start-DeployUserCerts -type ByUsername -username $user.username
+
+            # After running, validate that the commands before execution, no longer exist
+            $macCmdAfter = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:mac")
+            $windowsCmdAfter = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:windows")
+            # Get the queued after:
+            $queuedCmdsAfter = Get-QueuedCommandByUser -username $user.username
+            # test that the commands should not exist:
+            $macCmdAfter.id | Should -Not -Contain $macCmdBefore.id
+            $windowsCmdAfter.id | Should -Not -Contain $windowsCmdBefore.id
+            $macCmdAfter | Should -Not -BeNullOrEmpty
+            $windowsCmdAfter | Should -Not -BeNullOrEmpty
+            { Get-JcSdkCommand -Id $macCmdBefore.id } | Should -Throw # in other words the command should not exist
+            { Get-JcSdkCommand -Id $windowsCmdBefore.id } | Should -Throw # in other words the command should not exist
+            # test that the queued commands should not exist:
+            $queuedCmdsAfter.id | Should -Not -Contain $queuedCmdsBefore.Id
+            $queuedCmdsAfter.id | Should -BeNullOrEmpty
+            # user.json should have the newID in command associations.
+            $allUserData = Get-UserJsonData
+            $testUserData = $allUserData | Where-Object { $_.username -eq $user.username }
+            $testUserData.commandAssociations.commandId | Should -Not -Contain $macCmdBefore.id
+            $testUserData.commandAssociations.commandId | Should -Not -Contain $windowsCmdBefore.id
+        }
+        It 'When a single command with the same trigger SHA1 hashes exists, no cert should be generated' {
+            # create a user that has both a mac and windows association
+            $user = New-RandomUser -Domain "pesterRadius" | New-JCUser
+            $dateBefore = (Get-Date).ToString('MM/dd/yyyy HH:mm:ss')
+            # add user to membership group
+            Add-JCUserGroupMember -GroupID $Global:JCR_USER_GROUP -UserID $user.id
+            # get random system
+            $windowsSystem = Get-JCSystem -os windows | Get-Random -Count 1
+            $macSystem = Get-JCSystem -os "Mac OS X" | Get-Random -Count 1
+            Add-JCSystemUser -UserID $user.id -SystemID $windowsSystem.id
+            Add-JCSystemUser -UserID $user.id -SystemID $macSystem.id
+
+            # update membership
+            Get-JCRGlobalVars -skipAssociation -force
+            # todo: manually update association table to account for new membership
+            Set-JCRAssociationHash -userId $user.id
+            Update-JCRUsersJson
+
+            # Generate a user certificate for the user:
+            Start-GenerateUserCerts -type ByUsername -username $user.username
+
+            # Get the SHA1 hash for the user's cert:
+            $certData = Get-CertInfo -userCerts -username $user.username
+            # Mock some commands with the trigger to already exist if they do not exist
+            $macCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):MacOSX"
+                Command           = "sha1234"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($certData.sha1)"
+                commandType       = "mac"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newMacCommand = New-JcSdkCommand @macCommandBody
+            $macCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:mac")
+
+            # invoke the commands manually to simulate the command queue containing items:
+            Start-JcSdkCommand -Id $macCmdBefore.Id -SystemIds $macSystem.id
+
+            $windowsCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):Windows"
+                Command           = "sha1234"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($certData.sha1)"
+                commandType       = "windows"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newWindowsCommand = New-JcSdkCommand @windowsCommandBody
+            $windowsCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:windows")
+
+            # invoke the commands manually to simulate the command queue containing items:
+            Start-JcSdkCommand -Id $WindowsCmdBefore.Id -SystemIds $windowsSystem.id
+
+            # Get the queued commands:
+            $queuedCmdsBefore = Get-QueuedCommandByUser -username $user.username
+
+            # Run Start Deploy User Certs by username
+            Start-DeployUserCerts -type ByUsername -username $user.username
+
+            # After running, validate that the commands before execution, no longer exist
+            $macCmdAfter = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:mac")
+            $windowsCmdAfter = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:windows")
+            # Get the queued after:
+            $queuedCmdsAfter = Get-QueuedCommandByUser -username $user.username
+            # test that the commands should not exist:
+            $macCmdAfter.id | Should -Contain $macCmdBefore.id
+            $windowsCmdAfter.id | Should -Contain $windowsCmdBefore.id
+            $macCmdAfter | Should -Not -BeNullOrEmpty
+            $windowsCmdAfter | Should -Not -BeNullOrEmpty
+            { Get-JcSdkCommand -Id $macCmdBefore.id } | Should -Not -Throw # in other words the command should not exist
+            { Get-JcSdkCommand -Id $windowsCmdBefore.id } | Should -Not -Throw # in other words the command should not exist
+            # test that the queued commands should not exist:
+            $queuedCmdsAfter.id | Should -Not -Contain $queuedCmdsBefore.Id
+            $queuedCmdsAfter.id | Should -BeNullOrEmpty
+            # user.json should have the newID in command associations.
+            $allUserData = Get-UserJsonData
+            $testUserData = $allUserData | Where-Object { $_.username -eq $user.username }
+            $testUserData.commandAssociations.commandId | Should -Contain $macCmdBefore.id
+            $testUserData.commandAssociations.commandId | Should -Contain $windowsCmdBefore.id
+
+        }
     }
     Context 'Force Generate Certificate Tests' {
         It 'When forceGenerate switch is specified, the existing commands & queued commands should be removed' {
@@ -391,6 +558,8 @@ Describe 'Distribute User Cert Tests' -Tag 'Distribute' {
             # test that the commands should not exist:
             $macCmdAfter.id | Should -Not -Contain $macCmdBefore.id
             $windowsCmdAfter.id | Should -Not -Contain $windowsCmdBefore.id
+            $macCmdAfter | Should -Not -BeNullOrEmpty
+            $windowsCmdAfter | Should -Not -BeNullOrEmpty
             { Get-JcSdkCommand -Id $macCmdBefore.id } | Should -Throw # in other words the command should not exist
             { Get-JcSdkCommand -Id $windowsCmdBefore.id } | Should -Throw # in other words the command should not exist
             # test that the queued commands should not exist:
@@ -473,6 +642,8 @@ Describe 'Distribute User Cert Tests' -Tag 'Distribute' {
             # test that the commands should not exist:
             $macCmdAfter.id | Should -Not -Contain $macCmdBefore.id
             $windowsCmdAfter.id | Should -Not -Contain $windowsCmdBefore.id
+            $macCmdAfter | Should -Not -BeNullOrEmpty
+            $windowsCmdAfter | Should -Not -BeNullOrEmpty
             { Get-JcSdkCommand -Id $macCmdBefore.id } | Should -Throw # in other words the command should not exist
             { Get-JcSdkCommand -Id $windowsCmdBefore.id } | Should -Throw # in other words the command should not exist
             # test that the queued commands should not exist:

--- a/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
@@ -314,4 +314,175 @@ Describe 'Distribute User Cert Tests' -Tag 'Distribute' {
             $content -replace ('\$Global:JCR_CERT_TYPE = *.+', '$Global:JCR_CERT_TYPE = "UsernameCn"') | Set-Content -Path $configPath
         }
     }
+    Context 'Duplicate Command / Command Result Tests' {
+        It 'When a duplicate commands with differing trigger SHA1 hashes exists, the command with the old SHA1 hash should be removed' {}
+        It 'When a duplicate commands with the same trigger SHA1 hashes exists, duplicate commands should be removed, only one should remain' {}
+    }
+    Context 'Force Generate Certificate Tests' {
+        It 'When forceGenerate switch is specified, the existing commands & queued commands should be removed' {
+            # create a user that has both a mac and windows association
+            $user = New-RandomUser -Domain "pesterRadius" | New-JCUser
+            $dateBefore = (Get-Date).ToString('MM/dd/yyyy HH:mm:ss')
+            # add user to membership group
+            Add-JCUserGroupMember -GroupID $Global:JCR_USER_GROUP -UserID $user.id
+            # get random system
+            $windowsSystem = Get-JCSystem -os windows | Get-Random -Count 1
+            $macSystem = Get-JCSystem -os "Mac OS X" | Get-Random -Count 1
+            Add-JCSystemUser -UserID $user.id -SystemID $windowsSystem.id
+            Add-JCSystemUser -UserID $user.id -SystemID $macSystem.id
+
+            # update membership
+            Get-JCRGlobalVars -skipAssociation -force
+            # todo: manually update association table to account for new membership
+            Set-JCRAssociationHash -userId $user.id
+            Update-JCRUsersJson
+
+            # Generate a user certificate for the user:
+            Start-GenerateUserCerts -type ByUsername -username $user.username
+
+            # Get the SHA1 hash for the user's cert:
+            $certData = Get-CertInfo -userCerts -username $user.username
+
+            # Mock some commands with the trigger to already exist if they do not exist
+            $macCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):MacOSX"
+                Command           = "sha1234"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($certData.sha1)"
+                commandType       = "mac"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newMacCommand = New-JcSdkCommand @macCommandBody
+            $macCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:mac")
+
+            # invoke the commands manually to simulate the command queue containing items:
+            Start-JcSdkCommand -Id $macCmdBefore.Id -SystemIds $macSystem.id
+
+            $windowsCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):Windows"
+                Command           = "sha1234"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($certData.sha1)"
+                commandType       = "windows"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newWindowsCommand = New-JcSdkCommand @windowsCommandBody
+            $windowsCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:windows")
+
+            # invoke the commands manually to simulate the command queue containing items:
+            Start-JcSdkCommand -Id $WindowsCmdBefore.Id -SystemIds $windowsSystem.id
+
+            # Get the queued commands:
+            $queuedCmdsBefore = Get-QueuedCommandByUser -username $user.username
+
+            # Run Start Deploy User Certs by username
+            Start-DeployUserCerts -type ByUsername -username $user.username -forceGenerateCommands
+
+
+            # After running, validate that the commands before execution, no longer exist
+            $macCmdAfter = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:mac")
+            $windowsCmdAfter = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:windows")
+            # Get the queued after:
+            $queuedCmdsAfter = Get-QueuedCommandByUser -username $user.username
+            # test that the commands should not exist:
+            $macCmdAfter.id | Should -Not -Contain $macCmdBefore.id
+            $windowsCmdAfter.id | Should -Not -Contain $windowsCmdBefore.id
+            { Get-JcSdkCommand -Id $macCmdBefore.id } | Should -Throw # in other words the command should not exist
+            { Get-JcSdkCommand -Id $windowsCmdBefore.id } | Should -Throw # in other words the command should not exist
+            # test that the queued commands should not exist:
+            $queuedCmdsAfter.id | Should -Not -Contain $queuedCmdsBefore.Id
+            $queuedCmdsAfter.id | Should -BeNullOrEmpty
+            # user.json should have the newID in command associations.
+            $allUserData = Get-UserJsonData
+            $testUserData = $allUserData | Where-Object { $_.username -eq $user.username }
+            $testUserData.commandAssociations.commandId | Should -Not -Contain $macCmdBefore.id
+            $testUserData.commandAssociations.commandId | Should -Not -Contain $windowsCmdBefore.id
+        }
+        It 'When forceGenerate & forceInvoke switches are specified, the existing commands & queued commands should be removed; new commands queues should be queued' {
+            # create a user that has both a mac and windows association
+            $user = New-RandomUser -Domain "pesterRadius" | New-JCUser
+            $dateBefore = (Get-Date).ToString('MM/dd/yyyy HH:mm:ss')
+            # add user to membership group
+            Add-JCUserGroupMember -GroupID $Global:JCR_USER_GROUP -UserID $user.id
+            # get random system
+            $windowsSystem = Get-JCSystem -os windows | Get-Random -Count 1
+            $macSystem = Get-JCSystem -os "Mac OS X" | Get-Random -Count 1
+            Add-JCSystemUser -UserID $user.id -SystemID $windowsSystem.id
+            Add-JCSystemUser -UserID $user.id -SystemID $macSystem.id
+
+            # update membership
+            Get-JCRGlobalVars -skipAssociation -force
+            # todo: manually update association table to account for new membership
+            Set-JCRAssociationHash -userId $user.id
+            Update-JCRUsersJson
+
+            # Generate a user certificate for the user:
+            Start-GenerateUserCerts -type ByUsername -username $user.username
+
+            # Get the SHA1 hash for the user's cert:
+            $certData = Get-CertInfo -userCerts -username $user.username
+
+            # Mock some commands with the trigger to already exist if they do not exist
+            $macCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):MacOSX"
+                Command           = "sha1234"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($certData.sha1)"
+                commandType       = "mac"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newMacCommand = New-JcSdkCommand @macCommandBody
+            $macCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:mac")
+
+            # invoke the commands manually to simulate the command queue containing items:
+            Start-JcSdkCommand -Id $macCmdBefore.Id -SystemIds $macSystem.id
+
+            $windowsCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):Windows"
+                Command           = "sha1234"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($certData.sha1)"
+                commandType       = "windows"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newWindowsCommand = New-JcSdkCommand @windowsCommandBody
+            $windowsCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:windows")
+
+            # invoke the commands manually to simulate the command queue containing items:
+            Start-JcSdkCommand -Id $WindowsCmdBefore.Id -SystemIds $windowsSystem.id
+
+            # Get the queued commands:
+            $queuedCmdsBefore = Get-QueuedCommandByUser -username $user.username
+
+            # Run Start Deploy User Certs by username
+            Start-DeployUserCerts -type ByUsername -username $user.username -forceGenerateCommands -forceInvokeCommands
+
+            # After running, validate that the commands before execution, no longer exist
+            $macCmdAfter = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:mac")
+            $windowsCmdAfter = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:windows")
+            # Get the queued after:
+            $queuedCmdsAfter = Get-QueuedCommandByUser -username $user.username
+            # test that the commands should not exist:
+            $macCmdAfter.id | Should -Not -Contain $macCmdBefore.id
+            $windowsCmdAfter.id | Should -Not -Contain $windowsCmdBefore.id
+            { Get-JcSdkCommand -Id $macCmdBefore.id } | Should -Throw # in other words the command should not exist
+            { Get-JcSdkCommand -Id $windowsCmdBefore.id } | Should -Throw # in other words the command should not exist
+            # test that the queued commands should not exist:
+            $queuedCmdsAfter.id | Should -Not -Contain $queuedCmdsBefore.Id
+            $queuedCmdsAfter.id | Should -Not -BeNullOrEmpty
+            # user.json should have the newID in command associations.
+            $allUserData = Get-UserJsonData
+            $testUserData = $allUserData | Where-Object { $_.username -eq $user.username }
+            $testUserData.commandAssociations.commandId | Should -Not -Contain $macCmdBefore.id
+            $testUserData.commandAssociations.commandId | Should -Not -Contain $windowsCmdBefore.id
+        }
+    }
 }

--- a/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
@@ -400,7 +400,7 @@ Describe 'Distribute User Cert Tests' -Tag 'Distribute' {
             $testUserData.commandAssociations.commandId | Should -Not -Contain $macCmdBefore.id
             $testUserData.commandAssociations.commandId | Should -Not -Contain $windowsCmdBefore.id
         }
-        It 'When a single command with the same trigger SHA1 hashes exists, no cert should be generated' {
+        It 'When a single command with the same trigger SHA1 hashes exists, a new cert command should not should be generated' {
             # create a user that has both a mac and windows association
             $user = New-RandomUser -Domain "pesterRadius" | New-JCUser
             $dateBefore = (Get-Date).ToString('MM/dd/yyyy HH:mm:ss')
@@ -483,6 +483,114 @@ Describe 'Distribute User Cert Tests' -Tag 'Distribute' {
             $testUserData.commandAssociations.commandId | Should -Contain $macCmdBefore.id
             $testUserData.commandAssociations.commandId | Should -Contain $windowsCmdBefore.id
 
+        }
+        It 'When duplicate commands with the same trigger SHA1 hashes exists, one should be removed, a new command should not be generated' {
+            # create a user that has both a mac and windows association
+            $user = New-RandomUser -Domain "pesterRadius" | New-JCUser
+            $dateBefore = (Get-Date).ToString('MM/dd/yyyy HH:mm:ss')
+            # add user to membership group
+            Add-JCUserGroupMember -GroupID $Global:JCR_USER_GROUP -UserID $user.id
+            # get random system
+            $windowsSystem = Get-JCSystem -os windows | Get-Random -Count 1
+            $macSystem = Get-JCSystem -os "Mac OS X" | Get-Random -Count 1
+            Add-JCSystemUser -UserID $user.id -SystemID $windowsSystem.id
+            Add-JCSystemUser -UserID $user.id -SystemID $macSystem.id
+
+            # update membership
+            Get-JCRGlobalVars -skipAssociation -force
+            # todo: manually update association table to account for new membership
+            Set-JCRAssociationHash -userId $user.id
+            Update-JCRUsersJson
+
+            # Generate a user certificate for the user:
+            Start-GenerateUserCerts -type ByUsername -username $user.username
+
+            # Get the SHA1 hash for the user's cert:
+            $certData = Get-CertInfo -userCerts -username $user.username
+            # Mock some commands with the trigger to already exist if they do not exist
+            $macCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):MacOSX"
+                Command           = "sha1234"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($certData.sha1)"
+                commandType       = "mac"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newMacCommand = New-JcSdkCommand @macCommandBody
+            $macCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:mac")
+            $macCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):MacOSX"
+                Command           = "sha12345"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($certData.sha1)"
+                commandType       = "mac"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newMacCommand = New-JcSdkCommand @macCommandBody
+            $secondMacCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:mac")
+            $secondMacCmdBefore.count | Should -BeGreaterThan 1
+
+            # invoke the commands manually to simulate the command queue containing items:
+            Start-JcSdkCommand -Id $macCmdBefore.Id -SystemIds $macSystem.id
+
+            $windowsCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):Windows"
+                Command           = "sha1234"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($certData.sha1)"
+                commandType       = "windows"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newWindowsCommand = New-JcSdkCommand @windowsCommandBody
+            $windowsCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:windows")
+            $windowsCommandBody = @{
+                Name              = "RadiusCert-Install:$($user.username):Windows"
+                Command           = "sha12345"
+                launchType        = "trigger"
+                User              = "000000000000000000000000"
+                trigger           = "$($certData.sha1)"
+                commandType       = "windows"
+                timeout           = 600
+                TimeToLiveSeconds = 864000
+            }
+            $newWindowsCommand = New-JcSdkCommand @windowsCommandBody
+            $secondWindowsCmdBefore = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:windows")
+            $secondWindowsCmdBefore.count | Should -BeGreaterThan 1
+
+            # invoke the commands manually to simulate the command queue containing items:
+            Start-JcSdkCommand -Id $WindowsCmdBefore.Id -SystemIds $windowsSystem.id
+
+            # Get the queued commands:
+            $queuedCmdsBefore = Get-QueuedCommandByUser -username $user.username
+
+            # Run Start Deploy User Certs by username
+            Start-DeployUserCerts -type ByUsername -username $user.username
+
+            # After running, validate that the commands before execution, no longer exist
+            $macCmdAfter = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:mac")
+            $windowsCmdAfter = Get-JcSdkCommand -Filter @("trigger:eq:$($certData.sha1)", "commandType:eq:windows")
+            # Get the queued after:
+            $queuedCmdsAfter = Get-QueuedCommandByUser -username $user.username
+            # test that one of the commands should exist:
+            $macCmdBefore.id | Should -BeIn $macCmdAfter.id
+            $macCmdAfter.count | Should -Be 1
+            $windowsCmdBefore.id | Should -BeIn $windowsCmdAfter.id
+            $windowsCmdAfter.count | Should -Be 1
+
+            # test that the queued commands should not exist:
+            $queuedCmdsAfter.id | Should -Not -Contain $queuedCmdsBefore.Id
+            $queuedCmdsAfter.id | Should -BeNullOrEmpty
+            # user.json should have the newID in command associations.
+            $allUserData = Get-UserJsonData
+            $testUserData = $allUserData | Where-Object { $_.username -eq $user.username }
+            $macCmdBefore.id | Should -BeIn $testUserData.commandAssociations.commandId
+            $windowsCmdBefore.id | Should -BeIn $testUserData.commandAssociations.commandId
         }
     }
     Context 'Force Generate Certificate Tests' {

--- a/scripts/automation/Radius/Tests/SetupRadiusOrg.ps1
+++ b/scripts/automation/Radius/Tests/SetupRadiusOrg.ps1
@@ -16,6 +16,13 @@ foreach ($user in $pesterRadiusUsers) {
 Write-Warning "Removing Pester Radius Users with emailDomain: *pesterRadius*"
 $usersToRemove = Get-JCuser -email "*pesterRadius*" | Remove-JCUser -force
 
+# remove existing radius commands in test:
+Write-Warning "Removing Pester Radius Commands"
+$commandsToRemove = Get-JCCommand -Name "RadiusCert-Install:*"
+foreach ($commandToRemove in $commandsToRemove) {
+    Remove-JCCommand -CommandID $commandToRemove._id -force
+}
+
 # Create users
 Write-Warning "Creating New Pester Radius Users"
 # user bound to mac

--- a/scripts/automation/Radius/Tests/SetupRadiusOrg.ps1
+++ b/scripts/automation/Radius/Tests/SetupRadiusOrg.ps1
@@ -79,4 +79,5 @@ if ($IsMacOS) {
     $configContent -replace ('\$Global:JCR_OPENSSL = *.+', "`$Global:JCR_OPENSSL = `"$($brewListBinary)`"") | Set-Content -Path $configPath
 }
 
+$env:certKeyPassword = "TestCertificate123!@#"
 Import-Module "$psscriptRoot/../JumpCloud-Radius.psd1" -Force

--- a/scripts/automation/Radius/Tests/SetupRadiusOrg.ps1
+++ b/scripts/automation/Radius/Tests/SetupRadiusOrg.ps1
@@ -20,7 +20,7 @@ $usersToRemove = Get-JCuser -email "*pesterRadius*" | Remove-JCUser -force
 Write-Warning "Removing Pester Radius Commands"
 $commandsToRemove = Get-JCCommand -Name "RadiusCert-Install:*"
 foreach ($commandToRemove in $commandsToRemove) {
-    Remove-JCCommand -CommandID $commandToRemove._id -force
+    Remove-JCCommand -CommandID $commandToRemove._id -force | out-null
 }
 
 # Create users


### PR DESCRIPTION
## Issues
* [CUT-4309](https://jumpcloud.atlassian.net/browse/CUT-4309) - Update Deploy-UserCertificate Functions to generate certs on SHA match

## What does this solve?

This release aims to reduce the amount of time required to generate and deploy certificates for users. In previous iterations of this script, the tool would generate a new command each time the script was run for each user. This version changes the command "trigger" to the SHA1 hash of a user's certificate and compares that value when running Start-DeployUserCerts.

This release also introduces a multi-threaded operation when the tool generates commands for "new" or "all" users in the radiusMembers list. 

## Is there anything particularly tricky?

## How should this be tested?

Functionality for the changes should be already covered in our Pester tests for this module. To validate the changes in this pull request. Pull the branch, open up the `scripts/automation/Radius` directory in a PowerShell session and run the pester tests on one of our Pester Tests orgs: 

./tests/Invoke-Pester.ps1 -JumpCloudApiKey {YourPesterTestAPIKey}

![Screenshot 2024-10-21 at 1 35 57 PM](https://github.com/user-attachments/assets/71a31b2d-1abe-453c-8160-73feb65448ea)

In terms of updating from a previous version of the 2.0.0 development branch of radius certs:

- simply running this new version will generate new cert commands for each user, these new commands will have a trigger containing the SHA1 value of the user's cert. Subsequent times the script is run, commands for those users will not explicitly be re-generated unless the `$forceGenerateCommands` parameter is specified.

Before:
![Screenshot 2024-10-11 at 1 56 47 PM](https://github.com/user-attachments/assets/91e33b18-cfe4-4812-8b2c-c0d9e527fb36)

After:
![Screenshot 2024-10-11 at 1 57 00 PM](https://github.com/user-attachments/assets/4a83f5e4-435c-43ed-9c7a-a9aeb72bc8e9)

## Screenshots

Preliminary testing indicates that this version of the script runs about 47% faster than the previous version. 

Newest version (running threads in parallel to generate commands)
![Screenshot 2024-10-21 at 1 16 11 PM](https://github.com/user-attachments/assets/ccff29b3-25c4-4247-a344-7bc676d2865e)
Previous version (running single threaded and in sequence to generate commands)
![Screenshot 2024-10-21 at 1 34 49 PM](https://github.com/user-attachments/assets/441c72be-a17f-4089-ae78-e0d5eba5dc68)




[CUT-4309]: https://jumpcloud.atlassian.net/browse/CUT-4309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ