### PR TITLE
Cut 4091 verify password for cert key

### DIFF
--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -14,6 +14,7 @@ This release offers a significant overhaul for the Radius Cert Deployment tool, 
 - Association data is cached up front rather than gathered throughout the script, offering performance improvements for organizations with a large number of radius users
 - Added ability to run each public function headless in order to automate cert generation and distribution
 - Added a table to keep track of generated/deployed certificates when using the tool
+- Added password validation (re-enter) when generating root certificate
 
 ## 1.1.0
 

--- a/scripts/automation/Radius/Functions/Private/Menus/Get-ResponsePrompt.ps1
+++ b/scripts/automation/Radius/Functions/Private/Menus/Get-ResponsePrompt.ps1
@@ -12,8 +12,9 @@ function Get-ResponsePrompt {
         $invokeCommands = Read-Host "$message`nPlease type: 'y'/'n' (or 'E' to return to menu)"
         switch ($invokeCommands) {
             'e' {
+                Write-Host "Returning to Main Menu..."
                 $promptForInvokeInput = $false
-                break
+                return 'exit'
             }
             'n' {
                 return $false

--- a/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
@@ -81,7 +81,6 @@ Function Start-GenerateRootCert {
                 } else {
                     Write-Host "Password set successfully" -foregroundcolor Green
                     $certKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
-                    Write-Host "certKeyPass: $certKeyPass"
                 }
             } while ($plainCertKeyPass -ne $plainCertKeyPassReEntry)
         }

--- a/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
@@ -42,6 +42,9 @@ Function Start-GenerateRootCert {
                     $false {
                         return
                     }
+                    'exit' {
+                        return
+                    }
                 }
             }
             'cli' {
@@ -57,8 +60,29 @@ Function Start-GenerateRootCert {
     switch ($PSCmdlet.ParameterSetName) {
         'gui' {
             $env:certKeyPassword = ""
-            $secureCertKeyPass = Read-Host -Prompt "Enter a password for the certificate key" -AsSecureString
-            $certKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
+            # Loop until the passwords match
+            do {
+                # Prompt for password
+                $secureCertKeyPass = Read-Host -Prompt "Enter a password for the certificate key" -AsSecureString
+
+                # Reprompt for password
+                $secureCertKeyPass2 = Read-Host -Prompt "Re-enter the password for the certificate key" -AsSecureString
+
+                # Convert SecureString to plain text to validate
+                $plainCertKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
+                Write-Host "plainCertKeyPass: $plainCertKeyPass"
+                $plainCertKeyPass2 = ConvertFrom-SecureString $secureCertKeyPass2 -AsPlainText
+                Write-Host "plainCertKeyPass2: $plainCertKeyPass2"
+
+                # Validate that the passwords match
+                if ($plainCertKeyPass -ne $plainCertKeyPass2) {
+                    Write-Host "Passwords do not match. Please try again." -foregroundcolor Red
+                } else {
+                    Write-Host "Password set successfully" -foregroundcolor Green
+                    $certKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
+                    Write-Host "certKeyPass: $certKeyPass"
+                }
+            } while ($plainCertKeyPass -ne $plainCertKeyPass2)
         }
         'cli' {
             $certKeyPass = $certKeyPassword

--- a/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
@@ -71,9 +71,7 @@ Function Start-GenerateRootCert {
 
                 # Convert SecureString to plain text to validate
                 $plainCertKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
-                Write-Host "plainCertKeyPass: $plainCertKeyPass"
                 $plainCertKeyPassReEntry = ConvertFrom-SecureString $secureCertKeyPass2ReEntry -AsPlainText
-                Write-Host "plainCertKeyPassReEntry: $plainCertKeyPassReEntry"
 
                 # Validate that the passwords match
                 if ($plainCertKeyPass -ne $plainCertKeyPassReEntry) {

--- a/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
@@ -63,26 +63,27 @@ Function Start-GenerateRootCert {
             # Loop until the passwords match
             do {
                 # Prompt for password
+                Write-Host "NOTE: Please save your root certificate password in a password manager" -foregroundcolor Yellow
                 $secureCertKeyPass = Read-Host -Prompt "Enter a password for the certificate key" -AsSecureString
 
                 # Reprompt for password
-                $secureCertKeyPass2 = Read-Host -Prompt "Re-enter the password for the certificate key" -AsSecureString
+                $secureCertKeyPass2ReEntry = Read-Host -Prompt "Re-enter the password for the certificate key" -AsSecureString
 
                 # Convert SecureString to plain text to validate
                 $plainCertKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
                 Write-Host "plainCertKeyPass: $plainCertKeyPass"
-                $plainCertKeyPass2 = ConvertFrom-SecureString $secureCertKeyPass2 -AsPlainText
-                Write-Host "plainCertKeyPass2: $plainCertKeyPass2"
+                $plainCertKeyPassReEntry = ConvertFrom-SecureString $secureCertKeyPass2ReEntry -AsPlainText
+                Write-Host "plainCertKeyPassReEntry: $plainCertKeyPassReEntry"
 
                 # Validate that the passwords match
-                if ($plainCertKeyPass -ne $plainCertKeyPass2) {
+                if ($plainCertKeyPass -ne $plainCertKeyPassReEntry) {
                     Write-Host "Passwords do not match. Please try again." -foregroundcolor Red
                 } else {
                     Write-Host "Password set successfully" -foregroundcolor Green
                     $certKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
                     Write-Host "certKeyPass: $certKeyPass"
                 }
-            } while ($plainCertKeyPass -ne $plainCertKeyPass2)
+            } while ($plainCertKeyPass -ne $plainCertKeyPassReEntry)
         }
         'cli' {
             $certKeyPass = $certKeyPassword

--- a/scripts/automation/Radius/Functions/Public/Start-GenerateUserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-GenerateUserCerts.ps1
@@ -163,6 +163,9 @@ function Start-GenerateUserCerts {
                             $false {
                                 return
                             }
+                            'exit' {
+                                return
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Issues
* [CUT-4091](https://jumpcloud.atlassian.net/browse/CUT-4091) - CUT-4091-VerifyRootCertKeyPassword

## What does this solve?

- Ensures that the inputted root cert password is validated by having it re-entered
- Bug fix: 'E' exit not working properly for Generate Root and User cert menus
![image](https://github.com/user-attachments/assets/8278c141-1fb3-44f0-b3c5-24308757b860)


## Is there anything particularly tricky?
n/a
## How should this be tested?
**Root Cert Password Validation**
1. Generate a root cert using the GUI
2. Validate that you have to enter the password twice

- Validate that it fails if you enter two different passwords
![image](https://github.com/user-attachments/assets/1e960be2-de3d-4a09-ad6f-54e97f315886)

- Entering the same password on both prompts should be a success
![image](https://github.com/user-attachments/assets/1ba0f409-070f-45d5-8f80-5deae9f875e3)


**Bug Fix**
1. Go to generate root cert menu GUI then enter `E`, this should take you to main menu
2. Go to generate user cert menu GUI then enter `E`, this should take you to main menu

## Screenshots


[CUT-4091]: https://jumpcloud.atlassian.net/browse/CUT-4091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ