### PR TITLE
Use Universal Time to Compare Certificates

### DIFF
--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
@@ -803,10 +803,10 @@ exit 4
                     }
                     if (Get-Member -inputObject $user.certInfo -name "deploymentDate" -MemberType Properties) {
                         # if ($userObjectFromTable.certInfo.deploymentDate) {
-                        $user.certInfo.deploymentDate = (Get-Date)
+                        $user.certInfo.deploymentDate = (Get-Date).ToUniversalTime()
 
                     } else {
-                        $user.certInfo | Add-Member -Name 'deploymentDate' -Type NoteProperty -Value (Get-Date)
+                        $user.certInfo | Add-Member -Name 'deploymentDate' -Type NoteProperty -Value (Get-Date).ToUniversalTime()
                     }
                 }
             }

--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
@@ -803,10 +803,10 @@ exit 4
                     }
                     if (Get-Member -inputObject $user.certInfo -name "deploymentDate" -MemberType Properties) {
                         # if ($userObjectFromTable.certInfo.deploymentDate) {
-                        $user.certInfo.deploymentDate = (Get-Date).ToUniversalTime()
+                        $user.certInfo.deploymentDate = (Get-Date -Format "o")
 
                     } else {
-                        $user.certInfo | Add-Member -Name 'deploymentDate' -Type NoteProperty -Value (Get-Date).ToUniversalTime()
+                        $user.certInfo | Add-Member -Name 'deploymentDate' -Type NoteProperty -Value (Get-Date -Format "o")
                     }
                 }
             }

--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Get-CertInfo.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Get-CertInfo.ps1
@@ -64,7 +64,7 @@ function Get-CertInfo {
                         $date = $property.notAfter
                         $date = $date.replace('GMT', '').Trim()
                         $date = $date -replace '\s+', ' '
-                        $property.notAfter = [datetime]::ParseExact($date , "MMM d HH:mm:ss yyyy", $null)
+                        $property.notAfter = ([datetime]::ParseExact($date , "MMM d HH:mm:ss yyyy", $null)).ToUniversalTime()
                     }
 
                     $certHash += $property

--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Get-CertInfo.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Get-CertInfo.ps1
@@ -62,9 +62,10 @@ function Get-CertInfo {
                     # Convert notAfter property into datetime format
                     if ($property.notAfter) {
                         $date = $property.notAfter
-                        $date = $date.replace('GMT', '').Trim()
+                        # $date = $date.replace('GMT', '').Trim()
                         $date = $date -replace '\s+', ' '
-                        $property.notAfter = ([datetime]::ParseExact($date , "MMM d HH:mm:ss yyyy", $null)).ToUniversalTime()
+                        $date = ([datetime]::ParseExact($date , "MMM d HH:mm:ss yyyy GMT", $null)).ToUniversalTime()
+                        $property.notAfter = Get-Date $date.ToUniversalTime() -UFormat '+%Y-%m-%dT%H:%M:%S.000Z'
                     }
 
                     $certHash += $property
@@ -84,9 +85,11 @@ function Get-CertInfo {
                         switch ($($property.keys)) {
                             'notAfter' {
                                 $date = $property.notAfter
-                                $date = $date.replace('GMT', '').Trim()
+                                # $date = $date.replace('GMT', '').Trim()
                                 $date = $date -replace '\s+', ' '
-                                $property.notAfter = [datetime]::ParseExact($date , "MMM d HH:mm:ss yyyy", $null)
+                                $date = [datetime]::ParseExact($date , "MMM d HH:mm:ss yyyy GMT", $null)
+                                $property.notAfter = Get-Date $date.ToUniversalTime() -UFormat '+%Y-%m-%dT%H:%M:%S.000Z'
+
                             }
                             'sha1 Fingerprint' {
                                 $property.Values = ($($property.Values)).ToLower().Replace(":", "")
@@ -108,7 +111,7 @@ function Get-CertInfo {
                     }
 
                     $certHash | Add-Member -Name 'username' -Type NoteProperty -Value $username
-                    $certHash | Add-Member -Name 'generated' -Type NoteProperty -Value ($certFile.LastWriteTime.ToString('MM/dd/yyyy HH:mm:ss'))
+                    $certHash | Add-Member -Name 'generated' -Type NoteProperty -Value (Get-Date $certFile.LastWriteTime.ToUniversalTime() -UFormat '+%Y-%m-%dT%H:%M:%S.000Z')
                     # Add hash to certObj array if the user is a member of the userGroup
                     if ($username -in $global:JCRRadiusMembers.username) {
                         $certObj.add( $certHash) | Out-Null

--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Get-ExpiringCertInfo.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Get-ExpiringCertInfo.ps1
@@ -10,11 +10,13 @@ function Get-ExpiringCertInfo {
     )
     begin {
         $expiringCerts = New-Object System.Collections.ArrayList
-        $currentTime = Get-Date
+        $currentTime = (Get-Date).ToUniversalTime()
     }
     process {
         foreach ($cert in $certInfo) {
-            $certTimespan = New-Timespan -Start $currentTime -End $cert.notAfter
+            $startDate = [datetime]$currentTime
+            $endDate = [datetime]$cert.notAfter
+            $certTimespan = New-Timespan -Start $startDate -End $endDate
             # $cert
             if ($certTimespan.days -lt 15) {
                 Write-Debug "$($cert.userName)'s certificate will expire in $($certTimespan.Days) days"

--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Get-ExpiringCertInfo.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Get-ExpiringCertInfo.ps1
@@ -10,7 +10,7 @@ function Get-ExpiringCertInfo {
     )
     begin {
         $expiringCerts = New-Object System.Collections.ArrayList
-        $currentTime = (Get-Date).ToUniversalTime()
+        $currentTime = (Get-Date -Format "o")
     }
     process {
         foreach ($cert in $certInfo) {

--- a/scripts/automation/Radius/Functions/Private/Commands/Invoke-CommandsRetry.ps1
+++ b/scripts/automation/Radius/Functions/Private/Commands/Invoke-CommandsRetry.ps1
@@ -31,7 +31,7 @@ Function Invoke-CommandsRetry {
                             (($user.commandAssociations) | Where-Object { $_.commandId -eq $command.commandId }).commandPreviouslyRun = $true
                             (($user.commandAssociations) | Where-Object { $_.commandId -eq $command.commandId }).commandQueued = $true
                             $user.certInfo.deployed = $true
-                            $user.certInfo.deploymentDate = (get-date).ToUniversalTime()
+                            $user.certInfo.deploymentDate = (Get-Date -Format "o")
                             Set-UserTable -index $userIndex -certInfoObject $user.certInfo -commandAssociationsObject $user.commandAssociations
                             # track retried commands
                             $RetryCommands += $command.commandId

--- a/scripts/automation/Radius/Functions/Private/Commands/Invoke-CommandsRetry.ps1
+++ b/scripts/automation/Radius/Functions/Private/Commands/Invoke-CommandsRetry.ps1
@@ -31,7 +31,7 @@ Function Invoke-CommandsRetry {
                             (($user.commandAssociations) | Where-Object { $_.commandId -eq $command.commandId }).commandPreviouslyRun = $true
                             (($user.commandAssociations) | Where-Object { $_.commandId -eq $command.commandId }).commandQueued = $true
                             $user.certInfo.deployed = $true
-                            $user.certInfo.deploymentDate = (get-date)
+                            $user.certInfo.deploymentDate = (get-date).ToUniversalTime()
                             Set-UserTable -index $userIndex -certInfoObject $user.certInfo -commandAssociationsObject $user.commandAssociations
                             # track retried commands
                             $RetryCommands += $command.commandId

--- a/scripts/automation/Radius/Functions/Private/Menus/Show-GenerationMenu.ps1
+++ b/scripts/automation/Radius/Functions/Private/Menus/Show-GenerationMenu.ps1
@@ -9,7 +9,14 @@ function Show-GenerationMenu {
 
     if ($Global:expiringCerts) {
         Write-Host $(PadCenter -string ' Certs Expiring Soon ' -char '-')
-        $Global:expiringCerts | Format-Table -Property username, @{name = 'Remaining Days'; expression = { (New-TimeSpan -Start (Get-Date) -End ("$($_.notAfter)")).Days } }, @{name = "Expires On"; expression = { $_.notAfter } }
+
+        $Global:expiringCerts | Format-Table -Property username, @{name = 'Remaining Days'; expression = {
+            (New-TimeSpan -Start ((Get-Date).ToUniversalTime()) -End ([dateTime]("$($_.notAfter)"))).Days
+            }
+        }, @{name = "Expires On"; expression = {
+                [datetime]($_.notAfter)
+            }
+        }
     }
 
     Write-Host $(PadCenter -string ' User Certificate Generation Options ' -char '-')

--- a/scripts/automation/Radius/Functions/Private/Menus/Show-GenerationMenu.ps1
+++ b/scripts/automation/Radius/Functions/Private/Menus/Show-GenerationMenu.ps1
@@ -11,7 +11,7 @@ function Show-GenerationMenu {
         Write-Host $(PadCenter -string ' Certs Expiring Soon ' -char '-')
 
         $Global:expiringCerts | Format-Table -Property username, @{name = 'Remaining Days'; expression = {
-            (New-TimeSpan -Start ((Get-Date).ToUniversalTime()) -End ([dateTime]("$($_.notAfter)"))).Days
+            (New-TimeSpan -Start (Get-Date -Format "o") -End ([dateTime]("$($_.notAfter)"))).Days
             }
         }, @{name = "Expires On"; expression = {
                 [datetime]($_.notAfter)

--- a/scripts/automation/Radius/Functions/Private/Settings/New-JCRSettingsFile.ps1
+++ b/scripts/automation/Radius/Functions/Private/Settings/New-JCRSettingsFile.ps1
@@ -16,7 +16,7 @@ function New-JCRSettingsFile {
     }
     process {
         # Define Default Settings for the Config file
-        $date = Get-Date
+        $date = (Get-Date).ToUniversalTime()
         $config = @{
             'globalVars' = @{
                 'lastUpdate' = @{value = $date; write = $true; copy = $true ;

--- a/scripts/automation/Radius/Functions/Public/Get-JCRGlobalVars.ps1
+++ b/scripts/automation/Radius/Functions/Public/Get-JCRGlobalVars.ps1
@@ -27,10 +27,10 @@ function Get-JCRGlobalVars {
 
         # get settings file
         if ($IsMacOS) {
-            $lastUpdateTimespan = New-TimeSpan -Start $global:JCRConfig.globalvars.lastupdate -end (Get-Date).ToUniversalTime()
+            $lastUpdateTimespan = New-TimeSpan -Start $global:JCRConfig.globalvars.lastupdate -end (Get-Date -Format "o")
         }
         if ($ifWindows) {
-            $lastUpdateTimespan = New-TimeSpan -Start $global:JCRConfig.globalvars.lastupdate.value -end (Get-Date).ToUniversalTime()
+            $lastUpdateTimespan = New-TimeSpan -Start $global:JCRConfig.globalvars.lastupdate.value -end (Get-Date -Format "o")
         }
         if ($lastUpdateTimespan.TotalHours -gt 24) {
             $update = $true
@@ -247,7 +247,7 @@ function Get-JCRGlobalVars {
                 $Global:JCRRadiusMembers = $radiusMemberList
                 $Global:JCRCertHash = $certHash
                 # update the settings date
-                Set-JCRSettingsFile -globalVarslastUpdate (Get-Date).ToUniversalTime()
+                Set-JCRSettingsFile -globalVarslastUpdate (Get-Date -Format "o")
                 # update users.json
                 Update-JCRUsersJson
             }

--- a/scripts/automation/Radius/Functions/Public/Get-JCRGlobalVars.ps1
+++ b/scripts/automation/Radius/Functions/Public/Get-JCRGlobalVars.ps1
@@ -27,10 +27,10 @@ function Get-JCRGlobalVars {
 
         # get settings file
         if ($IsMacOS) {
-            $lastUpdateTimespan = New-TimeSpan -Start $global:JCRConfig.globalvars.lastupdate -end (Get-Date)
+            $lastUpdateTimespan = New-TimeSpan -Start $global:JCRConfig.globalvars.lastupdate -end (Get-Date).ToUniversalTime()
         }
         if ($ifWindows) {
-            $lastUpdateTimespan = New-TimeSpan -Start $global:JCRConfig.globalvars.lastupdate.value -end (Get-Date)
+            $lastUpdateTimespan = New-TimeSpan -Start $global:JCRConfig.globalvars.lastupdate.value -end (Get-Date).ToUniversalTime()
         }
         if ($lastUpdateTimespan.TotalHours -gt 24) {
             $update = $true
@@ -247,7 +247,7 @@ function Get-JCRGlobalVars {
                 $Global:JCRRadiusMembers = $radiusMemberList
                 $Global:JCRCertHash = $certHash
                 # update the settings date
-                Set-JCRSettingsFile -globalVarslastUpdate (Get-Date)
+                Set-JCRSettingsFile -globalVarslastUpdate (Get-Date).ToUniversalTime()
                 # update users.json
                 Update-JCRUsersJson
             }


### PR DESCRIPTION
## Issues
* [CUT-4551](https://jumpcloud.atlassian.net/browse/CUT-4551) - Use Universal Time to Compare Certificates

## What does this solve?

When running the radius certificate tool on devices with various datetime cultures where datetimes are stored as dd/mm/yyyy, the previous version of the tool would fail to compare expiring certificate dates. This update converts all stored dates to universal date time.

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots


[CUT-4551]: https://jumpcloud.atlassian.net/browse/CUT-4551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ