### PR TITLE
Get User to Device Reports with SDK Functions

### DIFF
--- a/scripts/automation/Radius/Functions/Private/Reports/Get-LatestUserToDeviceReport.ps1
+++ b/scripts/automation/Radius/Functions/Private/Reports/Get-LatestUserToDeviceReport.ps1
@@ -1,0 +1,54 @@
+Function Get-LatestUserToDeviceReport {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [System.Int32]
+        $minutes
+    )
+    begin {
+        # get UTC time now:
+        $utcTimeNow = Get-Date ([datetime]::UtcNow) -UFormat "%m/%d/%Y %r"
+
+        $headers = @{
+            "accept"    = "application/json";
+            "x-api-key" = $Env:JCApiKey;
+            "x-org-id"  = $Env:JCOrgId
+        }
+
+    }
+    process {
+        $reportList = Get-JCsdkReport -Sort 'CREATED_AT'
+        $userAndDeviceReports = $reportList | Where-Object { $_.Type -eq "ods-users-to-devices" }
+        if ($userAndDeviceReports) {
+            # get the first report
+            $firstUAndDReport = $userAndDeviceReports | Select-Object -First 1
+            $timespan = New-TimeSpan -end $utcTimeNow -start $firstUAndDReport.Created_At
+            # if time between now and the last generated report is >=24, create a new report
+            if ($timespan.Minutes -ge $minutes) {
+                write-host "last report generated $($timespan.Minutes) minutes ago; generating new user to device report"
+                $requestedReport = New-JcSdkReport -ReportType 'users-to-devices'
+                $latestReport = Get-ReportByID -reportID $requestedReport.Id
+            } else {
+                write-host "last report generated $($timespan.Minutes) minutes ago"
+                # return the last report
+                $latestReport = Get-ReportByID -reportID $firstUAndDReport.Id
+            }
+
+        } else {
+            # if there are no reports create a new one:
+            write-host "generating new user to device report"
+            $requestedReport = New-JcSdkReport -ReportType 'users-to-devices'
+            $latestReport = Get-ReportByID -reportID $requestedReport.Id
+        }
+
+        # get the json artifact:
+        # download json
+        $artifactID = ($latestReport.artifacts | Where-Object { $_.format -eq 'json' }).id
+        $reportID = $latestReport.id
+        $reportContent = Invoke-RestMethod -Uri "https://api.jumpcloud.com/insights/directory/v1/reports/$reportID/artifacts/$artifactID/content" -Method GET -Headers $headers
+    }
+    end {
+        # return the latest user report
+        return $reportContent
+    }
+}

--- a/scripts/automation/Radius/Functions/Private/Reports/Get-LatestUserToDeviceReport.ps1
+++ b/scripts/automation/Radius/Functions/Private/Reports/Get-LatestUserToDeviceReport.ps1
@@ -25,18 +25,18 @@ Function Get-LatestUserToDeviceReport {
             $timespan = New-TimeSpan -end $utcTimeNow -start $firstUAndDReport.Created_At
             # if time between now and the last generated report is >=24, create a new report
             if ($timespan.Minutes -ge $minutes) {
-                write-host "last report generated $($timespan.Minutes) minutes ago; generating new user to device report"
+                # write-host "last report generated $($timespan.Minutes) minutes ago; generating new user to device report"
                 $requestedReport = New-JcSdkReport -ReportType 'users-to-devices'
                 $latestReport = Get-ReportByID -reportID $requestedReport.Id
             } else {
-                write-host "last report generated $($timespan.Minutes) minutes ago"
+                # write-host "last report generated $($timespan.Minutes) minutes ago"
                 # return the last report
                 $latestReport = Get-ReportByID -reportID $firstUAndDReport.Id
             }
 
         } else {
             # if there are no reports create a new one:
-            write-host "generating new user to device report"
+            # write-host "generating new user to device report"
             $requestedReport = New-JcSdkReport -ReportType 'users-to-devices'
             $latestReport = Get-ReportByID -reportID $requestedReport.Id
         }

--- a/scripts/automation/Radius/Functions/Private/Reports/Get-ReportByID.ps1
+++ b/scripts/automation/Radius/Functions/Private/Reports/Get-ReportByID.ps1
@@ -1,0 +1,25 @@
+Function Get-ReportByID {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [System.String]
+        $reportID
+    )
+    begin {
+        write-host "attempting to get report by id: $reportId"
+    }
+    process {
+        do {
+            $reportList = Get-JCsdkReport -Sort 'CREATED_AT'
+            $foundReport = $reportList | Where-Object { $_.Id -eq $reportID }
+            if ($foundReport.Status -eq "PENDING") {
+                Write-Warning "[status] waiting 10s for jumpcloud report to complete"
+                start-sleep -Seconds 10
+            }
+
+        } until ($foundReport.Status -eq "COMPLETED")
+    }
+    end {
+        return $foundReport
+    }
+}

--- a/scripts/automation/Radius/Functions/Private/Reports/Get-ReportByID.ps1
+++ b/scripts/automation/Radius/Functions/Private/Reports/Get-ReportByID.ps1
@@ -6,7 +6,7 @@ Function Get-ReportByID {
         $reportID
     )
     begin {
-        write-host "attempting to get report by id: $reportId"
+        # write-host "attempting to get report by id: $reportId"
     }
     process {
         do {


### PR DESCRIPTION
## Issues
* [CUT-4519](https://jumpcloud.atlassian.net/browse/CUT-4519) - Get User to Device Reports with SDK Functions

## What does this solve?

- This change removes some of the invoke web request calls that were used previously to get the user to device reports.
- The `Get-JCRGlobalVars` function will now attempt to pull the latest user to device report if it's less than 10 minutes old. If the function is called and a report has been generated within 10 minutes, that report will be used to source user and system association data.

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots


[CUT-4519]: https://jumpcloud.atlassian.net/browse/CUT-4519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ