### PR TITLE
Update-JCDeviceFromCSV Tests

### DIFF
--- a/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/New-JCDeviceUpdateTemplate.Test.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/New-JCDeviceUpdateTemplate.Test.ps1
@@ -1,0 +1,9 @@
+Describe -Tag:('JCDeviceFromCSV') 'New-JCDeviceUpdateTemplate' {
+    BeforeAll {  }
+    It "Forcefully creates a CSV Import Template" {
+        New-JCDeviceUpdateTemplate -Force
+        $items = Get-ChildItem -Path $PWD | Where-Object { $_.FullName -Match "JCDeviceUpdateImport*" }
+        $items | Should -Exist
+        $items | ForEach-Object { Remove-Item -Path $_.FullName }
+    }
+}

--- a/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/Update-JCDeviceFromCSV.Tests.ps1
+++ b/PowerShell/JumpCloud Module/Tests/Public/Utilities/CSV_Import/Update-JCDeviceFromCSV.Tests.ps1
@@ -1,0 +1,26 @@
+Describe -Tag:('JCDeviceFromCSV') 'Update-JCDeviceFromCSV' {
+    BeforeAll {  }
+    It 'Updates users from a CSV populated with all information' {
+        $system = Get-JCDevice | Select-Object -First 1
+        $CSVData = @{
+            "DeviceID"                       = $system.id
+            "displayName"                    = "PesterUpdateFromCSV"
+            "description"                    = "PesterUpdateFromCSV"
+            "allowSshPasswordAuthentication" = $true
+            "allowSshRootLogin"              = $true
+            "allowMultiFactorAuthentication" = $false
+            "allowPublicKeyAuthentication"   = $true
+            "systemInsights"                 = $true
+        }
+        $CSVDATA | Export-Csv "$PesterParams_ImportPath/UpdateDeviceFromCSV.csv" -Force
+        $DeviceCSVUpdate = Update-JCDeviceFromCSV -CSVFilePath "$PesterParams_ImportPath/UpdateDeviceFromCSV.csv" -force
+
+        $DeviceCSVUpdate.displayName | Should -Be $CSVData.displayName
+        $DeviceCSVUpdate.description | Should -Be $CSVData.description
+        $DeviceCSVUpdate.allowSshPasswordAuthentication | Should -Be $CSVData.allowSshPasswordAuthentication
+        $DeviceCSVUpdate.allowSshRootLogin | Should -Be $CSVData.allowSshRootLogin
+        $DeviceCSVUpdate.allowMultiFactorAuthentication | Should -Be $CSVData.allowMultiFactorAuthentication
+        $DeviceCSVUpdate.allowPublicKeyAuthentication | Should -Be $CSVData.allowPublicKeyAuthentication
+        $DeviceCSVUpdate.systemInsights | Should -Be @{state = 'enabled'}
+    }
+}


### PR DESCRIPTION
## Issues
* [CUT-4395](https://jumpcloud.atlassian.net/browse/CUT-4395) - Update-JCDeviceFromCSV Tests

## What does this solve?
Creates basic Pester suite for the two new functions for updating devices via CSV
- New-JCDeviceUpdateTemplate
- Update-JCDeviceFromCSV

## Is there anything particularly tricky?
The tests themselves are not every verbose as there is not much to the functions in their current state

## How should this be tested?
Run the Pester tests for each of the functions

[CUT-4395]: https://jumpcloud.atlassian.net/browse/CUT-4395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ