### PR TITLE
added PWM daemon log collection

### DIFF
--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -139,6 +139,10 @@ for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do
         cp -r /Users/$u/Library/Logs/JumpCloud\ Password\ Manager $baseDir/userLogs/$u/
     fi
 
+    if [ -d /Users/$u/Library/Application\ Support/JumpCloud\ Password\ Manager/data/daemon/log ]; then
+        cp -r /Users/$u/Library/Application\ Support/JumpCloud\ Password\ Manager/data/daemon/log $baseDir/userLogs/$u/PWM_daemon_logs
+    fi
+
     if [ -d /Users/$u/Library/Logs/JumpCloud-Remote-Assist ]; then
         cp -r /Users/$u/Library/Logs/JumpCloud-Remote-Assist $baseDir/userLogs/$u/
     fi


### PR DESCRIPTION
## Issues
* [SUP-1496](https://jumpcloud.atlassian.net/browse/SUP-1496) - macOS - missed PWM log location

## What does this solve?

Collects previously missed logs for JumpCloud Password Manager daemon which are buried in ~/Library/Application Support/...

## Is there anything particularly tricky?

nope

## How should this be tested?

Run VM, bind to JC, Install PWM and add item to ensure logs are populated. Run collection script and look for entries within the archive located in [archive root]/userLogs/[username]/PWM_daemon_logs

## Screenshots
<img width="1097" alt="image" src="https://github.com/user-attachments/assets/dfce6fc6-b08b-4298-975b-4bbf6a243822" />


[SUP-1496]: https://jumpcloud.atlassian.net/browse/SUP-1496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ