### PR TITLE
sup-1492

### DIFF
--- a/scripts/windows/log_collection.ps1
+++ b/scripts/windows/log_collection.ps1
@@ -229,7 +229,7 @@ function Gather-Logs {
                     $rsopCmd = "gpresult /SCOPE COMPUTER /H $rsopOutputPath"
                     Invoke-Expression $rsopCmd
                 }
-                 "Active Directory Logs" {
+                "Active Directory Logs" {
                     $files += $fileList["ADLogs"]
                     $eventLogs += $eventLogList["EssentialEvents"]
                     # Export AD Integration Registry Keys
@@ -246,14 +246,13 @@ function Gather-Logs {
                         Write-Warning "No AD Sync Agent Keys exist"
                     }
                     # Output DistinguishedName to a Text File
-                    Import-Module Activedirectory
-                    if (get-Module -Name ActiveDirectory) {
+                    Import-Module ActiveDirectory
+                    if (Get-Module -Name ActiveDirectory) {
                         $distinguishedName = (Get-ADDomain).DistinguishedName
                         $distinguishedName | Out-File -FilePath (Join-Path $tempDir "AD_DistinguishedName.txt")
                     } else {
                         Write-Warning "The Active Directory PowerShell Module was not installed"
-                    } 
-
+                    }
                 }
             }
         }

--- a/scripts/windows/log_collection.ps1
+++ b/scripts/windows/log_collection.ps1
@@ -107,7 +107,7 @@ function Gather-Logs {
                 "C:\windows\temp\jcagent.log"
             )
             "ADLogs"              = @(
-                "C:\Program Files\JumpCloud\AD Integration\JumpCloud AD Import\JumpCloud_AD_Import_Grpc.log",
+                "C:\Program Files\JumpCloud\AD Integration\JumpCloud AD Import\JumpCloud_AD_Import_Grpc*.log",
                 "C:\Windows\Temp\JumpCloud_AD_Integration.log",
                 "C:\Program Files\JumpCloud\AD Integration\JumpCloud AD Import\jcadimportagent.config.json",
                 "C:\Program Files\JumpCloud\AD Integration\JumpCloud AD Sync\JumpCloud_AD_Sync.log",
@@ -229,8 +229,9 @@ function Gather-Logs {
                     $rsopCmd = "gpresult /SCOPE COMPUTER /H $rsopOutputPath"
                     Invoke-Expression $rsopCmd
                 }
-                "Active Directory Logs" {
+                 "Active Directory Logs" {
                     $files += $fileList["ADLogs"]
+                    $eventLogs += $eventLogList["EssentialEvents"]
                     # Export AD Integration Registry Keys
                     # test for import agent files
                     if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\JumpCloud\AD Integration Import Agent" -ErrorAction SilentlyContinue ) {
@@ -245,12 +246,14 @@ function Gather-Logs {
                         Write-Warning "No AD Sync Agent Keys exist"
                     }
                     # Output DistinguishedName to a Text File
-                    if (Get-Module -Name ActiveDirectory) {
+                    Import-Module Activedirectory
+                    if (get-Module -Name ActiveDirectory) {
                         $distinguishedName = (Get-ADDomain).DistinguishedName
                         $distinguishedName | Out-File -FilePath (Join-Path $tempDir "AD_DistinguishedName.txt")
                     } else {
                         Write-Warning "The Active Directory PowerShell Module was not installed"
-                    }
+                    } 
+
                 }
             }
         }


### PR DESCRIPTION
## Issues
*(https://jumpcloud.atlassian.net/browse/SUP-1492)
## What does this solve?
Adding additional files collected due to changes in AD Import Agent 3.20.0.

Collecting Standard Event Viewer logs
Collecting rolling logs for file "C:\Program Files\JumpCloud\AD Integration\JumpCloud AD Import\JumpCloud_AD_Import_Grpc.log"

## Is there anything particularly tricky?
No

## How should this be tested?
Run this on a Domain Controller and use option 10 to collect all logs. Verify that EventViewer files and grpc.log variants are present.

## Screenshots
