### PR TITLE
Update Mac - Install Chrome DMG.md

### DIFF
--- a/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Install Chrome DMG.md
+++ b/PowerShell/JumpCloud Commands Gallery/Mac Commands/Application Installs/Mac - Install Chrome DMG.md
@@ -10,7 +10,7 @@ mac
 
 ```
 # DMG Download URL
-DownloadUrl="https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg"
+DownloadUrl="https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg"
 
 ### Modify below this line at your own risk!
 
@@ -173,7 +173,7 @@ echo "Deleted /tmp/$TempFolder"
 
 #### Description
 
-Installs Google Chrome from the DMG file available for download from the link: `https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg`.
+Installs Google Chrome from the DMG file available for download from the link: `https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg`.
 
 This command creates a temporary folder in the /tmp directory and to downloads the DMG file to this folder.
 


### PR DESCRIPTION
Update to universal dmg to ensure current stable version is installed.

## Issues
* [SJ-9486](https://jumpcloud.atlassian.net/browse/SJ-9486)

## What does this solve?
Updates download URL to latest stable universal version. Old URL does not appear to be maintained (was pointing to a ~4 year old build)

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots


[SJ-9486]: https://jumpcloud.atlassian.net/browse/SJ-9486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ