### PR TITLE
Tests for radius membership

### DIFF
--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Get-CertInfo.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Get-CertInfo.ps1
@@ -23,10 +23,17 @@ function Get-CertInfo {
         if ($UserCerts) {
             # Find all userCert paths
             if ($username) {
-                $foundCerts = Resolve-Path -Path "$JCScriptRoot/UserCerts/$username-*.crt" -ErrorAction SilentlyContinue
+                $foundCerts = Resolve-Path -Path "$JCScriptRoot/UserCerts/$username-$($Global:JCR_CERT_TYPE)*.crt" -ErrorAction SilentlyContinue
 
             } else {
-                $foundCerts = Resolve-Path -Path "$JCScriptRoot/UserCerts/*.crt" -ErrorAction SilentlyContinue
+                $foundCerts = New-Object System.Collections.ArrayList
+                $global:JCRRadiusMembers.username | ForEach-Object {
+                    $foundCert = Resolve-Path -Path "$JCScriptRoot/UserCerts/$_-$($Global:JCR_CERT_TYPE)*.crt" -ErrorAction SilentlyContinue
+                    if ($foundCert) {
+                        $foundCerts.Add($foundCert) | Out-Null
+                    }
+
+                }
             }
         }
 

--- a/scripts/automation/Radius/Functions/Private/HashFunctions/Test-UserFromHash.ps1
+++ b/scripts/automation/Radius/Functions/Private/HashFunctions/Test-UserFromHash.ps1
@@ -37,7 +37,7 @@ function Test-UserFromHash {
                 # Get the UserID from the keys
                 $matchedUserID = $Global:JCRUsers.keys | Select-Object -Index $matchedIndex
                 # validate that the userID is in the radiusMembership hash:
-                if ($matchedIndex) {
+                if ($matchedUserID) {
                     # finally return the $matchedUser object
                     $matchedUser = $Global:JCRUsers[$matchedUserID]
                 } else {

--- a/scripts/automation/Radius/Tests/Public/Get-JCRGlobalVars.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Get-JCRGlobalVars.Tests.ps1
@@ -211,7 +211,7 @@ Describe "Get Global Variable Data Tests" -Tag "Cache" {
             Get-JCRGlobalVars -force -skipAssociation -associateManually
             Start-Sleep 1
             # the new user should be in the membership list
-            $global:JCRadiusMembers.username | Should -Contain $user.username
+            $global:JCRRadiusMembers.username | Should -Contain $user.username
 
             # the new user should be in user.json list
             $userData = Get-UserJsonData
@@ -231,7 +231,7 @@ Describe "Get Global Variable Data Tests" -Tag "Cache" {
             Get-JCRGlobalVars -force -skipAssociation -associateManually
             Start-Sleep 1
             # the new user should be in the membership list
-            $global:JCRadiusMembers.username | Should -Not -Contain $user.username
+            $global:JCRRadiusMembers.username | Should -Not -Contain $user.username
 
             # the new user should be in user.json list
             $userData = Get-UserJsonData

--- a/scripts/automation/Radius/Tests/Public/Get-JCRGlobalVars.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Get-JCRGlobalVars.Tests.ps1
@@ -196,4 +196,46 @@ Describe "Get Global Variable Data Tests" -Tag "Cache" {
         }
 
     }
+    Context "Tests that the RadiusMembers.json file is updated when users are added or removed from the user group" {
+        BeforeAll {
+            # create a new user
+            $user = New-RandomUser -Domain "pesterRadius" | New-JCUser
+        }
+        It "when a user is added to the group, they should be added to the RadiusMembers.json & users.json file" {
+            # get the RadiusMembers.json before
+            # get the user.json file before
+            # add a user to the radius Group
+            Add-JCUserGroupMember -GroupID $Global:JCR_USER_GROUP -UserID $user.id
+            Start-Sleep 1
+            # update the cache forcefully
+            Get-JCRGlobalVars -force -skipAssociation -associateManually
+            Start-Sleep 1
+            # the new user should be in the membership list
+            $global:JCRadiusMembers.username | Should -Contain $user.username
+
+            # the new user should be in user.json list
+            $userData = Get-UserJsonData
+            $userData.username | Should -Contain $user.username
+
+
+
+
+        }
+        It "when a user is removed from the group, they should be removed to the RadiusMembers.json & users.json file" {
+            # get the RadiusMembers.json before
+            # get the user.json file before
+            # add a user to the radius Group
+            Remove-JCUserGroupMember -GroupID $Global:JCR_USER_GROUP -UserID $user.id
+            Start-Sleep 1
+            # update the cache forcefully
+            Get-JCRGlobalVars -force -skipAssociation -associateManually
+            Start-Sleep 1
+            # the new user should be in the membership list
+            $global:JCRadiusMembers.username | Should -Not -Contain $user.username
+
+            # the new user should be in user.json list
+            $userData = Get-UserJsonData
+            $userData.username | Should -Not -Contain $user.username
+        }
+    }
 }

--- a/scripts/automation/Radius/Tests/Public/Start-GenerateRootCert.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-GenerateRootCert.Tests.ps1
@@ -1,25 +1,16 @@
 Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
+    BeforeEach {
+        # If the /Cert/ folder is not empty, clear the directory
+        $items = Get-ChildItem "$JCScriptRoot/Cert"
+        if ($items) {
+            foreach ($item in $items) {
+                # If the item is the 'backup' folder, process its contents separately
+                Remove-Item -Path $item.FullName -Recurse -Force -Confirm:$false
+            }
+        }
+    }
     Context "A new certificate can be generated" {
         It 'Generates a new root certificate' {
-            # If the /Cert/ folder is not empty, clear the directory
-            $items = Get-ChildItem "$JCScriptRoot/Cert"
-            if ($items) {
-                foreach ($item in $items) {
-                    # If the item is the 'backup' folder, process its contents separately
-                    if ($item.Name -eq 'Backups') {
-                        $backupItems = Get-ChildItem $item.FullName
-                        foreach ($backupItem in $backupItems) {
-                            Write-Host "Removing $($backupItem.FullName)"
-                            Remove-Item -Path $backupItem.FullName -Force
-                        }
-                    }
-                    # Otherwise, remove the item directly (outside of the 'backup' folder)
-                    elseif ($item.PSIsContainer -eq $false) {
-                        Write-Host "Removing $($item.FullName)"
-                        Remove-Item -Path $item.FullName -Force
-                    }
-                }
-            }
             Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
 
             # both the key and the cert should be generated
@@ -43,26 +34,6 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
 
     Context "Overwrite an existing root certificate when creating a new one" {
         It 'Generates a new root certificate when there is an existing one' {
-            # If the /Cert/ folder is not empty, clear the directory
-            $items = Get-ChildItem "$JCScriptRoot/Cert"
-            if ($items) {
-                foreach ($item in $items) {
-                    # If the item is the 'backup' folder, process its contents separately
-                    if ($item.Name -eq 'Backups') {
-                        $backupItems = Get-ChildItem $item.FullName
-                        foreach ($backupItem in $backupItems) {
-                            Write-Host "Removing $($backupItem.FullName)"
-                            Remove-Item -Path $backupItem.FullName -Force
-                        }
-                    }
-                    # Otherwise, remove the item directly (outside of the 'backup' folder)
-                    elseif ($item.PSIsContainer -eq $false) {
-                        Write-Host "Removing $($item.FullName)"
-                        Remove-Item -Path $item.FullName -Force
-                    }
-                }
-            }
-
             # Create a new root certificate
             Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "New" -force
             # get existing cert serial:
@@ -97,25 +68,6 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
 
     Context "An existing certificate can be replaced" {
         It 'Replaces a root certificate' {
-            # If the /Cert/ folder is not empty, clear the directory
-            $items = Get-ChildItem "$JCScriptRoot/Cert"
-            if ($items) {
-                foreach ($item in $items) {
-                    # If the item is the 'backup' folder, process its contents separately
-                    if ($item.Name -eq 'Backups') {
-                        $backupItems = Get-ChildItem $item.FullName
-                        foreach ($backupItem in $backupItems) {
-                            Write-Host "Removing $($backupItem.FullName)"
-                            Remove-Item -Path $backupItem.FullName -Force
-                        }
-                    }
-                    # Otherwise, remove the item directly (outside of the 'backup' folder)
-                    elseif ($item.PSIsContainer -eq $false) {
-                        Write-Host "Removing $($item.FullName)"
-                        Remove-Item -Path $item.FullName -Force
-                    }
-                }
-            }
             # Create a new root certificate
             Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
             # get existing cert serial:
@@ -150,25 +102,6 @@ Describe "Generate Root Certificate Tests" -Tag "GenerateRootCert" {
     }
     Context "An existing certificate can be renewed" {
         It 'Renews a root certificate' {
-            # If the /Cert/ folder is not empty, clear the directory
-            $items = Get-ChildItem "$JCScriptRoot/Cert"
-            if ($items) {
-                foreach ($item in $items) {
-                    # If the item is the 'backup' folder, process its contents separately
-                    if ($item.Name -eq 'Backups') {
-                        $backupItems = Get-ChildItem $item.FullName
-                        foreach ($backupItem in $backupItems) {
-                            Write-Host "Removing $($backupItem.FullName)"
-                            Remove-Item -Path $backupItem.FullName -Force
-                        }
-                    }
-                    # Otherwise, remove the item directly (outside of the 'backup' folder)
-                    elseif ($item.PSIsContainer -eq $false) {
-                        Write-Host "Removing $($item.FullName)"
-                        Remove-Item -Path $item.FullName -Force
-                    }
-                }
-            }
             # Generate new CA
             Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
             # get existing cert serial:

--- a/scripts/automation/Radius/Tests/Public/Start-GenerateUserCerts.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-GenerateUserCerts.Tests.ps1
@@ -46,13 +46,14 @@ Describe 'Generate User Cert Tests' -Tag "GenerateUserCerts" {
             # Get the certs before
             $certsBefore = Get-ChildItem -Path "$JCScriptRoot/UserCerts"
             # wait one moment
-            Start-Sleep 2
+            Start-Sleep 1
             # update the cache
             Get-JCRGlobalVars -force -skipAssociation -associateManually
             # wait just one moment before testing membership since we are writing a file
             Start-Sleep 1
             # the new user should be in the membership list:
             $global:JCRRadiusMembers.username | Should -Contain $user.username
+            $Global:JCRUsers.keys | should -Contain $user.id
             # Generate the user cert:
             Start-GenerateUserCerts -type ByUsername -username $($user.username) -forceReplaceCerts
             # Get the certs after
@@ -170,13 +171,14 @@ Describe 'Generate User Cert Tests' -Tag "GenerateUserCerts" {
             # Get the certs before
             $certsBefore = Get-ChildItem -Path "$JCScriptRoot/UserCerts"
             # wait one moment
-            Start-Sleep 2
+            Start-Sleep 1
             # update the cache
             Get-JCRGlobalVars -force -skipAssociation -associateManually
             # wait just one moment before testing membership since we are writing a file
             Start-Sleep 1
             # the new user should be in the membership list:
             $global:JCRRadiusMembers.username | Should -Contain $user.username
+            $Global:JCRUsers.keys | should -Contain $user.id
             # Generate the user cert:
             Start-GenerateUserCerts -type ByUsername -username $($user.username) -forceReplaceCerts
             # Get the certs after
@@ -201,13 +203,14 @@ Describe 'Generate User Cert Tests' -Tag "GenerateUserCerts" {
             # Get the certs before
             $certsBefore = Get-ChildItem -Path "$JCScriptRoot/UserCerts"
             # wait one moment
-            Start-Sleep 2
+            Start-Sleep 1
             # update the cache
             Get-JCRGlobalVars -force -skipAssociation -associateManually
             # wait just one moment before testing membership since we are writing a file
             Start-Sleep 1
             # the new user should be in the membership list:
             $global:JCRRadiusMembers.username | Should -Contain $user.username
+            $Global:JCRUsers.keys | should -Contain $user.id
             # Generate the user cert:
             Start-GenerateUserCerts -type ByUsername -username $($user.username) -forceReplaceCerts
             # Get the certs after


### PR DESCRIPTION
## Issues
* [CUT-4093](https://jumpcloud.atlassian.net/browse/CUT-4093) - Validate membership tests

## What does this solve?

- If large numbers of certificates are stored in the user certificates directory this update to the module will parse only the certificates that match usernames of the users in the defined radius group.
- BugFix for cases where a user was in the radius member group but their cert could not be identified if they were the first user in the group.
- Update tests to expand expected behavior

## Is there anything particularly tricky?

## How should this be tested?
Automated tests cover these changes

## Screenshots


[CUT-4093]: https://jumpcloud.atlassian.net/browse/CUT-4093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ