### PR TITLE
Sup 1483

### DIFF
--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -133,6 +133,8 @@ grep -o '\"username\":\"[^\"]*\"' /opt/jc/managedUsers.json | cut -d '"' -f 4 > 
 ## descend into managed user's homedirs (requires full disk access) and gather JumpCloud logs
 for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do
     echo "pulling logs from user $u"
+    mkdir $baseDir/userLogs/$u
+
     if [ -d /Users/$u/Library/Logs/JumpCloud\ Password\ Manager ]; then
         cp -r /Users/$u/Library/Logs/JumpCloud\ Password\ Manager $baseDir/userLogs/$u/
     fi
@@ -140,6 +142,9 @@ for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do
     if [ -d /Users/$u/Library/Logs/JumpCloud\ Remote\ Assist ]; then
         cp -r /Users/$u/Library/Logs/JumpCloud\ Remote\ Assist $baseDir/userLogs/$u/
     fi
+
+    # report on any user scope configuration profiles
+    sudo -u $u profiles -L -o stdout > $baseDir/userLogs/$u/installedProfiles.txt
 
     cp -r /Users/$u/Library/Logs/JumpCloud $baseDir/userLogs/$u/
 

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -139,8 +139,8 @@ for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do
         cp -r /Users/$u/Library/Logs/JumpCloud\ Password\ Manager $baseDir/userLogs/$u/
     fi
 
-    if [ -d /Users/$u/Library/Logs/JumpCloud\ Remote\ Assist ]; then
-        cp -r /Users/$u/Library/Logs/JumpCloud\ Remote\ Assist $baseDir/userLogs/$u/
+    if [ -d /Users/$u/Library/Logs/JumpCloud-Remote-Assist ]; then
+        cp -r /Users/$u/Library/Logs/JumpCloud-Remote-Assist $baseDir/userLogs/$u/
     fi
 
     # report on any user scope configuration profiles
@@ -149,6 +149,13 @@ for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do
     cp -r /Users/$u/Library/Logs/JumpCloud $baseDir/userLogs/$u/
 
 done
+
+# check for and gather remote assist logs from root homedir
+
+if [ -d /var/root/Library/Logs/JumpCloud-Remote-Assist ]; then
+    mkdir $baseDir/userLogs/root
+    cp -r /var/root/Library/Logs/JumpCloud-Remote-Assist $baseDir/userLogs/root/
+fi
 
 echo "Resetting gathered logs permissions"
 chmod -R 777 $baseDir

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -128,7 +128,7 @@ diskutil apfs list > $baseDir/systemInfo/diskReport.txt
 
 ## list managed usernames
 echo "finding managed users"
-grep -o '\"username\":\"\w*' /opt/jc/managedUsers.json | cut -d '"' -f 4 > $baseDir/systemInfo/managedUsers.txt
+grep -o '\"username\":\"[^\"]*\"' /opt/jc/managedUsers.json | cut -d '"' -f 4 > $baseDir/systemInfo/managedUsers.txt
 
 ## descend into managed user's homedirs (requires full disk access) and gather JumpCloud logs
 for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do


### PR DESCRIPTION
## Issues
* [SUP-1483](https://jumpcloud.atlassian.net/browse/SUP-1483) - Jan 2024 - Log Collection Refinements

## What does this solve?
 - usernames with non-alphanum chars are now handled correctly
 - added collection of user-scope MDM configuration profiles
 - updated folder naming convention for JumpCloud Remote Assist logs (JumpCloud-Remote-Assist)
 - added collection of RA logs from root user homedir

## Is there anything particularly tricky?
nope

## How should this be tested?
On a macOS endpoint prior to testing:
 - bind usernames with dots, dashes, and other chars commonly found in usernames
 - run JCRA background tools & silent assist
 - install a user scoped profile (I like using the screensaver config for this). It will need to be installed by hand since we do not install user scoped profiles from our MDM service.
[User ScreenSaver Config.zip](https://github.com/user-attachments/files/18303574/User.ScreenSaver.Config.zip)

Run log collect and inspect results.

## Screenshots
![Screenshot 2025-01-03 at 3 24 42 PM](https://github.com/user-attachments/assets/9a4f856e-4ad5-4c8d-bb13-e0434cbd2fb2)




[SUP-1483]: https://jumpcloud.atlassian.net/browse/SUP-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ