### PR TITLE
CUT-4490-ImportUpdate CSV Bug Fix

### DIFF
--- a/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Import-JCUsersFromCSV.ps1
+++ b/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Import-JCUsersFromCSV.ps1
@@ -369,13 +369,7 @@ Function Import-JCUsersFromCSV () {
             $FormatGroupOutput = $Null
             $CustomGroupArrayList = $Null
 
-            # Get custom attributes with definitions that are not null
-            $CustomAttributes = $UserAdd | Get-Member | Where-Object Name -Like "*Attribute*" | Where-Object { $_.Definition -NotLike "*=" -and $_.Definition -NotLike "*null" }
-
-            # Sort the custom attributes by name
-            $CustomAttributes = $CustomAttributes | Sort-Object {
-                [int]([regex]::Match($_.Name, '\d+').Value) },
-            { $_.Name }
+            $CustomAttributes = $UserAdd | Get-Member | Where-Object Name -Like "*Attribute*" | Where-Object { $_.Definition -NotLike "*=" -and $_.Definition -NotLike "*null" } | Select-Object
 
             Write-Verbose $CustomAttributes.name.count
 

--- a/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Import-JCUsersFromCSV.ps1
+++ b/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Import-JCUsersFromCSV.ps1
@@ -369,7 +369,13 @@ Function Import-JCUsersFromCSV () {
             $FormatGroupOutput = $Null
             $CustomGroupArrayList = $Null
 
-            $CustomAttributes = $UserAdd | Get-Member | Where-Object Name -Like "*Attribute*" | Where-Object { $_.Definition -NotLike "*=" -and $_.Definition -NotLike "*null" } | Select-Object
+            # Get custom attributes with definitions that are not null
+            $CustomAttributes = $UserAdd | Get-Member | Where-Object Name -Like "*Attribute*" | Where-Object { $_.Definition -NotLike "*=" -and $_.Definition -NotLike "*null" }
+
+            # Sort the custom attributes by name
+            $CustomAttributes = $CustomAttributes | Sort-Object {
+                [int]([regex]::Match($_.Name, '\d+').Value) },
+            { $_.Name }
 
             Write-Verbose $CustomAttributes.name.count
 

--- a/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Import-JCUsersFromCSV.ps1
+++ b/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Import-JCUsersFromCSV.ps1
@@ -369,7 +369,13 @@ Function Import-JCUsersFromCSV () {
             $FormatGroupOutput = $Null
             $CustomGroupArrayList = $Null
 
-            $CustomAttributes = $UserAdd | Get-Member | Where-Object Name -Like "*Attribute*" | Where-Object { $_.Definition -NotLike "*=" -and $_.Definition -NotLike "*null" } | Select-Object
+            # Get all the custom attributes that are not null
+            $CustomAttributes = $UserAdd | Get-Member | Where-Object Name -Like "*Attribute*" | Where-Object { $_.Definition -NotLike "*=" -and $_.Definition -NotLike "*null" }
+
+            # Sort the attributes by number and name
+            $CustomAttributes = $CustomAttributes | Sort-Object {
+                [int]([regex]::Match($_.Name, '\d+').Value) },
+            { $_.Name }
 
             Write-Verbose $CustomAttributes.name.count
 

--- a/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/New-JCDeviceUpdateTemplate.ps1
+++ b/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/New-JCDeviceUpdateTemplate.ps1
@@ -224,59 +224,56 @@ Function New-JCDeviceUpdateTemplate {
             }
         }
     }
-}
-
-
-
-end {
-    $ExportPath = Test-Path ("$ExportLocation/$FileName")
-    if ($PSCmdlet.ParameterSetName -eq 'force') {
-        if (!$ExportPath ) {
+    end {
+        $ExportPath = Test-Path ("$ExportLocation/$FileName")
+        if ($PSCmdlet.ParameterSetName -eq 'force') {
+            if (!$ExportPath ) {
+                Write-Host ""
+                $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
+                Write-Host 'Creating file '  -NoNewline
+                Write-Host $FileName -ForegroundColor Yellow -NoNewline
+                Write-Host ' in the location' -NoNewline
+                Write-Host " $ExportLocation" -ForegroundColor Yellow
+            } else {
+                Write-Warning "The file $fileName already exists, overwriting..."
+                $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
+                Write-Host 'Creating file '  -NoNewline
+                Write-Host $FileName -ForegroundColor Yellow -NoNewline
+                Write-Host ' in the location' -NoNewline
+                Write-Host " $ExportLocation" -ForegroundColor Yellow
+            }
+        } Else {
+            if (!$ExportPath ) {
+                Write-Host ""
+                $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
+                Write-Host 'Creating file'  -NoNewline
+                Write-Host " $fileName" -ForegroundColor Yellow -NoNewline
+                Write-Host ' in the location' -NoNewline
+                Write-Host " $ExportLocation" -ForegroundColor Yellow
+            } else {
+                Write-Host ""
+                Write-Warning "The file $fileName already exists do you want to overwrite it?" -WarningAction Inquire
+                Write-Host ""
+                $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
+                Write-Host 'Creating file '  -NoNewline
+                Write-Host $FileName -ForegroundColor Yellow -NoNewline
+                Write-Host ' in the location' -NoNewline
+                Write-Host " $ExportLocation" -ForegroundColor Yellow
+            }
             Write-Host ""
-            $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
-            Write-Host 'Creating file '  -NoNewline
-            Write-Host $FileName -ForegroundColor Yellow -NoNewline
-            Write-Host ' in the location' -NoNewline
-            Write-Host " $ExportLocation" -ForegroundColor Yellow
-        } else {
-            Write-Warning "The file $fileName already exists, overwriting..."
-            $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
-            Write-Host 'Creating file '  -NoNewline
-            Write-Host $FileName -ForegroundColor Yellow -NoNewline
-            Write-Host ' in the location' -NoNewline
-            Write-Host " $ExportLocation" -ForegroundColor Yellow
-        }
-    } Else {
-        if (!$ExportPath ) {
-            Write-Host ""
-            $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
-            Write-Host 'Creating file'  -NoNewline
-            Write-Host " $fileName" -ForegroundColor Yellow -NoNewline
-            Write-Host ' in the location' -NoNewline
-            Write-Host " $ExportLocation" -ForegroundColor Yellow
-        } else {
-            Write-Host ""
-            Write-Warning "The file $fileName already exists do you want to overwrite it?" -WarningAction Inquire
-            Write-Host ""
-            $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
-            Write-Host 'Creating file '  -NoNewline
-            Write-Host $FileName -ForegroundColor Yellow -NoNewline
-            Write-Host ' in the location' -NoNewline
-            Write-Host " $ExportLocation" -ForegroundColor Yellow
-        }
-        Write-Host ""
-        Write-Host "Do you want to open the file" -NoNewline
-        Write-Host " $FileName`?" -ForegroundColor Yellow
+            Write-Host "Do you want to open the file" -NoNewline
+            Write-Host " $FileName`?" -ForegroundColor Yellow
 
-        while ($Open -ne 'Y' -and $Open -ne 'N') {
-            $Open = Read-Host  "Enter Y for Yes or N for No"
-        }
+            while ($Open -ne 'Y' -and $Open -ne 'N') {
+                $Open = Read-Host  "Enter Y for Yes or N for No"
+            }
 
-        if ($Open -eq 'Y') {
-            Invoke-Item -Path "$ExportLocation/$FileName"
+            if ($Open -eq 'Y') {
+                Invoke-Item -Path "$ExportLocation/$FileName"
 
-        }
-        if ($Open -eq 'N') {
+            }
+            if ($Open -eq 'N') {
+            }
         }
     }
 }

--- a/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/New-JCDeviceUpdateTemplate.ps1
+++ b/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/New-JCDeviceUpdateTemplate.ps1
@@ -1,0 +1,282 @@
+Function New-JCDeviceUpdateTemplate {
+    [CmdletBinding()]
+
+    param
+    (
+        [Parameter(
+            ParameterSetName = 'force',
+            HelpMessage = 'Parameter to force populate CSV with all headers when creating an update template. When selected this option will forcefully replace existing files in the current working directory',
+            Mandatory = $false)]
+        [Switch]
+        $Force
+    )
+
+    begin {
+        $date = Get-Date -Format MM-dd-yyyy
+        if ($PSCmdlet.ParameterSetName -eq 'force') {
+            $ExportLocation = $PWD
+        } else {
+
+            $Banner = @"
+       __                          ______ __                   __
+      / /__  __ ____ ___   ____   / ____// /____   __  __ ____/ /
+ __  / // / / // __  __ \ / __ \ / /    / // __ \ / / / // __  /
+/ /_/ // /_/ // / / / / // /_/ // /___ / // /_/ // /_/ // /_/ /
+\____/ \____//_/ /_/ /_// ____/ \____//_/ \____/ \____/ \____/
+                       /_/
+                                    CSV Device Import Template
+"@
+
+            $Heading2 = 'The CSV file will be created within the directory:'
+
+            If (!(Get-PSCallStack | Where-Object { $_.Command -match 'Pester' })) {
+                Clear-Host
+            }
+
+            Write-Host $Banner -ForegroundColor Green
+            Write-Host "`n$Heading2`n"
+            Write-Host " $PWD" -ForegroundColor Yellow
+            Write-Host ""
+
+
+            while ($ConfirmFile -ne 'Y' -and $ConfirmFile -ne 'N') {
+                $ConfirmFile = Read-Host  "Enter Y to confirm or N to change output location" #Confirm .csv file location creation
+            }
+
+            if ($ConfirmFile -eq 'Y') {
+
+                $ExportLocation = $PWD
+            }
+
+            elseif ($ConfirmFile -eq 'N') {
+                $ExportLocation = Read-Host "Enter the full path to the folder you wish to create the import file in"
+
+                while (-not(Test-Path -Path $ExportLocation -PathType Container)) {
+                    Write-Host -BackgroundColor Yellow -ForegroundColor Red "The location $ExportLocation does not exist. Try another"
+                    $ExportLocation = Read-Host "Enter the full path to the folder you wish to create the import file in"
+
+                }
+                Write-Host ""
+                Write-Host -BackgroundColor Green -ForegroundColor Black "The CSV file will be created within the $ExportLocation directory"
+                Pause
+
+            }
+        }
+    }
+    process {
+        if ($PSCmdlet.ParameterSetName -eq 'force') {
+            $CSV = [ordered]@{
+                DeviceID                       = $null
+                displayName                    = $null
+                hostname                       = $null
+                description                    = $null
+                allowSshPasswordAuthentication = $null
+                allowSshRootLogin              = $null
+                allowMultiFactorAuthentication = $null
+                allowPublicKeyAuthentication   = $null
+                systemInsights                 = $null
+
+            }
+            $fileName = 'JCDeviceUpdateImport_' + $date + '.csv'
+            Write-Debug $fileName
+            $CSVheader = New-Object psobject -Property $Csv
+            $systems = Get-DynamicHash -Object System -returnProperties displayName, description, allowSshPasswordAuthentication, allowSshRootLogin, allowMultiFactorAuthentication, allowPublicKeyAuthentication, systemInsights, hostname
+            $CSVheader = @()
+            foreach ($System in $Systems.GetEnumerator()) {
+                $CSVDeviceUpdate = $CSV
+                $CSVDeviceUpdate.DeviceID = $System.Key
+                $CSVDeviceUpdate.displayName = $System.value.displayname
+                $SystemObject = New-Object psobject -Property $CSVDeviceUpdate
+                $CSVheader += $SystemObject
+            }
+        } else {
+            $fileName = 'JCDeviceUpdateImport_' + $date + '.csv'
+            Write-Debug $fileName
+
+            $CSV = [ordered]@{
+                DeviceID    = $null
+                displayname = $null
+            }
+
+            Write-Host "`nWould you like to populate this update template with all of your existing systems?"
+            Write-Host -ForegroundColor Yellow 'You can remove systems you do not wish to modify from the import file after it is created.'
+
+
+            while ($ConfirmDevicePop -ne 'Y' -and $ConfirmDevicePop -ne 'N') {
+                $ConfirmDevicePop = Read-Host  "Enter Y for Yes or N for No"
+            }
+
+            if ($ConfirmDevicePop -eq 'Y') {
+                Write-Verbose 'Verifying JCAPI Key'
+                if ([System.String]::IsNullOrEmpty($JCAPIKEY)) {
+                    Connect-JCOnline
+                }
+                $systems = Get-DynamicHash -Object System -returnProperties displayName, description, allowSshPasswordAuthentication, allowSshRootLogin, allowMultiFactorAuthentication, allowPublicKeyAuthentication, systemInsights, hostname
+            }
+
+            elseif ($ConfirmDevicePop -eq 'N') {
+            }
+
+
+            Write-Host "`nWould you like to update device descriptions?"
+
+            while ($ConfirmDeviceDescription -ne 'Y' -and $ConfirmDeviceDescription -ne 'N') {
+                $ConfirmDeviceDescription = Read-Host  "Enter Y for Yes or N for No"
+            }
+
+            if ($ConfirmDeviceDescription -eq 'Y') {
+                $CSV.add('description', $null)
+            }
+
+            elseif ($ConfirmDeviceDescription -eq 'N') {
+            }
+
+            Write-Host "`nWould you like to update device hostnames?"
+
+            while ($ConfirmDeviceHostname -ne 'Y' -and $ConfirmDeviceHostname -ne 'N') {
+                $ConfirmDeviceHostname = Read-Host  "Enter Y for Yes or N for No"
+            }
+
+            if ($ConfirmDeviceHostname -eq 'Y') {
+                $CSV.add('hostname', $null)
+            }
+
+            elseif ($ConfirmDeviceHostname -eq 'N') {
+            }
+
+            Write-Host "`nWould you like to update allowing SSH Password Authentication?"
+
+            while ($ConfirmSshPasswordAuth -ne 'Y' -and $ConfirmSshPasswordAuth -ne 'N') {
+                $ConfirmSshPasswordAuth = Read-Host  "Enter Y for Yes or N for No"
+            }
+
+            if ($ConfirmSshPasswordAuth -eq 'Y') {
+                $CSV.add('allowSshPasswordAuthentication', $null)
+            }
+
+            elseif ($ConfirmSshPasswordAuth -eq 'N') {
+            }
+
+            Write-Host "`nWould you like to update allowing SSH Root Login?"
+
+            while ($ConfirmSshRootLogin -ne 'Y' -and $ConfirmSshRootLogin -ne 'N') {
+                $ConfirmSshRootLogin = Read-Host  "Enter Y for Yes or N for No"
+            }
+
+            if ($ConfirmSshRootLogin -eq 'Y') {
+                $CSV.add('allowSshRootLogin', $null)
+            }
+
+            elseif ($ConfirmSshRootLogin -eq 'N') {
+            }
+
+            Write-Host "`nWould you like to update allowing MFA?"
+
+            while ($ConfirmMFA -ne 'Y' -and $ConfirmMFA -ne 'N') {
+                $ConfirmMFA = Read-Host  "Enter Y for Yes or N for No"
+            }
+
+            if ($ConfirmMFA -eq 'Y') {
+                $CSV.add('allowMultiFactorAuthentication', $null)
+            }
+
+            elseif ($ConfirmMFA -eq 'N') {
+            }
+
+            Write-Host "`nWould you like to update allowing Public Key Authentication?"
+
+            while ($ConfirmPublicKeyAuth -ne 'Y' -and $ConfirmPublicKeyAuth -ne 'N') {
+                $ConfirmPublicKeyAuth = Read-Host  "Enter Y for Yes or N for No"
+            }
+
+            if ($ConfirmPublicKeyAuth -eq 'Y') {
+                $CSV.add('allowPublicKeyAuthentication', $null)
+            }
+
+            elseif ($ConfirmPublicKeyAuth -eq 'N') {
+            }
+
+            Write-Host "`nWould you like to update enabling System Insights?"
+
+            while ($ConfirmSystemInsights -ne 'Y' -and $ConfirmSystemInsights -ne 'N') {
+                $ConfirmSystemInsights = Read-Host  "Enter Y for Yes or N for No"
+            }
+
+            if ($ConfirmSystemInsights -eq 'Y') {
+                $CSV.add('systemInsights', $null)
+            }
+
+            elseif ($ConfirmSystemInsights -eq 'N') {
+            }
+
+            $CSVheader = New-Object psobject -Property $Csv
+
+            if ($systems) {
+                $CSVheader = @()
+
+                foreach ($System in $Systems.GetEnumerator()) {
+                    $CSVDeviceUpdate = $CSV
+                    $CSVDeviceUpdate.DeviceID = $System.Key
+                    $CSVDeviceUpdate.displayName = $System.value.displayname
+                    $SystemObject = New-Object psobject -Property $CSVDeviceUpdate
+                    $CSVheader += $SystemObject
+                }
+            }
+        }
+    }
+}
+
+
+
+end {
+    $ExportPath = Test-Path ("$ExportLocation/$FileName")
+    if ($PSCmdlet.ParameterSetName -eq 'force') {
+        if (!$ExportPath ) {
+            Write-Host ""
+            $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
+            Write-Host 'Creating file '  -NoNewline
+            Write-Host $FileName -ForegroundColor Yellow -NoNewline
+            Write-Host ' in the location' -NoNewline
+            Write-Host " $ExportLocation" -ForegroundColor Yellow
+        } else {
+            Write-Warning "The file $fileName already exists, overwriting..."
+            $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
+            Write-Host 'Creating file '  -NoNewline
+            Write-Host $FileName -ForegroundColor Yellow -NoNewline
+            Write-Host ' in the location' -NoNewline
+            Write-Host " $ExportLocation" -ForegroundColor Yellow
+        }
+    } Else {
+        if (!$ExportPath ) {
+            Write-Host ""
+            $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
+            Write-Host 'Creating file'  -NoNewline
+            Write-Host " $fileName" -ForegroundColor Yellow -NoNewline
+            Write-Host ' in the location' -NoNewline
+            Write-Host " $ExportLocation" -ForegroundColor Yellow
+        } else {
+            Write-Host ""
+            Write-Warning "The file $fileName already exists do you want to overwrite it?" -WarningAction Inquire
+            Write-Host ""
+            $CSVheader | Export-Csv -Path "$ExportLocation/$FileName" -NoTypeInformation
+            Write-Host 'Creating file '  -NoNewline
+            Write-Host $FileName -ForegroundColor Yellow -NoNewline
+            Write-Host ' in the location' -NoNewline
+            Write-Host " $ExportLocation" -ForegroundColor Yellow
+        }
+        Write-Host ""
+        Write-Host "Do you want to open the file" -NoNewline
+        Write-Host " $FileName`?" -ForegroundColor Yellow
+
+        while ($Open -ne 'Y' -and $Open -ne 'N') {
+            $Open = Read-Host  "Enter Y for Yes or N for No"
+        }
+
+        if ($Open -eq 'Y') {
+            Invoke-Item -Path "$ExportLocation/$FileName"
+
+        }
+        if ($Open -eq 'N') {
+        }
+    }
+}

--- a/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/New-JCDeviceUpdateTemplate.ps1
+++ b/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/New-JCDeviceUpdateTemplate.ps1
@@ -86,7 +86,6 @@ Function New-JCDeviceUpdateTemplate {
                 $CSVDeviceUpdate = $CSV
                 $CSVDeviceUpdate.DeviceID = $System.Key
                 $CSVDeviceUpdate.displayName = $System.value.displayname
-                $CSVDeviceUpdate.hostname = $System.value.hostname
                 $SystemObject = New-Object psobject -Property $CSVDeviceUpdate
                 $CSVheader += $SystemObject
             }
@@ -97,85 +96,124 @@ Function New-JCDeviceUpdateTemplate {
             $CSV = [ordered]@{
                 DeviceID    = $null
                 displayname = $null
-                hostname    = $null
             }
-
-            # Begin Prompts for Properties
 
             Write-Host "`nWould you like to populate this update template with all of your existing systems?"
             Write-Host -ForegroundColor Yellow 'You can remove systems you do not wish to modify from the import file after it is created.'
+
+
             while ($ConfirmDevicePop -ne 'Y' -and $ConfirmDevicePop -ne 'N') {
                 $ConfirmDevicePop = Read-Host  "Enter Y for Yes or N for No"
             }
+
             if ($ConfirmDevicePop -eq 'Y') {
                 Write-Verbose 'Verifying JCAPI Key'
                 if ([System.String]::IsNullOrEmpty($JCAPIKEY)) {
                     Connect-JCOnline
                 }
                 $systems = Get-DynamicHash -Object System -returnProperties displayName, description, allowSshPasswordAuthentication, allowSshRootLogin, allowMultiFactorAuthentication, allowPublicKeyAuthentication, systemInsights, hostname
-            } elseif ($ConfirmDevicePop -eq 'N') {
+            }
+
+            elseif ($ConfirmDevicePop -eq 'N') {
             }
 
 
             Write-Host "`nWould you like to update device descriptions?"
+
             while ($ConfirmDeviceDescription -ne 'Y' -and $ConfirmDeviceDescription -ne 'N') {
                 $ConfirmDeviceDescription = Read-Host  "Enter Y for Yes or N for No"
             }
+
             if ($ConfirmDeviceDescription -eq 'Y') {
                 $CSV.add('description', $null)
-            } elseif ($ConfirmDeviceDescription -eq 'N') {
+            }
+
+            elseif ($ConfirmDeviceDescription -eq 'N') {
+            }
+
+            Write-Host "`nWould you like to update device hostnames?"
+
+            while ($ConfirmDeviceHostname -ne 'Y' -and $ConfirmDeviceHostname -ne 'N') {
+                $ConfirmDeviceHostname = Read-Host  "Enter Y for Yes or N for No"
+            }
+
+            if ($ConfirmDeviceHostname -eq 'Y') {
+                $CSV.add('hostname', $null)
+            }
+
+            elseif ($ConfirmDeviceHostname -eq 'N') {
             }
 
             Write-Host "`nWould you like to update allowing SSH Password Authentication?"
+
             while ($ConfirmSshPasswordAuth -ne 'Y' -and $ConfirmSshPasswordAuth -ne 'N') {
                 $ConfirmSshPasswordAuth = Read-Host  "Enter Y for Yes or N for No"
             }
+
             if ($ConfirmSshPasswordAuth -eq 'Y') {
                 $CSV.add('allowSshPasswordAuthentication', $null)
-            } elseif ($ConfirmSshPasswordAuth -eq 'N') {
+            }
+
+            elseif ($ConfirmSshPasswordAuth -eq 'N') {
             }
 
             Write-Host "`nWould you like to update allowing SSH Root Login?"
+
             while ($ConfirmSshRootLogin -ne 'Y' -and $ConfirmSshRootLogin -ne 'N') {
                 $ConfirmSshRootLogin = Read-Host  "Enter Y for Yes or N for No"
             }
+
             if ($ConfirmSshRootLogin -eq 'Y') {
                 $CSV.add('allowSshRootLogin', $null)
-            } elseif ($ConfirmSshRootLogin -eq 'N') {
+            }
+
+            elseif ($ConfirmSshRootLogin -eq 'N') {
             }
 
             Write-Host "`nWould you like to update allowing MFA?"
+
             while ($ConfirmMFA -ne 'Y' -and $ConfirmMFA -ne 'N') {
                 $ConfirmMFA = Read-Host  "Enter Y for Yes or N for No"
             }
+
             if ($ConfirmMFA -eq 'Y') {
                 $CSV.add('allowMultiFactorAuthentication', $null)
-            } elseif ($ConfirmMFA -eq 'N') {
+            }
+
+            elseif ($ConfirmMFA -eq 'N') {
             }
 
             Write-Host "`nWould you like to update allowing Public Key Authentication?"
+
             while ($ConfirmPublicKeyAuth -ne 'Y' -and $ConfirmPublicKeyAuth -ne 'N') {
                 $ConfirmPublicKeyAuth = Read-Host  "Enter Y for Yes or N for No"
             }
+
             if ($ConfirmPublicKeyAuth -eq 'Y') {
                 $CSV.add('allowPublicKeyAuthentication', $null)
-            } elseif ($ConfirmPublicKeyAuth -eq 'N') {
+            }
+
+            elseif ($ConfirmPublicKeyAuth -eq 'N') {
             }
 
             Write-Host "`nWould you like to update enabling System Insights?"
+
             while ($ConfirmSystemInsights -ne 'Y' -and $ConfirmSystemInsights -ne 'N') {
                 $ConfirmSystemInsights = Read-Host  "Enter Y for Yes or N for No"
             }
+
             if ($ConfirmSystemInsights -eq 'Y') {
                 $CSV.add('systemInsights', $null)
-            } elseif ($ConfirmSystemInsights -eq 'N') {
             }
 
-            # End Prompts
+            elseif ($ConfirmSystemInsights -eq 'N') {
+            }
 
             $CSVheader = New-Object psobject -Property $Csv
+
             if ($systems) {
                 $CSVheader = @()
+
                 foreach ($System in $Systems.GetEnumerator()) {
                     $CSVDeviceUpdate = $CSV
                     $CSVDeviceUpdate.DeviceID = $System.Key

--- a/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.ps1
+++ b/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.ps1
@@ -341,7 +341,13 @@ Function Update-JCUsersFromCSV () {
             $FormatGroupOutput = $Null
             $CustomGroupArrayList = $Null
 
+            # Get all the custom attributes that are not null
             $CustomAttributes = $UserUpdate | Get-Member | Where-Object Name -Like "*Attribute*" | Where-Object { $_.Definition -NotLike "*=" -and $_.Definition -NotLike "*null" } | Select-Object
+
+            # Sort the attributes by number and name
+            $CustomAttributes = $CustomAttributes | Sort-Object {
+                [int]([regex]::Match($_.Name, '\d+').Value) },
+            { $_.Name }
 
             if ($CustomAttributes.name.count -gt 1) {
                 try {

--- a/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.ps1
+++ b/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.ps1
@@ -348,6 +348,8 @@ Function Update-JCUsersFromCSV () {
                 [int]([regex]::Match($_.Name, '\d+').Value) },
             { $_.Name }
 
+            $CustomAttributes | Format-Table -AutoSize
+
             if ($CustomAttributes.name.count -gt 1) {
                 try {
                     # Counter is used to create a clean list of attributes

--- a/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.ps1
+++ b/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.ps1
@@ -340,15 +340,8 @@ Function Update-JCUsersFromCSV () {
             $SystemAddStatus = $Null
             $FormatGroupOutput = $Null
             $CustomGroupArrayList = $Null
-            # Get custom attributes with definitions that are not null
-            $CustomAttributes = $UserUpdate | Get-Member | Where-Object Name -Like "*Attribute*" | Where-Object { $_.Definition -NotLike "*=" -and $_.Definition -NotLike "*null" }
 
-            # Sort the custom attributes by name
-            $CustomAttributes = $CustomAttributes | Sort-Object {
-                [int]([regex]::Match($_.Name, '\d+').Value) },
-            { $_.Name }
-
-            $CustomAttributes | Format-Table -AutoSize
+            $CustomAttributes = $UserUpdate | Get-Member | Where-Object Name -Like "*Attribute*" | Where-Object { $_.Definition -NotLike "*=" -and $_.Definition -NotLike "*null" } | Select-Object
 
             if ($CustomAttributes.name.count -gt 1) {
                 try {
@@ -386,12 +379,13 @@ Function Update-JCUsersFromCSV () {
                     }
 
                     Write-Verbose "Attributes are $($UpdateParams)"
+
                     $NumberOfCustomAttributes = $UpdateParams.Keys | Where-Object { $_ -like "*Attribute*" } | Measure-Object | Select-Object -ExpandProperty Count
 
                     $UpdateParams.Add("NumberOfCustomAttributes", $NumberOfCustomAttributes / 2)
 
                     $JSONParams = $UpdateParams | ConvertTo-Json
-                    #Write-Debug "$($JSONParams)"
+
                     $NewUser = Set-JCUser @UpdateParams
 
                     if ($NewUser._id) {

--- a/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.ps1
+++ b/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.ps1
@@ -348,8 +348,6 @@ Function Update-JCUsersFromCSV () {
                 [int]([regex]::Match($_.Name, '\d+').Value) },
             { $_.Name }
 
-            $CustomAttributes | Format-Table -AutoSize
-
             if ($CustomAttributes.name.count -gt 1) {
                 try {
                     # Counter is used to create a clean list of attributes

--- a/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.ps1
+++ b/PowerShell/JumpCloud Module/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.ps1
@@ -340,8 +340,15 @@ Function Update-JCUsersFromCSV () {
             $SystemAddStatus = $Null
             $FormatGroupOutput = $Null
             $CustomGroupArrayList = $Null
+            # Get custom attributes with definitions that are not null
+            $CustomAttributes = $UserUpdate | Get-Member | Where-Object Name -Like "*Attribute*" | Where-Object { $_.Definition -NotLike "*=" -and $_.Definition -NotLike "*null" }
 
-            $CustomAttributes = $UserUpdate | Get-Member | Where-Object Name -Like "*Attribute*" | Where-Object { $_.Definition -NotLike "*=" -and $_.Definition -NotLike "*null" } | Select-Object
+            # Sort the custom attributes by name
+            $CustomAttributes = $CustomAttributes | Sort-Object {
+                [int]([regex]::Match($_.Name, '\d+').Value) },
+            { $_.Name }
+
+            $CustomAttributes | Format-Table -AutoSize
 
             if ($CustomAttributes.name.count -gt 1) {
                 try {
@@ -379,13 +386,12 @@ Function Update-JCUsersFromCSV () {
                     }
 
                     Write-Verbose "Attributes are $($UpdateParams)"
-
                     $NumberOfCustomAttributes = $UpdateParams.Keys | Where-Object { $_ -like "*Attribute*" } | Measure-Object | Select-Object -ExpandProperty Count
 
                     $UpdateParams.Add("NumberOfCustomAttributes", $NumberOfCustomAttributes / 2)
 
                     $JSONParams = $UpdateParams | ConvertTo-Json
-
+                    #Write-Debug "$($JSONParams)"
                     $NewUser = Set-JCUser @UpdateParams
 
                     if ($NewUser._id) {

--- a/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/Import-JCUsersFromCSV.Tests.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/Import-JCUsersFromCSV.Tests.ps1
@@ -636,6 +636,47 @@ Describe -Tag:('JCUsersFromCSV') "Import-JCUsersFromCSV 2.14.2" {
         }
     }
 }
+Describe -Tag:('JCUsersFromCSV') "Import-JCUsersFromCSV 2.15.1" {
+    Context "Import-JCUsersFromCSV with 10 or more custom attributes" {
+        It "When there are 10 or more custom attributes, the API should not return an error message in the status field and continue to import the user" {
+            $user = New-RandomUser -Domain "ImportCSVUser.$(New-RandomString -NumberOfChars 5)"
+            $today = Get-Date
+            $EnrollmentDays = 14
+            $CSVDATA = @{
+                Username          = $user.username
+                LastName          = $user.LastName
+                FirstName         = $user.FirstName
+                Email             = $user.Email
+                Attribute1_name   = "Name"
+                Attribute1_value  = "Value"
+                Attribute2_name   = "Name1"
+                Attribute2_value  = "Value1"
+                Attribute3_name   = "Name2"
+                Attribute3_value  = "Value2"
+                Attribute4_name   = "Name3"
+                Attribute4_value  = "Value3"
+                Attribute5_name   = "Name4"
+                Attribute5_value  = "Value4"
+                Attribute6_name   = "Name5"
+                Attribute6_value  = "Value5"
+                Attribute7_name   = "Name6"
+                Attribute7_value  = "Value6"
+                Attribute8_name   = "Name7"
+                Attribute8_value  = "Value7"
+                Attribute9_name   = "Name8"
+                Attribute9_value  = "Value8"
+                Attribute10_name  = "Name9"
+                Attribute10_value = "Value9"
+                Attribute11_name  = "Name10"
+                Attribute11_value = "Value10"
+            }
+            $CSVFILE = $CSVDATA | Export-Csv "$PesterParams_ImportPath/custom_attribute.csv" -Force
+            $importResults = Import-JCUsersFromCSV -CSVFilePath "$PesterParams_ImportPath/custom_attribute.csv" -force
+            # ImportResults should not be error
+            $importResults[0].Status | Should -Match "User Created"
+        }
+    }
+}
 
 AfterAll {
     Get-JCUser | Where-Object Email -like *testimportcsvuser* | Remove-JCUser -force

--- a/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/Import-JCUsersFromCSV.Tests.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/Import-JCUsersFromCSV.Tests.ps1
@@ -636,47 +636,6 @@ Describe -Tag:('JCUsersFromCSV') "Import-JCUsersFromCSV 2.14.2" {
         }
     }
 }
-Describe -Tag:('JCUsersFromCSV') "Import-JCUsersFromCSV 2.15.1" {
-    Context "Import-JCUsersFromCSV with 10 or more custom attributes" {
-        It "When there are 10 or more custom attributes, the API should not return an error message in the status field and continue to import the user" {
-            $user = New-RandomUser -Domain "ImportCSVUser.$(New-RandomString -NumberOfChars 5)"
-            $today = Get-Date
-            $EnrollmentDays = 14
-            $CSVDATA = @{
-                Username          = $user.username
-                LastName          = $user.LastName
-                FirstName         = $user.FirstName
-                Email             = $user.Email
-                Attribute1_name   = "Name"
-                Attribute1_value  = "Value"
-                Attribute2_name   = "Name1"
-                Attribute2_value  = "Value1"
-                Attribute3_name   = "Name2"
-                Attribute3_value  = "Value2"
-                Attribute4_name   = "Name3"
-                Attribute4_value  = "Value3"
-                Attribute5_name   = "Name4"
-                Attribute5_value  = "Value4"
-                Attribute6_name   = "Name5"
-                Attribute6_value  = "Value5"
-                Attribute7_name   = "Name6"
-                Attribute7_value  = "Value6"
-                Attribute8_name   = "Name7"
-                Attribute8_value  = "Value7"
-                Attribute9_name   = "Name8"
-                Attribute9_value  = "Value8"
-                Attribute10_name  = "Name9"
-                Attribute10_value = "Value9"
-                Attribute11_name  = "Name10"
-                Attribute11_value = "Value10"
-            }
-            $CSVFILE = $CSVDATA | Export-Csv "$PesterParams_ImportPath/custom_attribute.csv" -Force
-            $importResults = Import-JCUsersFromCSV -CSVFilePath "$PesterParams_ImportPath/custom_attribute.csv" -force
-            # ImportResults should not be error
-            $importResults[0].Status | Should -Match "User Created"
-        }
-    }
-}
 
 AfterAll {
     Get-JCUser | Where-Object Email -like *testimportcsvuser* | Remove-JCUser -force

--- a/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.Tests.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.Tests.ps1
@@ -1032,6 +1032,43 @@ Describe -Tag:('JCUsersFromCSV') "Update-JCUsersFromCSV 2.14.2" {
         }
     }
 }
+
+Describe -Tag:('JCUsersFromCSV') "Update-JCUsersFromCSV 2.15.1" {
+    Context "User should be updated even with 10 or more custom attributes" {
+        It "When there are 10 or more custom attributes, the user should still be updated" {
+            $user = New-RandomUser -Domain "testupdatecsvuser.$(New-RandomString -NumberOfChars 5)" | New-JCUser
+            $CSVDATA = @{
+                Username          = $user.username
+                Attribute1_name   = "Name"
+                Attribute1_value  = "Value"
+                Attribute2_name   = "Name1"
+                Attribute2_value  = "Value1"
+                Attribute3_name   = "Name2"
+                Attribute3_value  = "Value2"
+                Attribute4_name   = "Name3"
+                Attribute4_value  = "Value3"
+                Attribute5_name   = "Name4"
+                Attribute5_value  = "Value4"
+                Attribute6_name   = "Name5"
+                Attribute6_value  = "Value5"
+                Attribute7_name   = "Name6"
+                Attribute7_value  = "Value6"
+                Attribute8_name   = "Name7"
+                Attribute8_value  = "Value7"
+                Attribute9_name   = "Name8"
+                Attribute9_value  = "Value8"
+                Attribute10_name  = "Name9"
+                Attribute10_value = "Value9"
+                Attribute11_name  = "Name10"
+                Attribute11_value = "Value10"
+            }
+            $CSVFILE = $CSVDATA | Export-Csv "$PesterParams_UpdatePath/custom_attribute.csv" -Force
+            $UpdateStatus = Update-JCUsersFromCSV -CSVFilePath "$PesterParams_UpdatePath/custom_attribute.csv" -force
+            # the error message should show that custom attribute names cannot contain spaces
+            $UpdateStatus[0].status | Should -Be "User Updated"
+        }
+    }
+}
 AfterAll {
     Get-JCUser | Where-Object Email -like *testupdatecsvuser* | Remove-JCUser -force
 }

--- a/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.Tests.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/Update-JCUsersFromCSV.Tests.ps1
@@ -1032,43 +1032,6 @@ Describe -Tag:('JCUsersFromCSV') "Update-JCUsersFromCSV 2.14.2" {
         }
     }
 }
-
-Describe -Tag:('JCUsersFromCSV') "Update-JCUsersFromCSV 2.15.1" {
-    Context "User should be updated even with 10 or more custom attributes" {
-        It "When there are 10 or more custom attributes, the user should still be updated" {
-            $user = New-RandomUser -Domain "testupdatecsvuser.$(New-RandomString -NumberOfChars 5)" | New-JCUser
-            $CSVDATA = @{
-                Username          = $user.username
-                Attribute1_name   = "Name"
-                Attribute1_value  = "Value"
-                Attribute2_name   = "Name1"
-                Attribute2_value  = "Value1"
-                Attribute3_name   = "Name2"
-                Attribute3_value  = "Value2"
-                Attribute4_name   = "Name3"
-                Attribute4_value  = "Value3"
-                Attribute5_name   = "Name4"
-                Attribute5_value  = "Value4"
-                Attribute6_name   = "Name5"
-                Attribute6_value  = "Value5"
-                Attribute7_name   = "Name6"
-                Attribute7_value  = "Value6"
-                Attribute8_name   = "Name7"
-                Attribute8_value  = "Value7"
-                Attribute9_name   = "Name8"
-                Attribute9_value  = "Value8"
-                Attribute10_name  = "Name9"
-                Attribute10_value = "Value9"
-                Attribute11_name  = "Name10"
-                Attribute11_value = "Value10"
-            }
-            $CSVFILE = $CSVDATA | Export-Csv "$PesterParams_UpdatePath/custom_attribute.csv" -Force
-            $UpdateStatus = Update-JCUsersFromCSV -CSVFilePath "$PesterParams_UpdatePath/custom_attribute.csv" -force
-            # the error message should show that custom attribute names cannot contain spaces
-            $UpdateStatus[0].status | Should -Be "User Updated"
-        }
-    }
-}
 AfterAll {
     Get-JCUser | Where-Object Email -like *testupdatecsvuser* | Remove-JCUser -force
 }

--- a/PowerShell/ModuleChangelog.md
+++ b/PowerShell/ModuleChangelog.md
@@ -1,3 +1,17 @@
+## 2.16.0
+
+Release Date: December 4, 2024
+
+#### RELEASE NOTES
+
+```
+This release introduces a bug fix for `Import-JCUsersFromCSV` and `Update-JCUsersFromCSV` issues with importing more than 10 custom attributes
+```
+
+#### BUG FIXES:
+
+- Fixed a bug with `Import-JCUsersFromCSV` and `Update-JCUsersFromCSV` throwing error when importing 10 or more Custom Attributes due to a sorting issue
+
 ## 2.15.0
 
 Release Date: November 18, 2024

--- a/PowerShell/ModuleChangelog.md
+++ b/PowerShell/ModuleChangelog.md
@@ -1,3 +1,17 @@
+## 2.15.1
+
+Release Date: December 4, 2024
+
+#### RELEASE NOTES
+
+```
+This release introduces a bug fix for `Import-JCUsersFromCSV` and `Update-JCUsersFromCSV` issues with importing more than 10 custom attributes
+```
+
+#### BUG FIXES:
+
+- Fixed a bug with `Import-JCUsersFromCSV` and `Update-JCUsersFromCSV` throwing error when importing 10 or more Custom Attributes due to a sorting issue
+
 ## 2.15.0
 
 Release Date: November 18, 2024

--- a/PowerShell/ModuleChangelog.md
+++ b/PowerShell/ModuleChangelog.md
@@ -1,17 +1,3 @@
-## 2.15.1
-
-Release Date: December 4, 2024
-
-#### RELEASE NOTES
-
-```
-This release introduces a bug fix for `Import-JCUsersFromCSV` and `Update-JCUsersFromCSV` issues with importing more than 10 custom attributes
-```
-
-#### BUG FIXES:
-
-- Fixed a bug with `Import-JCUsersFromCSV` and `Update-JCUsersFromCSV` throwing error when importing 10 or more Custom Attributes due to a sorting issue
-
 ## 2.15.0
 
 Release Date: November 18, 2024


### PR DESCRIPTION
## Issues
* [CUT-4490](https://jumpcloud.atlassian.net/browse/CUT-4490) - CUT-4490-CSVImportUpdate-Sort-Bug

## What does this solve?
Fixes an issue when importing/updatingCSV user/s with more than 10 custom attributes
## Is there anything particularly tricky?
n/a
## How should this be tested?
Import-JCUsersFromCSV
1. Import a user with 10 or more custom attributes
[NewUserCSV.csv](https://github.com/user-attachments/files/18013569/NewUserCSV.csv)
2. User creation should not return an error and create the user and custom attributes
![image](https://github.com/user-attachments/assets/af701b77-6314-4e09-ab07-2c7ace6254b9)
<img width="2047" alt="image" src="https://github.com/user-attachments/assets/ea997bd6-1688-4d89-a2fe-de2c0c5258f6">


Update-JCUsersFromCSV
1. Update a user with 10 or more custom attributes
[UpdateUser.csv](https://github.com/user-attachments/files/18013621/UpdateUser.csv)
4. User update should not return an error and update the custom attributes
<img width="1733" alt="image" src="https://github.com/user-attachments/assets/ccd40ae2-a73a-45d9-8d60-c757d732f88c">

## Screenshots
