### PR TITLE
root cert menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 /scripts/automation/Radius/users.json
 /scripts/automation/Radius/settings.json
 /scripts/automation/Radius/data/*
+/scripts/automation/Radius/Cert/Backups/*.pem
+/scripts/automation/Radius/Cert/Backups/*.zip
+
 __pycache__/
 *.pyc
 # Ignore PWSH CSV Import/Update Files:

--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,6 +1,6 @@
 ## 2.0.0
 
-Release Date: January 5, 2024
+Release Date: January 28, 2024
 
 #### RELEASE NOTES
 
@@ -15,6 +15,11 @@ This release offers a significant overhaul for the Radius Cert Deployment tool, 
 - Added ability to run each public function headless in order to automate cert generation and distribution
 - Added a table to keep track of generated/deployed certificates when using the tool
 - Added password validation (re-enter) when generating root certificate
+- Added Start-GenerateRootCert menu
+  - Functionalities added
+    - New: creates new root cert. If there is an existing root cert, user gets prompted to overwrite the cert
+    - Replace: replaces the current cert. If you replace root cert, it will contain a different serial number and user certs generated with the previous CA will no longer authenticate
+    - Renew: renewing the root CA will contain the same serial number and CA subject headers. User certs generated with the previous CA will continue to authenticate.
 
 ## 1.1.0
 

--- a/scripts/automation/Radius/Changelog.md
+++ b/scripts/automation/Radius/Changelog.md
@@ -1,6 +1,6 @@
 ## 2.0.0
 
-Release Date: January 28, 2024
+Release Date: January 30, 2024
 
 #### RELEASE NOTES
 

--- a/scripts/automation/Radius/Functions/Private/Menus/Get-ResponsePrompt.ps1
+++ b/scripts/automation/Radius/Functions/Private/Menus/Get-ResponsePrompt.ps1
@@ -3,16 +3,27 @@ function Get-ResponsePrompt {
     param (
         [Parameter(HelpMessage = "The message prompt to display to the console", Mandatory)]
         [System.String]
-        $message
+        $message,
+        [Parameter(HelpMessage = "Change messaging if running in CLI")]
+        [System.Boolean]
+        $cli = $false
     )
 
 
     $promptForInvokeInput = $true
     while ($promptForInvokeInput) {
-        $invokeCommands = Read-Host "$message`nPlease type: 'y'/'n' (or 'E' to return to menu)"
+        if ($cli) {
+            $invokeCommands = Read-Host "$message`nPlease type: 'y'/'n' (or 'E' to exit)"
+        } else {
+            $invokeCommands = Read-Host "$message`nPlease type: 'y'/'n' (or 'E' to return to Main Menu)"
+        }
         switch ($invokeCommands) {
             'e' {
-                Write-Host "Returning to Main Menu..."
+                if ($cli) {
+                    Write-Host "Exiting..."
+                } else {
+                    Write-Host "Returning to Main Menu..."
+                }
                 $promptForInvokeInput = $false
                 return 'exit'
             }
@@ -23,7 +34,7 @@ function Get-ResponsePrompt {
                 return $true
             }
             default {
-                write-host "Invalid input`nPlease type 'y'/ 'n' (or 'E' to return to menu)"
+                write-host "Invalid input`nPlease type 'y'/ 'n' (or 'E' to exit)"
             }
         }
     }

--- a/scripts/automation/Radius/Functions/Private/Menus/Get-ResponsePrompt.ps1
+++ b/scripts/automation/Radius/Functions/Private/Menus/Get-ResponsePrompt.ps1
@@ -34,7 +34,7 @@ function Get-ResponsePrompt {
                 return $true
             }
             default {
-                write-host "Invalid input`nPlease type 'y'/ 'n' (or 'E' to exit)"
+                Write-host "Invalid input`nPlease type 'y'/ 'n' (or 'E' to exit)" -ForegroundColor Red
             }
         }
     }

--- a/scripts/automation/Radius/Functions/Private/Menus/Show-RadiusMainMenu.ps1
+++ b/scripts/automation/Radius/Functions/Private/Menus/Show-RadiusMainMenu.ps1
@@ -46,25 +46,14 @@ function Show-RadiusMainMenu {
     Write-Host $(PadCenter -string "Radius User Group: $($radiusUserGroup.Name)" -char " ") -ForegroundColor Green
     Write-Host $(PadCenter -string "Total Radius Users: $($radiusUserGroupMemberCount)" -char " ") -ForegroundColor Green
     Write-Host $(PadCenter -string "Radius SSID(s): $radiusSSID" -char " ") -ForegroundColor Green
-    if ($IsMacOS){
+    if ($IsMacOS) {
         Write-Host $(PadCenter -string "Last Updated User/System Data: $($Global:JCRConfig.globalVars.lastupdate)" -char " ") -ForegroundColor Green
-    } If ($isWindows){
+    } If ($isWindows) {
         Write-Host $(PadCenter -string "Last Updated User/System Data: $($Global:JCRConfig.globalVars.lastupdate.value)" -char " ") -ForegroundColor Green
     }
-    # Write-Host "`n"
-    # if ($radiusSSID.count -gt 1) {
-    #     Write-Host $(PadCenter -string "Radius SSIDs:" -char " ") -ForegroundColor Green
-    #     $radiusSSID | ForEach-Object {
-    #         Write-Host $(PadCenter -string $_ -char " ") -ForegroundColor Green
-    #     }
-    # } else {
-    #     Write-Host $(PadCenter -string "Radius SSID: $radiusSSID" -char " ") -ForegroundColor Green
-    #     Write-Host "`n"
-    # }
-    # /==== GROUP/SSID ====
 
     Write-Host $(PadCenter -string "-" -char '-')
-    Write-Host "1: Press '1' to generate your Root Certificate."
+    Write-Host "1: Press '1' to generate/update your Root Certificate."
     Write-Host "2: Press '2' to generate/update your User Certificate(s)."
     Write-Host "3: Press '3' to distribute your User Certificate(s)."
     Write-Host "4: Press '4' to monitor your User Certification Distribution."

--- a/scripts/automation/Radius/Functions/Private/Menus/Show-RootCAGenerationMenu.ps1
+++ b/scripts/automation/Radius/Functions/Private/Menus/Show-RootCAGenerationMenu.ps1
@@ -19,24 +19,27 @@ function Show-RootCAGenerationMenu {
 
         # Check if expiration is less root cert warning days
         if ($daysRemaining -lt $JCR_ROOT_CERT_Expire_Warning_Days) {
-            Write-Host $(PadCenter -string "WARNING: The root certificate is expiring in $daysRemaining day(s) on $expirationDate! Please press '3' to regenerate your root cert.") -ForegroundColor Yellow
+            Write-Host $(PadCenter -string "WARNING: The root certificate is expiring in $daysRemaining day(s) on $expirationDate! Please press '2' to regenerate your root cert.") -ForegroundColor Yellow
         }
     }
 
-
     Write-Host $(PadCenter -string ' Root Certificate Generation Options ' -char '-')
-    # List Options
-    # Generate new root CA
-    Write-Host "1: Press '1' to generate new root certificate. `n`t$([char]0x1b)[96mNOTE: you will be prompted to overwrite any previously generated certificates. This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate."
 
-    # Replace root CA
-    Write-Host "2: Press '2' to replace current root certificate. `n`t$([char]0x1b)[96mNOTE: if you replace root CA it will contain a different serial number and user certs generated with the previous CA will no longer authenticate."
 
-    # Regenerate with the same serial number
-    Write-Host "3: Press '3' to renew root certificate. `n`t$([char]0x1b)[96mNOTE: renewing the root CA will contain the same serial number and CA subject headers. User certs generated with the previous CA will continue to authenticate."
 
-    # Return to main menu
-    Write-Host "E: Press 'E' to return to main menu."
-
+    if (Test-Path -Path "$JCScriptRoot/Cert/radius_ca_cert.pem") {
+        # Generate new root CA
+        Write-Host "1: Press '1' to replace current root certificate. `n`t$([char]0x1b)[96mNOTE: you will be prompted to overwrite any previously generated certificates. This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate."
+        # Regenerate with the same serial number
+        Write-Host  "2: Press '2' to renew root certificate. `n`t$([char]0x1b)[96mNOTE: renewing the root CA will contain the same serial number and CA subject headers. User certs generated with the previous CA will continue to authenticate."
+        # Return to main menu
+        Write-Host "E: Press 'E' to return to main menu."
+    } else {
+        # Generate new root CA
+        Write-Host "1: Press '1' to generate new root certificate"
+        # Return to main menu
+        Write-Host "E: Press 'E' to return to main menu."
+    }
     Write-Host $(PadCenter -string "-" -char '-')
+
 }

--- a/scripts/automation/Radius/Functions/Private/Menus/Show-RootCAGenerationMenu.ps1
+++ b/scripts/automation/Radius/Functions/Private/Menus/Show-RootCAGenerationMenu.ps1
@@ -1,0 +1,42 @@
+function Show-RootCAGenerationMenu {
+    $title = ' JumpCloud Radius Root CA Cert Deployment '
+    Clear-Host
+    Write-Host $(PadCenter -string $Title -char '=')
+    Write-Host $(PadCenter -string "Select an option below to generate/regenerate root certificate`n" -char ' ') -ForegroundColor Yellow
+
+    $rootCAInfo = Get-CertInfo -rootCa
+    Write-Host $(PadCenter -string ' Root CA ' -char '-')
+    if ($rootCAInfo -eq $null) {
+        Write-Host $(PadCenter -string "No Root CA detected`n" -char ' ') -ForegroundColor Yellow
+    } else {
+        Write-Host $(PadCenter -string "Root CA Serial Number: $($rootCAInfo.serial)" -char ' ') -ForegroundColor Green
+        Write-Host $(PadCenter -string "Root CA Expiration: $($rootCAInfo.notAfter)`n" -char ' ') -ForegroundColor Green
+
+        # If root CA is expiring within 30 days, display warning
+        $expirationDate = [datetime]$rootCAInfo.notAfter
+        $currentDate = Get-Date
+        $daysRemaining = ($expirationDate - $currentDate).Days
+
+        # Check if expiration is less root cert warning days
+        if ($daysRemaining -lt $JCR_ROOT_CERT_Expire_Warning_Days) {
+            Write-Host $(PadCenter -string "WARNING: The root certificate is expiring in $daysRemaining day(s) on $expirationDate! Please press '3' to regenerate your root cert.") -ForegroundColor Yellow
+        }
+    }
+
+
+    Write-Host $(PadCenter -string ' Root Certificate Generation Options ' -char '-')
+    # List Options
+    # Generate new root CA
+    Write-Host "1: Press '1' to generate new root certificate. `n`t$([char]0x1b)[96mNOTE: you will be prompted to overwrite any previously generated certificates. This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate."
+
+    # Replace root CA
+    Write-Host "2: Press '2' to replace current root certificate. `n`t$([char]0x1b)[96mNOTE: if you replace root CA it will contain a different serial number and user certs generated with the previous CA will no longer authenticate."
+
+    # Regenerate with the same serial number
+    Write-Host "3: Press '3' to renew root certificate. `n`t$([char]0x1b)[96mNOTE: renewing the root CA will contain the same serial number and CA subject headers. User certs generated with the previous CA will continue to authenticate."
+
+    # Return to main menu
+    Write-Host "E: Press 'E' to return to main menu."
+
+    Write-Host $(PadCenter -string "-" -char '-')
+}

--- a/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
@@ -8,7 +8,7 @@ Function Start-GenerateRootCert {
         # Parameter to "New" or "Replace" the root certificate validateSet ('1', '2', '3', 'E')
         [Parameter(HelpMessage = 'Select an option to generate or replace the root certificate', ParameterSetName = 'cli')]
         [ValidateSet('New', 'Replace', 'Renew')]
-        [string] $GenerateType = 'New',
+        [string] $generateType = 'New',
         # Force invoke commands after generation
         [Parameter(HelpMessage = 'When specified, this parameter will replace certificates if they already exist on the current filesystem', ParameterSetName = 'cli')]
         [switch]

--- a/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
@@ -4,8 +4,23 @@ Function Start-GenerateRootCert {
         # Cert Key Password
         [Parameter(HelpMessage = 'The root certificate key password', ParameterSetName = 'cli')]
         [string]
-        $certKeyPassword
+        $certKeyPassword,
+        # Parameter to "New" or "Replace" the root certificate validateSet ('1', '2', '3', 'E')
+        [Parameter(HelpMessage = 'Select an option to generate or replace the root certificate', ParameterSetName = 'cli')]
+        [ValidateSet('New', 'Replace', 'Renew')]
+        [string] $GenerateType = 'New',
+        # Force invoke commands after generation
+        [Parameter(HelpMessage = 'When specified, this parameter will replace certificates if they already exist on the current filesystem', ParameterSetName = 'cli')]
+        [switch]
+        $forceReplaceCert
+
+
     )
+
+    $CertPath = Resolve-Path "$JCScriptRoot/Cert"
+    $outKey = "$CertPath/radius_ca_key.pem"
+    $outCA = "$CertPath/radius_ca_cert.pem"
+    $timestamp = Get-Date -Format "yyyyMMddHHmmss"
     # this script will generate a Self Signed CA (root cert) to be imported on the
     # Radius CBA-BYO Authentication UI
 
@@ -29,75 +44,95 @@ Function Start-GenerateRootCert {
         Write-Host "Creating Cert Path"
         New-Item -ItemType Directory -Path "$JCScriptRoot/Cert"
     }
-    # Check if cert exists, prompt user to overwrite with a while loop
-    if (Test-Path -Path "$JCScriptRoot/Cert/radius_ca_cert.pem") {
-        Write-Host "CA Cert already exists"
-        switch ($PSCmdlet.ParameterSetName) {
-            'gui' {
-                $overwrite = Get-ResponsePrompt -message "Do you want to overwrite the existing CA Cert?"
+
+    # If parameterSetname is CLI
+    if ($PSCmdlet.ParameterSetName -eq 'cli') {
+        switch ($GenerateType) {
+            'New' {
+                $selection = 1
+            }
+            'Replace' {
+                $selection = 2
+            }
+            'Renew' {
+                $selection = 3
+            }
+        }
+    } else {
+        Show-RootCAGenerationMenu
+        $selection = Read-Host "Please make a selection"
+    }
+
+
+
+    switch ($selection) {
+        # Generate new root certificate
+        '1' {
+            if (Test-Path -Path "$JCScriptRoot/Cert/radius_ca_cert.pem") {
+                Write-Host "Root Cert already exists"
+                # If the forceReplaceCert switch is set, force the generation of a new root certificate
+                if (!$forceReplaceCert) {
+                    if ($PSCmdlet.ParameterSetName -eq 'cli') {
+                        $overwrite = Get-ResponsePrompt -message "Do you want to overwrite the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate." -cli $true
+                    } else {
+                        $overwrite = Get-ResponsePrompt -message "Do you want to overwrite the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate."
+                    }
+
+                } else {
+                    $overwrite = $true
+                }
                 switch ($overwrite) {
                     $true {
-                        continue
-                    }
-                    $false {
-                        return
-                    }
-                    'exit' {
-                        return
-                    }
-                }
-            }
-            'cli' {
+                        Write-Host "Overwriting Root Cert..." -ForegroundColor Yellow
 
-            }
-        }
-    }
-    $CertPath = Resolve-Path "$JCScriptRoot/Cert"
-    $outKey = "$CertPath/radius_ca_key.pem"
-    $outCA = "$CertPath/radius_ca_cert.pem"
-    # Ask the user to enter a pass phrase for the CA key:
-    # Clear the pass phrase from the env:
-    switch ($PSCmdlet.ParameterSetName) {
-        'gui' {
-            $env:certKeyPassword = ""
-            # Loop until the passwords match
-            do {
-                # Prompt for password
-                Write-Host "NOTE: Please save your root certificate password in a password manager" -foregroundcolor Yellow
-                $secureCertKeyPass = Read-Host -Prompt "Enter a password for the certificate key" -AsSecureString
+                        switch ($PSCmdlet.ParameterSetName) {
+                            'gui' {
+                                $env:certKeyPassword = ""
+                                # Loop until the passwords match
+                                do {
+                                    # Prompt for password
+                                    Write-Host "NOTE: Please save your root certificate password in a password manager" -foregroundcolor Yellow
+                                    $secureCertKeyPass = Read-Host -Prompt "Enter a password for the certificate key" -AsSecureString
 
-                # Reprompt for password
-                $secureCertKeyPass2ReEntry = Read-Host -Prompt "Re-enter the password for the certificate key" -AsSecureString
+                                    # Reprompt for password
+                                    $secureCertKeyPass2ReEntry = Read-Host -Prompt "Re-enter the password for the certificate key" -AsSecureString
 
-                # Convert SecureString to plain text to validate
-                $plainCertKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
-                $plainCertKeyPassReEntry = ConvertFrom-SecureString $secureCertKeyPass2ReEntry -AsPlainText
+                                    # Convert SecureString to plain text to validate
+                                    $plainCertKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
+                                    $plainCertKeyPassReEntry = ConvertFrom-SecureString $secureCertKeyPass2ReEntry -AsPlainText
 
-                # Validate that the passwords match
-                if ($plainCertKeyPass -ne $plainCertKeyPassReEntry) {
-                    Write-Host "Passwords do not match. Please try again." -foregroundcolor Red
-                } else {
-                    Write-Host "Password set successfully" -foregroundcolor Green
-                    $certKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
-                }
-            } while ($plainCertKeyPass -ne $plainCertKeyPassReEntry)
-        }
-        'cli' {
-            $certKeyPass = $certKeyPassword
-        }
-    }
-    # Save the pass phrase in the env:
-    $env:certKeyPassword = $certKeyPass
-    Invoke-Expression "$JCR_OPENSSL req -x509 -newkey rsa:2048 -days $JCR_ROOT_CERT_VALIDITY_DAYS -keyout `"$outKey`" -out `"$outCA`" -passout pass:$($env:certKeyPassword) -subj /C=$($JCR_SUBJECT_HEADERS.countryCode)/ST=$($JCR_SUBJECT_HEADERS.stateCode)/L=$($JCR_SUBJECT_HEADERS.Locality)/O=$($JCR_SUBJECT_HEADERS.Organization)/OU=$($JCR_SUBJECT_HEADERS.OrganizationUnit)/CN=$($JCR_SUBJECT_HEADERS.CommonName)"
-    # REM PEM pass phrase: myorgpass
-    Invoke-Expression "$JCR_OPENSSL x509 -in `"$outCA`" -noout -text"
-    # openssl x509 -in ca-cert.pem -noout -text
-    # Update Extensions Distinguished Names:
-    $exts = Get-ChildItem -Path "$JCScriptRoot/Extensions"
-    foreach ($ext in $exts) {
-        Write-Host "Updating Subject Headers for $($ext.Name)"
-        $extContent = Get-Content -Path $ext.FullName -Raw
-        $reqDistinguishedName = @"
+                                    # Validate that the passwords match
+                                    if ($plainCertKeyPass -ne $plainCertKeyPassReEntry) {
+                                        Write-Host "Passwords do not match. Please try again." -foregroundcolor Red
+                                    } else {
+                                        Write-Host "Password set successfully" -foregroundcolor Green
+                                        $certKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
+                                    }
+                                } while ($plainCertKeyPass -ne $plainCertKeyPassReEntry)
+                            }
+                            'cli' {
+                                $certKeyPass = $certKeyPassword
+                            }
+                        }
+
+                        # Copy the current root cert to the backups folder
+                        try {
+                            Copy-Item -Path "$CertPath/radius_ca_cert.pem" -Destination "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
+                        } catch {
+                            Write-Error "Error backing up the current root cert. $($_.Exception.Message)"
+                        }
+                        # Save the pass phrase in the env:
+                        $env:certKeyPassword = $certKeyPass
+                        Invoke-Expression "$JCR_OPENSSL req -x509 -newkey rsa:2048 -days $JCR_ROOT_CERT_VALIDITY_DAYS -keyout `"$outKey`" -out `"$outCA`" -passout pass:$($env:certKeyPassword) -subj /C=$($JCR_SUBJECT_HEADERS.countryCode)/ST=$($JCR_SUBJECT_HEADERS.stateCode)/L=$($JCR_SUBJECT_HEADERS.Locality)/O=$($JCR_SUBJECT_HEADERS.Organization)/OU=$($JCR_SUBJECT_HEADERS.OrganizationUnit)/CN=$($JCR_SUBJECT_HEADERS.CommonName)"
+                        # REM PEM pass phrase: myorgpass
+                        Invoke-Expression "$JCR_OPENSSL x509 -in `"$outCA`" -noout -text"
+                        # openssl x509 -in ca-cert.pem -noout -text
+                        # Update Extensions Distinguished Names:
+                        $exts = Get-ChildItem -Path "$JCScriptRoot/Extensions"
+                        foreach ($ext in $exts) {
+                            Write-Host "Updating Subject Headers for $($ext.Name)"
+                            $extContent = Get-Content -Path $ext.FullName -Raw
+                            $reqDistinguishedName = @"
 [req_distinguished_name]
 C = $($JCR_SUBJECT_HEADERS.countryCode)
 ST = $($JCR_SUBJECT_HEADERS.stateCode)
@@ -107,6 +142,243 @@ OU = $($JCR_SUBJECT_HEADERS.OrganizationUnit)
 CN = $($JCR_SUBJECT_HEADERS.CommonName)
 
 "@
-        $extContent -Replace ("\[req_distinguished_name\][\s\S]*(?=\[v3_req\])", $reqDistinguishedName) | Set-Content -Path $ext.FullName -NoNewline -Force
+                            $extContent -Replace ("\[req_distinguished_name\][\s\S]*(?=\[v3_req\])", $reqDistinguishedName) | Set-Content -Path $ext.FullName -NoNewline -Force
+                        }
+                    }
+                    $false {
+                        return
+                    }
+                    'exit' {
+                        return
+                    }
+                }
+
+            } else {
+                # Generate new root certificate
+                Write-Host "Generating new CA Cert..."
+
+                switch ($PSCmdlet.ParameterSetName) {
+                    'gui' {
+                        $env:certKeyPassword = ""
+                        # Loop until the passwords match
+                        do {
+                            # Prompt for password
+                            Write-Host "NOTE: Please save your root certificate password in a password manager" -foregroundcolor Yellow
+                            $secureCertKeyPass = Read-Host -Prompt "Enter a password for the certificate key" -AsSecureString
+
+                            # Reprompt for password
+                            $secureCertKeyPass2ReEntry = Read-Host -Prompt "Re-enter the password for the certificate key" -AsSecureString
+
+                            # Convert SecureString to plain text to validate
+                            $plainCertKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
+                            $plainCertKeyPassReEntry = ConvertFrom-SecureString $secureCertKeyPass2ReEntry -AsPlainText
+
+                            # Validate that the passwords match
+                            if ($plainCertKeyPass -ne $plainCertKeyPassReEntry) {
+                                Write-Host "Passwords do not match. Please try again." -foregroundcolor Red
+                            } else {
+                                Write-Host "Password set successfully" -foregroundcolor Green
+                                $certKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
+                            }
+                        } while ($plainCertKeyPass -ne $plainCertKeyPassReEntry)
+                    }
+                    'cli' {
+                        $certKeyPass = $certKeyPassword
+                    }
+                }
+                # Save the pass phrase in the env:
+                $env:certKeyPassword = $certKeyPass
+                Invoke-Expression "$JCR_OPENSSL req -x509 -newkey rsa:2048 -days $JCR_ROOT_CERT_VALIDITY_DAYS -keyout `"$outKey`" -out `"$outCA`" -passout pass:$($env:certKeyPassword) -subj /C=$($JCR_SUBJECT_HEADERS.countryCode)/ST=$($JCR_SUBJECT_HEADERS.stateCode)/L=$($JCR_SUBJECT_HEADERS.Locality)/O=$($JCR_SUBJECT_HEADERS.Organization)/OU=$($JCR_SUBJECT_HEADERS.OrganizationUnit)/CN=$($JCR_SUBJECT_HEADERS.CommonName)"
+                # REM PEM pass phrase: myorgpass
+                Invoke-Expression "$JCR_OPENSSL x509 -in `"$outCA`" -noout -text"
+                # openssl x509 -in ca-cert.pem -noout -text
+                # Update Extensions Distinguished Names:
+                $exts = Get-ChildItem -Path "$JCScriptRoot/Extensions"
+                foreach ($ext in $exts) {
+                    Write-Host "Updating Subject Headers for $($ext.Name)"
+                    $extContent = Get-Content -Path $ext.FullName -Raw
+                    $reqDistinguishedName = @"
+    [req_distinguished_name]
+    C = $($JCR_SUBJECT_HEADERS.countryCode)
+    ST = $($JCR_SUBJECT_HEADERS.stateCode)
+    L = $($JCR_SUBJECT_HEADERS.Locality)
+    O = $($JCR_SUBJECT_HEADERS.Organization)
+    OU = $($JCR_SUBJECT_HEADERS.OrganizationUnit)
+    CN = $($JCR_SUBJECT_HEADERS.CommonName)
+
+"@
+                    $extContent -Replace ("\[req_distinguished_name\][\s\S]*(?=\[v3_req\])", $reqDistinguishedName) | Set-Content -Path $ext.FullName -NoNewline -Force
+                }
+                return
+            }
+        }
+        # Replace current root certificate
+        '2' {
+            # Check if there is a current CA cert
+            if (Test-Path -Path "$JCScriptRoot/Cert/radius_ca_cert.pem") {
+
+                if (!$forceReplaceCert) {
+                    $overwrite = Get-ResponsePrompt -message "Do you want to overwrite/replace the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate."
+
+                    if ($PSCmdlet.ParameterSetName -eq 'cli') {
+                        $overwrite = Get-ResponsePrompt -message "Do you want to overwrite/replace the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate." -cli $true
+                    } else {
+                        $overwrite = Get-ResponsePrompt -message "Do you want to overwrite/replace the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate."
+                    }
+                } else {
+                    $overwrite = $true
+                }
+
+
+                switch ($overwrite) {
+                    $true {
+                        Write-Host "Replacing Root Cert..." -ForegroundColor Yellow
+                        switch ($PSCmdlet.ParameterSetName) {
+                            'gui' {
+                                $env:certKeyPassword = ""
+                                # Loop until the passwords match
+                                do {
+                                    # Prompt for password
+                                    Write-Host "NOTE: Please save your root certificate password in a password manager" -foregroundcolor Yellow
+                                    $secureCertKeyPass = Read-Host -Prompt "Enter a password for the certificate key" -AsSecureString
+
+                                    # Reprompt for password
+                                    $secureCertKeyPass2ReEntry = Read-Host -Prompt "Re-enter the password for the certificate key" -AsSecureString
+
+                                    # Convert SecureString to plain text to validate
+                                    $plainCertKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
+                                    $plainCertKeyPassReEntry = ConvertFrom-SecureString $secureCertKeyPass2ReEntry -AsPlainText
+
+                                    # Validate that the passwords match
+                                    if ($plainCertKeyPass -ne $plainCertKeyPassReEntry) {
+                                        Write-Host "Passwords do not match. Please try again." -foregroundcolor Red
+                                    } else {
+                                        Write-Host "Password set successfully" -foregroundcolor Green
+                                        $certKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
+                                    }
+                                } while ($plainCertKeyPass -ne $plainCertKeyPassReEntry)
+                            }
+                            'cli' {
+                                $certKeyPass = $certKeyPassword
+                            }
+                        }
+                        # Copy the current root cert to the backups folder
+                        try {
+                            Copy-Item -Path "$CertPath/radius_ca_cert.pem" -Destination "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
+                            Copy-Item -Path "$CertPath/radius_ca_key.pem" -Destination "$CertPath/Backups/radius_ca_key_$timestamp.pem"
+
+                            # Zip the root cert and key files
+                            $zipPath = "$CertPath/Backups/replace_radius_ca_cert_backup_$timestamp.zip"
+                            Compress-Archive -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem", "$CertPath/Backups/radius_ca_key_$timestamp.pem" -DestinationPath $zipPath
+
+                            # Remove the original files
+                            Remove-Item -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
+                            Remove-Item -Path "$CertPath/Backups/radius_ca_key_$timestamp.pem"
+                        } catch {
+                            Write-Error "Error backing up the current root cert and key. $($_.Exception.Message)"
+                        }
+
+                        # Save the pass phrase in the env:
+                        $env:certKeyPassword = $certKeyPass
+                        Invoke-Expression "$JCR_OPENSSL req -x509 -newkey rsa:2048 -days $JCR_ROOT_CERT_VALIDITY_DAYS -keyout `"$outKey`" -out `"$outCA`" -passout pass:$($env:certKeyPassword) -subj /C=$($JCR_SUBJECT_HEADERS.countryCode)/ST=$($JCR_SUBJECT_HEADERS.stateCode)/L=$($JCR_SUBJECT_HEADERS.Locality)/O=$($JCR_SUBJECT_HEADERS.Organization)/OU=$($JCR_SUBJECT_HEADERS.OrganizationUnit)/CN=$($JCR_SUBJECT_HEADERS.CommonName)"
+                        # REM PEM pass phrase: myorgpass
+                        Invoke-Expression "$JCR_OPENSSL x509 -in `"$outCA`" -noout -text"
+                        # openssl x509 -in ca-cert.pem -noout -text
+                        # Update Extensions Distinguished Names:
+                        $exts = Get-ChildItem -Path "$JCScriptRoot/Extensions"
+                        foreach ($ext in $exts) {
+                            Write-Host "Updating Subject Headers for $($ext.Name)"
+                            $extContent = Get-Content -Path $ext.FullName -Raw
+                            $reqDistinguishedName = @"
+[req_distinguished_name]
+C = $($JCR_SUBJECT_HEADERS.countryCode)
+ST = $($JCR_SUBJECT_HEADERS.stateCode)
+L = $($JCR_SUBJECT_HEADERS.Locality)
+O = $($JCR_SUBJECT_HEADERS.Organization)
+OU = $($JCR_SUBJECT_HEADERS.OrganizationUnit)
+CN = $($JCR_SUBJECT_HEADERS.CommonName)
+
+"@
+                            $extContent -Replace ("\[req_distinguished_name\][\s\S]*(?=\[v3_req\])", $reqDistinguishedName) | Set-Content -Path $ext.FullName -NoNewline -Force
+                        }
+                        return
+                    }
+                    $false {
+                        return
+                    }
+                    'exit' {
+                        return
+                    }
+                }
+
+
+            } else {
+                Write-Host "No Root Cert detected. Please generate a new CA Cert. Returning to main menu..." -ForegroundColor Yellow
+                return
+            }
+
+        }
+        '3' {
+            # Check if there is a current CA cert
+            if (Test-Path -Path "$JCScriptRoot/Cert/radius_ca_cert.pem") {
+
+                # Copy the current root cert to the backups folder and zip it
+                try {
+                    Copy-Item -Path "$CertPath/radius_ca_cert.pem" -Destination "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
+                    Copy-Item -Path "$CertPath/radius_ca_key.pem" -Destination "$CertPath/Backups/radius_ca_key_$timestamp.pem"
+
+                    # Zip the root cert and key files
+                    $zipPath = "$CertPath/Backups/replace_radius_ca_cert_backup_$timestamp.zip"
+                    Compress-Archive -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem", "$CertPath/Backups/radius_ca_key_$timestamp.pem" -DestinationPath $zipPath
+
+                    # Remove the original files
+                    Remove-Item -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
+                    Remove-Item -Path "$CertPath/Backups/radius_ca_key_$timestamp.pem"
+                } catch {
+                    Write-Error "Error backing up the current root cert and key. $($_.Exception.Message)"
+                }
+
+                $oldCACert = "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
+                $csrOutPath = "$CertPath/radius_ca_cert.csr"
+
+                $select = openssl x509 -in $oldCACert -serial -noout | Select-String -Pattern "serial=(.*)"
+                $serial = $select.Matches.Groups[1].value
+                Write-Host $serial
+
+                openssl x509 -x509toreq -in $oldCACert -signkey $outKey -out $csrOutPath
+                # Create path for cert2.conf
+                $certConfPath = "$CertPath/radius_ca_cert2.conf"
+                $string = @"
+[ v3_ca ]
+basicConstraints= CA:TRUE
+subjectKeyIdentifier= hash
+authorityKeyIdentifier= keyid:always,issuer:always
+"@ | Out-File "$certConfPath"
+
+                try {
+                    # Use invoke expression to run the openssl command
+                    Invoke-Expression "$JCR_OPENSSL req -x509 -newkey rsa:2048 -days $JCR_ROOT_CERT_VALIDITY_DAYS -keyout `"$outKey`" -out `"$outCA`" -passout pass:$($env:certKeyPassword) -subj /C=$($JCR_SUBJECT_HEADERS.countryCode)/ST=$($JCR_SUBJECT_HEADERS.stateCode)/L=$($JCR_SUBJECT_HEADERS.Locality)/O=$($JCR_SUBJECT_HEADERS.Organization)/OU=$($JCR_SUBJECT_HEADERS.OrganizationUnit)/CN=$($JCR_SUBJECT_HEADERS.CommonName)"
+
+                    Invoke-Expression "$JCR_OPENSSL x509 -req -days $JCR_ROOT_CERT_VALIDITY_DAYS -in $csrOutPath -set_serial `"0x$serial`" -signkey `"$outKey`" -out `"$outCA`" -extfile $certConfPath -extensions v3_ca"
+                    # openssl x509 -req -days $JCR_ROOT_CERT_VALIDITY_DAYS -in $csrOutPath -set_serial "0x$serial" -signkey $outKey -out $outCA -extfile $certConfPath -extensions v3_ca
+                    # Cleanup
+                    Remove-Item -Path $certConfPath
+                    Remove-Item -Path $csrOutPath
+                } catch {
+                    # Error replacing the certificate
+                    Write-Error "Error replacing the certificate. $($_.Exception.Message)"
+                }
+                Invoke-Expression "$JCR_OPENSSL x509 -in `"$outCA`" -enddate -noout "
+            } else {
+                Write-Host "No Root Cert detected. Please generate a new CA Cert. Returning to main menu..." -ForegroundColor Yellow
+                return
+            }
+        }
+        # Return to main menu
+        'E' {
+            return
+        }
     }
 }
+
+

--- a/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
@@ -45,6 +45,14 @@ Function Start-GenerateRootCert {
         New-Item -ItemType Directory -Path "$JCScriptRoot/Cert"
     }
 
+    # If cert backup folder does not exist, create it
+    if (Test-Path -Path "$JCScriptRoot/Cert/Backups") {
+        Write-Host "Backup Path Exists"
+    } else {
+        Write-Host "Creating Backup Path"
+        New-Item -ItemType Directory -Path "$JCScriptRoot/Cert/Backups"
+    }
+
     # If parameterSetname is CLI
     if ($PSCmdlet.ParameterSetName -eq 'cli') {
         switch ($GenerateType) {

--- a/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
+++ b/scripts/automation/Radius/Functions/Public/Start-GenerateRootCert.ps1
@@ -12,7 +12,7 @@ Function Start-GenerateRootCert {
         # Force invoke commands after generation
         [Parameter(HelpMessage = 'When specified, this parameter will replace certificates if they already exist on the current filesystem', ParameterSetName = 'cli')]
         [switch]
-        $forceReplaceCert
+        $force
 
 
     )
@@ -70,18 +70,18 @@ Function Start-GenerateRootCert {
         '1' {
             if (Test-Path -Path "$JCScriptRoot/Cert/radius_ca_cert.pem") {
                 Write-Host "Root Cert already exists"
-                # If the forceReplaceCert switch is set, force the generation of a new root certificate
-                if (!$forceReplaceCert) {
+                # If the force switch is set, force the generation of a new root certificate
+                if (!$force) {
                     if ($PSCmdlet.ParameterSetName -eq 'cli') {
-                        $overwrite = Get-ResponsePrompt -message "Do you want to overwrite the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate." -cli $true
+                        $overwritePrompt = Get-ResponsePrompt -message "Do you want to overwrite the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate." -cli $true
                     } else {
-                        $overwrite = Get-ResponsePrompt -message "Do you want to overwrite the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate."
+                        $overwritePrompt = Get-ResponsePrompt -message "Do you want to overwrite the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate."
                     }
-
                 } else {
-                    $overwrite = $true
+                    $overwritePrompt = $true
                 }
-                switch ($overwrite) {
+
+                switch ($overwritePrompt) {
                     $true {
                         Write-Host "Overwriting Root Cert..." -ForegroundColor Yellow
 
@@ -115,11 +115,21 @@ Function Start-GenerateRootCert {
                             }
                         }
 
-                        # Copy the current root cert to the backups folder
+                        # Copy the current root cert to the backups folder and zip it
                         try {
                             Copy-Item -Path "$CertPath/radius_ca_cert.pem" -Destination "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
+                            Copy-Item -Path "$CertPath/radius_ca_key.pem" -Destination "$CertPath/Backups/radius_ca_key_$timestamp.pem"
+
+                            # Zip the root cert and key files
+                            $zipPath = "$CertPath/Backups/newOverwrite_radius_ca_cert_backup_$timestamp.zip"
+                            Compress-Archive -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem", "$CertPath/Backups/radius_ca_key_$timestamp.pem" -DestinationPath $zipPath
+
+                            Remove-Item -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
+                            Remove-Item -Path "$CertPath/Backups/radius_ca_key_$timestamp.pem"
+
                         } catch {
-                            Write-Error "Error backing up the current root cert. $($_.Exception.Message)"
+                            Write-Error "Error backing up the current root cert and key. $($_.Exception.Message)"
+                            exit
                         }
                         # Save the pass phrase in the env:
                         $env:certKeyPassword = $certKeyPass
@@ -217,20 +227,18 @@ CN = $($JCR_SUBJECT_HEADERS.CommonName)
             # Check if there is a current CA cert
             if (Test-Path -Path "$JCScriptRoot/Cert/radius_ca_cert.pem") {
 
-                if (!$forceReplaceCert) {
-                    $overwrite = Get-ResponsePrompt -message "Do you want to overwrite/replace the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate."
-
+                if (!$force) {
                     if ($PSCmdlet.ParameterSetName -eq 'cli') {
-                        $overwrite = Get-ResponsePrompt -message "Do you want to overwrite/replace the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate." -cli $true
+                        $overwritePrompt = Get-ResponsePrompt -message "Do you want to overwrite/replace the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate." -cli $true
                     } else {
-                        $overwrite = Get-ResponsePrompt -message "Do you want to overwrite/replace the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate."
+                        $overwritePrompt = Get-ResponsePrompt -message "Do you want to overwrite/replace the existing CA Cert? This will generate a new root CA with a new serial number and user certs generated with the previous CA will no longer authenticate."
                     }
                 } else {
-                    $overwrite = $true
+                    $overwritePrompt = $true
                 }
 
 
-                switch ($overwrite) {
+                switch ($overwritePrompt) {
                     $true {
                         Write-Host "Replacing Root Cert..." -ForegroundColor Yellow
                         switch ($PSCmdlet.ParameterSetName) {
@@ -262,7 +270,7 @@ CN = $($JCR_SUBJECT_HEADERS.CommonName)
                                 $certKeyPass = $certKeyPassword
                             }
                         }
-                        # Copy the current root cert to the backups folder
+                        # Copy the current root cert to the backups folder and zip it
                         try {
                             Copy-Item -Path "$CertPath/radius_ca_cert.pem" -Destination "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
                             Copy-Item -Path "$CertPath/radius_ca_key.pem" -Destination "$CertPath/Backups/radius_ca_key_$timestamp.pem"
@@ -271,11 +279,12 @@ CN = $($JCR_SUBJECT_HEADERS.CommonName)
                             $zipPath = "$CertPath/Backups/replace_radius_ca_cert_backup_$timestamp.zip"
                             Compress-Archive -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem", "$CertPath/Backups/radius_ca_key_$timestamp.pem" -DestinationPath $zipPath
 
-                            # Remove the original files
                             Remove-Item -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
                             Remove-Item -Path "$CertPath/Backups/radius_ca_key_$timestamp.pem"
+
                         } catch {
                             Write-Error "Error backing up the current root cert and key. $($_.Exception.Message)"
+                            exit
                         }
 
                         # Save the pass phrase in the env:
@@ -319,56 +328,132 @@ CN = $($JCR_SUBJECT_HEADERS.CommonName)
 
         }
         '3' {
+            $env:certKeyPassword = $certKeyPass
             # Check if there is a current CA cert
             if (Test-Path -Path "$JCScriptRoot/Cert/radius_ca_cert.pem") {
 
-                # Copy the current root cert to the backups folder and zip it
-                try {
-                    Copy-Item -Path "$CertPath/radius_ca_cert.pem" -Destination "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
-                    Copy-Item -Path "$CertPath/radius_ca_key.pem" -Destination "$CertPath/Backups/radius_ca_key_$timestamp.pem"
-
-                    # Zip the root cert and key files
-                    $zipPath = "$CertPath/Backups/replace_radius_ca_cert_backup_$timestamp.zip"
-                    Compress-Archive -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem", "$CertPath/Backups/radius_ca_key_$timestamp.pem" -DestinationPath $zipPath
-
-                    # Remove the original files
-                    Remove-Item -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
-                    Remove-Item -Path "$CertPath/Backups/radius_ca_key_$timestamp.pem"
-                } catch {
-                    Write-Error "Error backing up the current root cert and key. $($_.Exception.Message)"
+                if (!$force) {
+                    if ($PSCmdlet.ParameterSetName -eq 'cli') {
+                        $replacePrompt = Get-ResponsePrompt -message "Do you want to renew the existing CA Cert? renewing the root CA will contain the same serial number and CA subject headers. User certs generated with the previous CA will continue to authenticate." -cli $true
+                    } else {
+                        $replacePrompt = Get-ResponsePrompt -message "Do you want to renew the existing CA Cert? renewing the root CA will contain the same serial number and CA subject headers. User certs generated with the previous CA will continue to authenticate."
+                    }
+                } else {
+                    $replacePrompt = $true
                 }
 
-                $oldCACert = "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
-                $csrOutPath = "$CertPath/radius_ca_cert.csr"
+                switch ($replacePrompt) {
+                    $true {
+                        Write-Host "Renewing Root Cert..." -ForegroundColor Yellow
+                        switch ($PSCmdlet.ParameterSetName) {
+                            'gui' {
+                                $env:certKeyPassword = ""
+                                # Loop until the passwords match
+                                $secureCertKeyPass = Read-Host -Prompt "Enter the current password for the certificate key" -AsSecureString
+                                $certKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
+                                do {
+                                    # Run the OpenSSL command and capture the result
+                                    $result = Invoke-Expression "$JCR_OPENSSL rsa -in `"$outKey`" -passin pass:$($certKeyPass) -check"
 
-                $select = openssl x509 -in $oldCACert -serial -noout | Select-String -Pattern "serial=(.*)"
-                $serial = $select.Matches.Groups[1].value
-                Write-Host $serial
+                                    # Check if the command was successful (e.g., "RSA key ok" is in the output)
+                                    if ($result -match "RSA key ok") {
+                                        Write-Host "Password validated! Proceeding..."
+                                        $env:certKeyPassword = $certKeyPass
+                                        $passwordValid = $true  # Exit condition for the loop
+                                    } else {
+                                        Write-Host "Incorrect password"
+                                        $passwordValid = $false  # Continue loop if password is incorrect
+                                        # Optionally, you could prompt the user to enter the password again
+                                        $secureCertKeyPass = Read-Host "Enter password for private key" -AsSecureString
+                                        $certKeyPass = ConvertFrom-SecureString $secureCertKeyPass -AsPlainText
+                                    }
+                                } while (-not $passwordValid)  # Continue looping until the password is correct
+                            }
+                            'cli' {
+                                $certKeyPass = $certKeyPassword
+                                # Validate that the password works with the old CA cert
+                                # Attempt to read the private key with the password
+                                do {
+                                    # Run the OpenSSL command and capture the result
+                                    $result = Invoke-Expression "$JCR_OPENSSL rsa -in `"$outKey`" -passin pass:$($certKeyPass) -check"
 
-                openssl x509 -x509toreq -in $oldCACert -signkey $outKey -out $csrOutPath
-                # Create path for cert2.conf
-                $certConfPath = "$CertPath/radius_ca_cert2.conf"
-                $string = @"
+                                    # Check if the command was successful (e.g., "RSA key ok" is in the output)
+                                    if ($result -match "RSA key ok") {
+                                        Write-Host "Password validated! Proceeding..."
+                                        $env:certKeyPassword = $certKeyPass
+                                        $passwordValid = $true  # Exit condition for the loop
+                                    } else {
+                                        Write-Host "Incorrect password"
+                                        $passwordValid = $false  # Continue loop if password is incorrect
+                                        # Optionally, you could prompt the user to enter the password again
+                                        $certKeyPass = Read-Host "Enter password for private key" -AsSecureString
+                                        $certKeyPass = ConvertFrom-SecureString $certKeyPass -AsPlainText
+                                    }
+                                } while (-not $passwordValid)  # Continue looping until the password is correct
+                            }
+                        }
+
+                        # Copy the current root cert to the backups folder and zip it
+                        try {
+                            Copy-Item -Path "$CertPath/radius_ca_cert.pem" -Destination "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
+                            Copy-Item -Path "$CertPath/radius_ca_key.pem" -Destination "$CertPath/Backups/radius_ca_key_$timestamp.pem"
+
+                            # Zip the root cert and key files
+                            $zipPath = "$CertPath/Backups/renew_radius_ca_cert_backup_$timestamp.zip"
+                            Compress-Archive -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem", "$CertPath/Backups/radius_ca_key_$timestamp.pem" -DestinationPath $zipPath
+
+                            Remove-Item -Path "$CertPath/Backups/radius_ca_cert_$timestamp.pem"
+                            Remove-Item -Path "$CertPath/Backups/radius_ca_key_$timestamp.pem"
+
+                        } catch {
+                            Write-Error "Error backing up the current root cert and key. $($_.Exception.Message)"
+                            exit
+                        }
+                        $certConfPath = "$CertPath/radius_ca_cert2.conf"
+                        $csrOutPath = "$CertPath/radius_ca_cert.csr"
+                        $select = Invoke-Expression "$JCR_OPENSSL x509 -in `"$($outCA)`" -serial -noout"
+                        $serial = $select -replace "serial=", ""
+
+                        # Validate that the password works with the old CA cert
+                        # Attempt to read the private key with the password
+
+                        try {
+                            Invoke-Expression "$JCR_OPENSSL x509 -x509toreq  -in $($outCA) -signkey $($outKey)  -out $csrOutPath -passin pass:$($env:certKeyPassword)"
+
+                        } catch {
+                            # Exit
+                            Write-Error "Error creating CSR file $($_.Exception.Message)"
+                            exit
+                        }
+
+                        $string = @"
 [ v3_ca ]
 basicConstraints= CA:TRUE
 subjectKeyIdentifier= hash
 authorityKeyIdentifier= keyid:always,issuer:always
 "@ | Out-File "$certConfPath"
 
-                try {
-                    # Use invoke expression to run the openssl command
-                    Invoke-Expression "$JCR_OPENSSL req -x509 -newkey rsa:2048 -days $JCR_ROOT_CERT_VALIDITY_DAYS -keyout `"$outKey`" -out `"$outCA`" -passout pass:$($env:certKeyPassword) -subj /C=$($JCR_SUBJECT_HEADERS.countryCode)/ST=$($JCR_SUBJECT_HEADERS.stateCode)/L=$($JCR_SUBJECT_HEADERS.Locality)/O=$($JCR_SUBJECT_HEADERS.Organization)/OU=$($JCR_SUBJECT_HEADERS.OrganizationUnit)/CN=$($JCR_SUBJECT_HEADERS.CommonName)"
+                        try {
+                            Invoke-Expression "$JCR_OPENSSL req -x509 -newkey rsa:2048 -days $JCR_ROOT_CERT_VALIDITY_DAYS -keyout `"$outKey`" -out `"$outCA`" -passout pass:$($env:certKeyPassword) -subj /C=$($JCR_SUBJECT_HEADERS.countryCode)/ST=$($JCR_SUBJECT_HEADERS.stateCode)/L=$($JCR_SUBJECT_HEADERS.Locality)/O=$($JCR_SUBJECT_HEADERS.Organization)/OU=$($JCR_SUBJECT_HEADERS.OrganizationUnit)/CN=$($JCR_SUBJECT_HEADERS.CommonName)"
 
-                    Invoke-Expression "$JCR_OPENSSL x509 -req -days $JCR_ROOT_CERT_VALIDITY_DAYS -in $csrOutPath -set_serial `"0x$serial`" -signkey `"$outKey`" -out `"$outCA`" -extfile $certConfPath -extensions v3_ca"
-                    # openssl x509 -req -days $JCR_ROOT_CERT_VALIDITY_DAYS -in $csrOutPath -set_serial "0x$serial" -signkey $outKey -out $outCA -extfile $certConfPath -extensions v3_ca
-                    # Cleanup
-                    Remove-Item -Path $certConfPath
-                    Remove-Item -Path $csrOutPath
-                } catch {
-                    # Error replacing the certificate
-                    Write-Error "Error replacing the certificate. $($_.Exception.Message)"
+                            Invoke-Expression "$JCR_OPENSSL x509 -req -days $JCR_ROOT_CERT_VALIDITY_DAYS -in $csrOutPath -set_serial `"0x$serial`" -signkey `"$outKey`" -out `"$outCA`" -extfile $certConfPath -extensions v3_ca -passin pass:$($env:certKeyPassword)"
+
+                            # Cleanup
+                            Remove-Item -Path $certConfPath
+                            Remove-Item -Path $csrOutPath
+                        } catch {
+                            # Error replacing the certificate
+                            Write-Error "Error replacing the certificate. $($_.Exception.Message)"
+                        }
+                        Invoke-Expression "$JCR_OPENSSL x509 -in `"$outCA`" -enddate -serial -noout "
+                    }
+                    $false {
+                        return
+                    }
+                    'exit' {
+                        return
+                    }
                 }
-                Invoke-Expression "$JCR_OPENSSL x509 -in `"$outCA`" -enddate -noout "
             } else {
                 Write-Host "No Root Cert detected. Please generate a new CA Cert. Returning to main menu..." -ForegroundColor Yellow
                 return

--- a/scripts/automation/Radius/JumpCloud-Radius.psm1
+++ b/scripts/automation/Radius/JumpCloud-Radius.psm1
@@ -31,6 +31,7 @@ $global:JCRConfig = Get-JCRSettingsFile
 # if the Certs / UserCerts directories do not exist, create them
 if (-Not (Test-Path -Path "$JCScriptRoot/Cert" -PathType Container)) {
     New-Item -Path "$JCScriptRoot/Cert" -ItemType Directory
+    New-Item -Path "$JCScriptRoot/Cert/Backups" -ItemType Directory
 }
 if (-Not (Test-Path -Path "$JCScriptRoot/UserCerts" -PathType Container)) {
     New-Item -Path "$JCScriptRoot/UserCerts" -ItemType Directory

--- a/scripts/automation/Radius/Tests/Public/Get-JCRGlobalVars.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Get-JCRGlobalVars.Tests.ps1
@@ -17,7 +17,7 @@ Describe "Get Global Variable Data Tests" -Tag "Cache" {
                 Write-Error -Message "Failed to import function $($Import.FullName): $_"
             }
         }
-        Start-GenerateRootCert -certKeyPassword "TestCertificate123!@#"
+        Start-GenerateRootCert -certKeyPassword "TestCertificate123!@#" -generateType "new" -force
     }
     Context "When no 'data' directory exists" {
         BeforeAll {

--- a/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Distribute User Cert Tests' -Tag 'Distribute' {
             Set-JCRAssociationHash -UserID $user.userID
         }
         Get-JCRGlobalVars -Force -associateManually
-        Start-GenerateRootCert -certKeyPassword "TestCertificate123!@#"
+        Start-GenerateRootCert -certKeyPassword "TestCertificate123!@#" -generateType "new" -force
 
     }
     Context 'Distribute all certificates for all users forcibly' {

--- a/scripts/automation/Radius/Tests/Public/Start-GenerateRootCert.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-GenerateRootCert.Tests.ps1
@@ -2,11 +2,22 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
     Context "A new certificate can be generated" {
         It 'Generates a new root certificate' {
             # If the /Cert/ folder is not empty, clear the directory
-            $items = Get-ChildItem $JCScriptRoot/Cert
+            $items = Get-ChildItem "$JCScriptRoot/Cert"
             if ($items) {
                 foreach ($item in $items) {
-                    write-host "removing $($item.FullName)"
-                    Remove-Item -Path $item.FullName -force
+                    # If the item is the 'backup' folder, process its contents separately
+                    if ($item.Name -eq 'Backups') {
+                        $backupItems = Get-ChildItem $item.FullName
+                        foreach ($backupItem in $backupItems) {
+                            Write-Host "Removing $($backupItem.FullName)"
+                            Remove-Item -Path $backupItem.FullName -Force
+                        }
+                    }
+                    # Otherwise, remove the item directly (outside of the 'backup' folder)
+                    elseif ($item.PSIsContainer -eq $false) {
+                        Write-Host "Removing $($item.FullName)"
+                        Remove-Item -Path $item.FullName -Force
+                    }
                 }
             }
             Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
@@ -36,11 +47,22 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
     Context "Overwrite an existing root certificate when creating a new one" {
         It 'Generates a new root certificate when there is an existing one' {
             # If the /Cert/ folder is not empty, clear the directory
-            $items = Get-ChildItem $JCScriptRoot/Cert
+            $items = Get-ChildItem "$JCScriptRoot/Cert"
             if ($items) {
                 foreach ($item in $items) {
-                    write-host "removing $($item.FullName)"
-                    Remove-Item -Path $item.FullName -Force
+                    # If the item is the 'backup' folder, process its contents separately
+                    if ($item.Name -eq 'Backups') {
+                        $backupItems = Get-ChildItem $item.FullName
+                        foreach ($backupItem in $backupItems) {
+                            Write-Host "Removing $($backupItem.FullName)"
+                            Remove-Item -Path $backupItem.FullName -Force
+                        }
+                    }
+                    # Otherwise, remove the item directly (outside of the 'backup' folder)
+                    elseif ($item.PSIsContainer -eq $false) {
+                        Write-Host "Removing $($item.FullName)"
+                        Remove-Item -Path $item.FullName -Force
+                    }
                 }
             }
 
@@ -82,11 +104,22 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
     Context "An existing certificate can be replaced" {
         It 'Replaces a root certificate' {
             # If the /Cert/ folder is not empty, clear the directory
-            $items = Get-ChildItem $JCScriptRoot/Cert
+            $items = Get-ChildItem "$JCScriptRoot/Cert"
             if ($items) {
                 foreach ($item in $items) {
-                    write-host "removing $($item.FullName)"
-                    Remove-Item -Path $item.FullName -Force
+                    # If the item is the 'backup' folder, process its contents separately
+                    if ($item.Name -eq 'Backups') {
+                        $backupItems = Get-ChildItem $item.FullName
+                        foreach ($backupItem in $backupItems) {
+                            Write-Host "Removing $($backupItem.FullName)"
+                            Remove-Item -Path $backupItem.FullName -Force
+                        }
+                    }
+                    # Otherwise, remove the item directly (outside of the 'backup' folder)
+                    elseif ($item.PSIsContainer -eq $false) {
+                        Write-Host "Removing $($item.FullName)"
+                        Remove-Item -Path $item.FullName -Force
+                    }
                 }
             }
             # Create a new root certificate
@@ -127,11 +160,22 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
     Context "An existing certificate can be renewed" {
         It 'Renews a root certificate' {
             # If the /Cert/ folder is not empty, clear the directory
-            $items = Get-ChildItem $JCScriptRoot/Cert
+            $items = Get-ChildItem "$JCScriptRoot/Cert"
             if ($items) {
                 foreach ($item in $items) {
-                    write-host "removing $($item.FullName)"
-                    Remove-Item -Path $item.FullName -Force
+                    # If the item is the 'backup' folder, process its contents separately
+                    if ($item.Name -eq 'Backups') {
+                        $backupItems = Get-ChildItem $item.FullName
+                        foreach ($backupItem in $backupItems) {
+                            Write-Host "Removing $($backupItem.FullName)"
+                            Remove-Item -Path $backupItem.FullName -Force
+                        }
+                    }
+                    # Otherwise, remove the item directly (outside of the 'backup' folder)
+                    elseif ($item.PSIsContainer -eq $false) {
+                        Write-Host "Removing $($item.FullName)"
+                        Remove-Item -Path $item.FullName -Force
+                    }
                 }
             }
             # Generate new CA

--- a/scripts/automation/Radius/Tests/Public/Start-GenerateRootCert.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-GenerateRootCert.Tests.ps1
@@ -36,9 +36,6 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
             ($CA_subject | Where-Object { $_ -match "O=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.Organization
             ($CA_subject | Where-Object { $_ -match "OU=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.OrganizationUnit
             ($CA_subject | Where-Object { $_ -match "CN=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.CommonName
-
-            # Clean up the Cert directory
-            Remove-Item -Path $JCScriptRoot/Cert/* -Force
         }
     }
 
@@ -95,9 +92,6 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
             ($CA_subject | Where-Object { $_ -match "O=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.Organization
             ($CA_subject | Where-Object { $_ -match "OU=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.OrganizationUnit
             ($CA_subject | Where-Object { $_ -match "CN=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.CommonName
-
-            # Clean up the Cert directory
-            Remove-Item -Path $JCScriptRoot/Cert/* -Force
         }
     }
 
@@ -151,9 +145,6 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
             ($CA_subject | Where-Object { $_ -match "O=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.Organization
             ($CA_subject | Where-Object { $_ -match "OU=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.OrganizationUnit
             ($CA_subject | Where-Object { $_ -match "CN=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.CommonName
-
-            # Clean up the Cert directory
-            Remove-Item -Path $JCScriptRoot/Cert/* -Force
         }
 
     }
@@ -207,9 +198,6 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
             ($CA_subject | Where-Object { $_ -match "O=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.Organization
             ($CA_subject | Where-Object { $_ -match "OU=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.OrganizationUnit
             ($CA_subject | Where-Object { $_ -match "CN=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.CommonName
-
-            # Clean up the Cert directory
-            Remove-Item -Path $JCScriptRoot/Cert/* -Force
         }
 
     }

--- a/scripts/automation/Radius/Tests/Public/Start-GenerateRootCert.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-GenerateRootCert.Tests.ps1
@@ -6,7 +6,7 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
             if ($items) {
                 foreach ($item in $items) {
                     write-host "removing $($item.FullName)"
-                    Remove-Item -Path $item.FullName
+                    Remove-Item -Path $item.FullName -force
                 }
             }
             Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
@@ -35,6 +35,14 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
 
     Context "Overwrite an existing root certificate when creating a new one" {
         It 'Generates a new root certificate when there is an existing one' {
+            # If the /Cert/ folder is not empty, clear the directory
+            $items = Get-ChildItem $JCScriptRoot/Cert
+            if ($items) {
+                foreach ($item in $items) {
+                    write-host "removing $($item.FullName)"
+                    Remove-Item -Path $item.FullName -Force
+                }
+            }
 
             # Create a new root certificate
             Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "New" -force
@@ -73,7 +81,14 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
 
     Context "An existing certificate can be replaced" {
         It 'Replaces a root certificate' {
-
+            # If the /Cert/ folder is not empty, clear the directory
+            $items = Get-ChildItem $JCScriptRoot/Cert
+            if ($items) {
+                foreach ($item in $items) {
+                    write-host "removing $($item.FullName)"
+                    Remove-Item -Path $item.FullName -Force
+                }
+            }
             # Create a new root certificate
             Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
             # get existing cert serial:
@@ -111,7 +126,14 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
     }
     Context "An existing certificate can be renewed" {
         It 'Renews a root certificate' {
-
+            # If the /Cert/ folder is not empty, clear the directory
+            $items = Get-ChildItem $JCScriptRoot/Cert
+            if ($items) {
+                foreach ($item in $items) {
+                    write-host "removing $($item.FullName)"
+                    Remove-Item -Path $item.FullName -Force
+                }
+            }
             # Generate new CA
             Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
             # get existing cert serial:

--- a/scripts/automation/Radius/Tests/Public/Start-GenerateRootCert.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-GenerateRootCert.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
                     Remove-Item -Path $item.FullName
                 }
             }
-            Start-GenerateRootCert -certKeyPassword "testCertificate123!@#"
+            Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
 
             # both the key and the cert should be generated
             $itemsAfter = Get-ChildItem $JCScriptRoot/Cert
@@ -25,17 +25,23 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
             ($CA_subject | Where-Object { $_ -match "O=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.Organization
             ($CA_subject | Where-Object { $_ -match "OU=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.OrganizationUnit
             ($CA_subject | Where-Object { $_ -match "CN=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.CommonName
+
+            # Clean up the Cert directory
+            Remove-Item -Path $JCScriptRoot/Cert/* -Force
         }
     }
 
     # Overwrite the existing certificate
 
-    Context "Overwrite an existing root certificate" {
+    Context "Overwrite an existing root certificate when creating a new one" {
         It 'Generates a new root certificate when there is an existing one' {
+
+            # Create a new root certificate
+            Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "New" -force
             # get existing cert serial:
             $origSN = Invoke-Expression "$JCR_OPENSSL x509 -noout -in $JCScriptRoot/Cert/radius_ca_cert.pem -serial"
-            # force generate new CA
-            Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "New" -forceReplaceCert
+            # Force overwrite the existing certificate
+            Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "New" -force
             # get new SN
             $newSN = Invoke-Expression "$JCR_OPENSSL x509 -noout -in $JCScriptRoot/Cert/radius_ca_cert.pem -serial"
             # the serial numbers of the cert should not be the same, i.e. a new cert has replaced the existing one
@@ -59,15 +65,21 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
             ($CA_subject | Where-Object { $_ -match "O=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.Organization
             ($CA_subject | Where-Object { $_ -match "OU=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.OrganizationUnit
             ($CA_subject | Where-Object { $_ -match "CN=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.CommonName
+
+            # Clean up the Cert directory
+            Remove-Item -Path $JCScriptRoot/Cert/* -Force
         }
     }
 
     Context "An existing certificate can be replaced" {
         It 'Replaces a root certificate' {
+
+            # Create a new root certificate
+            Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
             # get existing cert serial:
             $origSN = Invoke-Expression "$JCR_OPENSSL x509 -noout -in $JCScriptRoot/Cert/radius_ca_cert.pem -serial"
-            # force generate new CA
-            Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "replace" -forceReplaceCert
+            # Replace root certificate
+            Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "replace" -force
             # get new SN
             $newSN = Invoke-Expression "$JCR_OPENSSL x509 -noout -in $JCScriptRoot/Cert/radius_ca_cert.pem -serial"
             # the serial numbers of the cert should not be the same, i.e. a new cert has replaced the existing one
@@ -91,15 +103,21 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
             ($CA_subject | Where-Object { $_ -match "O=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.Organization
             ($CA_subject | Where-Object { $_ -match "OU=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.OrganizationUnit
             ($CA_subject | Where-Object { $_ -match "CN=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.CommonName
+
+            # Clean up the Cert directory
+            Remove-Item -Path $JCScriptRoot/Cert/* -Force
         }
 
     }
     Context "An existing certificate can be renewed" {
         It 'Renews a root certificate' {
+
+            # Generate new CA
+            Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
             # get existing cert serial:
             $origSN = Invoke-Expression "$JCR_OPENSSL x509 -noout -in $JCScriptRoot/Cert/radius_ca_cert.pem -serial"
-            # force generate new CA
-            Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "renew" -forceReplaceCert
+            # Renew CA
+            Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "renew" -force
             # get new SN
             $newSN = Invoke-Expression "$JCR_OPENSSL x509 -noout -in $JCScriptRoot/Cert/radius_ca_cert.pem -serial"
             # the serial numbers of the cert should not be the same, i.e. a new cert has replaced the existing one
@@ -123,17 +141,10 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
             ($CA_subject | Where-Object { $_ -match "O=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.Organization
             ($CA_subject | Where-Object { $_ -match "OU=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.OrganizationUnit
             ($CA_subject | Where-Object { $_ -match "CN=" }) | Should -Match $Global:JCR_SUBJECT_HEADERS.CommonName
+
+            # Clean up the Cert directory
+            Remove-Item -Path $JCScriptRoot/Cert/* -Force
         }
-
-    }
-    Context "Zip backup should be created when replacing certs" {
-
-
-    }
-    Context "Zip backup should be created when renewing certs" {
-
-    }
-    Context "Zip backup should be created when overwrting certs" {
 
     }
 }

--- a/scripts/automation/Radius/Tests/Public/Start-GenerateUserCerts.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-GenerateUserCerts.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'Generate User Cert Tests' -Tag "GenerateUserCerts" {
                 Write-Error -Message "Failed to import function $($Import.FullName): $_"
             }
         }
-        Start-GenerateRootCert -certKeyPassword "testCertificate123!@#"
+        Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
     }
     Context 'Certs forcibly re-generated for all users' {
         It 'Certs re-generated have actually been re-written for all users' {

--- a/scripts/automation/Radius/readme.md
+++ b/scripts/automation/Radius/readme.md
@@ -154,6 +154,12 @@ A Certificate Authority (CA) is required for passwordless Radius Authentication.
 
 The first option in the menu will present options to generate a self-signed CA. The resulting file `radius_ca_cert.pem` in the `projectDirectory/Radius/Cert` directory. When generating a self signed CA, a password prompt is displayed, this password is used to protect the CA from unauthorized access. Choose a secure but memorable password, during the session this password will be stored as an environment variable as it is required to generate user certificates.
 
+#### Renewing a self-signed certificate
+
+The second option in the root certificate menu allows you to renew the current CA certificate. During the renewal process, you will be prompted to enter the password for the current private key. This ensures that administrators can renew expiring CA certificates while maintaining the ability to authenticate user certificates issued by the previous CA. The renewed certificate will retain the same serial number and CA headers.
+
+![Root Cert Menu](./images/rootCertMenu.png)
+
 #### Importing a certificate
 
 To Import your own CA, the certificate and key files can be copied to the `projectDirectory/Radius/Cert` directory. **Note: Please ensure the certificate and key name ends with `key.pem` and `cert.pem` (ex. `radius_ca_cert.pem` or `radius_ca_key.pem`)**


### PR DESCRIPTION
## Issues
* [CUT-4092](https://jumpcloud.atlassian.net/browse/CUT-4092) - Generate-RootCert-Menu

## What does this solve?
Adds new functionality when generating/updating root certificate. 
Root Cert Menu system with 3 options:

1.  `New` - This will generate a new root certificate. If a root certificate is present, it will be an option to overwrite it
2.  `Replace` - Will replace current root cert and the generated root cert will have a different serial number. User certs generated with the previous root cert `will no longer authenticate`
3. `Renew` - Renewing will replace the current root cert but will retain the same serial number and headers. User certs generated with the previous root cert `will continue to authenticate`

![image](https://github.com/user-attachments/assets/ab00e05d-0823-4df6-904f-077ee08c0d49)


## Is there anything particularly tricky?
N/a
## How should this be tested?
### CLI
**Generate new root cert**
Note: Make sure to empty the cert folder before running new root cert
Note: You can use -force parameter to disregard prompts when running the commands

- Create new root cert: 
```powershell
Start-GenerateRootCert -certKeyPassword "testCertificate123!222" -generateType "new"
``` 
- Overwrite current root cert, this should create a backup zip file containing the old root cert and key: 
```powershell
Start-GenerateRootCert -certKeyPassword "testCertificate123!222" -generateType "new"
``` 
![image](https://github.com/user-attachments/assets/c0a16412-f4bb-46a0-a2cb-33e680665910)

**Replace current root cert**
- Replace current root cert. Should create new certificate with different serial number.
```powershell
Start-GenerateRootCert -certKeyPassword "testCertificate123!222" -generateType "replace"
``` 
- If no root cert is detected: 
![image](https://github.com/user-attachments/assets/fbfe496c-c513-41f7-a6d4-99d96a45ac7d)

**Renew current root cert**
- Renew current root cert. Should renew root cert with the same headers and serial number. 
```powershell
Start-GenerateRootCert -certKeyPassword "testCertificate123!222" -generateType "renew"
``` 
- Validate that a backup zip file is created
![image](https://github.com/user-attachments/assets/53749b04-7212-4877-a914-66ce8201181b)

- Validate that using an invalid private key password when renewing is not allowed. 
```powershell
Start-GenerateRootCert -certKeyPassword "InvalidPassword" -generateType "renew"
```  
You should be prompted to re-enter private key password:
![image](https://github.com/user-attachments/assets/b08c60ce-72e6-4093-9fe1-f2a51a47f26c)

- If no root cert detected:
![image](https://github.com/user-attachments/assets/05fc8145-8910-42a1-a161-d3b6dc9adb5f)


### GUI
1. Go to the root cert menu by pressing '1' from the main menu
2. Test New, Replace, and Renew functionalities:

**Generate new root cert**
- From the root cert menu, Press '1' to generate new root certificate. A certificate should be generated
- Re-Run and overwrite the previously generated cert. A new cert should be generated as well as a zip file that contains the backup cert and key files
![image](https://github.com/user-attachments/assets/5c3936ac-9c47-4609-99e6-34f5feec9738)

**Replace current root cert**
- From the root cert menu, Press '2' to replace current root certificate. This should overwrite/replace the current certificate with different serial number. A backup zip file should also be created 
![image](https://github.com/user-attachments/assets/65754131-7e8e-4c53-bad5-e4d2971b09cf)
- Delete the cert, key, and backups. From the root cert menu, Press '2' to replace current root certificate. No root cert detected message should appear
![image](https://github.com/user-attachments/assets/c8909b30-0159-4ec0-8d37-ea0d80bbf248)

**Renew current root cert**
- MUST have cert and key present in the Cert folder
- From the root cert menu, Press '3' to renew current root certificate. 
- You must enter a valid private key password (password you used to create the root cert), else you will be prompted to re-enter a valid private key password. If a valid private key password, a cert with the same serial number and subject headers should be created
Invalid private key password:
![image](https://github.com/user-attachments/assets/fd538f60-7e91-4c4f-aaed-8008029b126b)
Valid private key password:
![image](https://github.com/user-attachments/assets/e3f08fcb-e1f8-48e5-89f0-f2629b6c7a57)
- Backup file should be created:
![image](https://github.com/user-attachments/assets/7dd0faf4-039c-4246-97ab-2a7fd7f3085d)



[CUT-4092]: https://jumpcloud.atlassian.net/browse/CUT-4092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ