### PR TITLE
CUT-4602: Multi-Group Radius Report Function

### DIFF
--- a/scripts/automation/Radius/Functions/Public/Get-JCRCertReport.ps1
+++ b/scripts/automation/Radius/Functions/Public/Get-JCRCertReport.ps1
@@ -1,0 +1,67 @@
+function Get-JCRCertReport {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$UserGroupIDs,
+        [Parameter(Mandatory)]
+        [string]$ExportFilePath
+    )
+
+    # Initialize an empty array to store the results
+    $reportData = @()
+
+    foreach ($groupID in $UserGroupIDs) {
+        $radiusMembersPath = Join-Path -Path $PSScriptRoot -ChildPath "data/radiusMembers.json"
+        $certHashPath = Join-Path -Path $PSScriptRoot -ChildPath "data/certHash.json"
+
+        if (!(Test-Path $radiusMembersPath)) {
+            Write-Error "radiusMembers.json not found at $radiusMembersPath"
+            continue # Skip to the next group if file not found
+        }
+        if (!(Test-Path $certHashPath)) {
+            Write-Error "certHash.json not found at $certHashPath"
+            continue # Skip to the next group if file not found
+        }
+
+
+        $radiusMembers = Get-Content $radiusMembersPath | ConvertFrom-Json
+        $certHashes = Get-Content $certHashPath | ConvertFrom-Json
+
+        foreach ($user in $radiusMembers) {
+            foreach ($device in $user.devices) {
+                $reportEntry = [ordered]@{}
+                $reportEntry.username = $user.username
+                $reportEntry.userid = $user.userid
+                $reportEntry.systemHostname = $device.systemHostname
+                $reportEntry.systemID = $device.systemID
+                $reportEntry.systemOS = $device.systemOS
+
+
+                # Check if certificate is installed on the device
+                $certInstalled = $false
+                $certificateSerialNumber = $null
+                $certificateExpirationDate = $null
+
+                if ($certHashes."$($device.systemID)") {
+                    # Check if the systemID exists in certHashes
+                    foreach ($cert in $certHashes."$($device.systemID)") {
+                        # Loop through possible certs on the device
+                        $certificateSerialNumber = $cert.serialNumber # Capture the serial number
+                        $certificateExpirationDate = $cert.notAfter # Capture expiration date
+                        $certInstalled = $true # If we got here there is at least one cert
+                        break # Exit inner loop, we can assume the user has a cert
+                    }
+                }
+
+                $reportEntry.CertificateSerialNumber = $certificateSerialNumber
+                $reportEntry."Certificate Expiration Date" = $certificateExpirationDate
+                $reportEntry."Certificate Installed on the device" = $certInstalled
+
+                $reportData += [pscustomobject]$reportEntry
+            }
+        }
+    }
+
+    # Export to CSV
+    $reportData | Export-Csv -Path $ExportFilePath -NoTypeInformation
+    Write-Host "Certificate report generated at: $ExportFilePath"
+}

--- a/scripts/automation/Radius/Functions/Public/Get-JCRCertReport.ps1
+++ b/scripts/automation/Radius/Functions/Public/Get-JCRCertReport.ps1
@@ -1,10 +1,17 @@
 function Get-JCRCertReport {
     param(
-        [Parameter(Mandatory = $true)]
-        [string[]]$UserGroupIDs,
         [Parameter(Mandatory)]
-        [ValidateScript({ Test-Path -IsValid -Path $_ -PathType Leaf })]
-        [string]$ExportFilePath
+        [ValidateScript({
+                $directory = Split-Path -Path $_ -Parent
+                if (-not (Test-Path -Path $directory -PathType Container)) {
+                    throw "The directory '$directory' does not exist."
+                }
+                if (-not ($_ -like '*.csv')) {
+                    throw "The specified path '$_' does not end with '.csv'."
+                }
+                return $true
+            })]
+        [System.IO.FileInfo]$ExportFilePath
     )
 
     # Initialize an empty array to store the results

--- a/scripts/automation/Radius/Functions/Public/Get-JCRCertReport.ps1
+++ b/scripts/automation/Radius/Functions/Public/Get-JCRCertReport.ps1
@@ -7,7 +7,7 @@ function Get-JCRCertReport {
     )
 
     # Initialize an empty array to store the results
-    $reportData = @()
+    $reportData = New-Object System.Collections.ArrayList
 
     foreach ($groupID in $UserGroupIDs) {
         $radiusMembersPath = Join-Path -Path $JCScriptRoot -ChildPath "data/radiusMembers.json"
@@ -58,7 +58,7 @@ function Get-JCRCertReport {
                 $reportEntry.certExpirationDate = $certificateExpirationDate
                 $reportEntry.certInstalled = $certInstalled
 
-                $reportData += [pscustomobject]$reportEntry
+                $reportData.Add([pscustomobject]$reportEntry) | Out-Null
             }
         }
     }

--- a/scripts/automation/Radius/JumpCloud-Radius.psd1
+++ b/scripts/automation/Radius/JumpCloud-Radius.psd1
@@ -70,7 +70,7 @@
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = 'Start-DeployUserCerts', 'Start-GenerateRootCert',
-    'Start-GenerateUserCerts', 'Start-MonitorCertDeployment', 'Get-JCRGlobalVars'
+    'Start-GenerateUserCerts', 'Start-MonitorCertDeployment', 'Get-JCRGlobalVars', 'Get-JCRCertReport'
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = @()

--- a/scripts/automation/Radius/Tests/Public/Get-JCRCertReport.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Get-JCRCertReport.Tests.ps1
@@ -1,0 +1,37 @@
+Describe 'User Cert Report' {
+    BeforeAll {
+        # Load all functions from private folders
+        $Private = @( Get-ChildItem -Path "$JCScriptRoot/Functions/Private/*.ps1" -Recurse)
+        Foreach ($Import in $Private) {
+            Try {
+                . $Import.FullName
+            } Catch {
+                Write-Error -Message "Failed to import function $($Import.FullName): $_"
+            }
+        }
+        # import helper functions:
+        . "$PSScriptRoot/../HelperFunctions.ps1"
+        # Manually update user associations for radius members, cache won't pick them up before:
+        foreach ($user in $global:JCRRadiusMembers) {
+            Set-JCRAssociationHash -UserID $user.userID
+        }
+        Get-JCRGlobalVars -Force -associateManually
+        Start-GenerateRootCert -certKeyPassword "TestCertificate123!@#" -generateType "new" -force
+        Start-GenerateUserCerts -type All -forceReplaceCerts
+        Start-DeployUserCerts -type All -forceInvokeCommands
+    }
+    Context "Report Generation" {
+        It "Generates the Report" {
+            # Export the report
+            Get-JCRCertReport -ExportFilePath "$JCScriptRoot/testReport.csv"
+            $report = Import-Csv -Path "$JCScriptRoot/testReport.csv"
+            $report | Should -Not -BeNullOrEmpty
+        }
+        It "Checks for invalid Path" {
+            # Export the report
+            { Get-JCRCertReport -ExportFilePath "$JCScriptRoot/testReport" } | Should -Throw
+            { Get-JCRCertReport -ExportFilePath "testReport" } | Should -Throw
+            { Get-JCRCertReport -ExportFilePath "$JCScriptRoot/testReport.csv" } | Should -Not -Throw
+        }
+    }
+}

--- a/scripts/automation/Radius/Tests/Public/Get-JCRCertReport.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Get-JCRCertReport.Tests.ps1
@@ -1,4 +1,4 @@
-Describe 'User Cert Report' {
+Describe 'User Cert Report' -Tag "Reports" {
     BeforeAll {
         # Load all functions from private folders
         $Private = @( Get-ChildItem -Path "$JCScriptRoot/Functions/Private/*.ps1" -Recurse)


### PR DESCRIPTION
## Issues
* [CUT-4602](https://jumpcloud.atlassian.net/browse/CUT-4602) - Multi-Group Radius Report Function

## What does this solve?
Created a new function to generate a report that accepts multiple groupIDs and will output a report that contains the following properties:
username
userid
systemHostname
systemID
systemOS
CertSerialNumber
CertExpirationDate
CertInstalled

## Is there anything particularly tricky?
The function will need to be added to the end of the [MultiGroup RADIUS script](https://gist.github.com/jworkmanjc/d5a3f26c6c77aec15ed4af51a313a219) in order to function correctly

## How should this be tested?

### Without the MultiGroup Radius Script
1. Import the RADIUS module
    a. NOTE: You may have to force update the global variables to ensure that the hashes are populated, it is also recommended to have at least a few certs deployed
2. Run the following function: 
```powershell
Get-JCRCertReport -UserGroupIDs "usergroupid1" -ExportFilePath '/Users/USERNAME/RadiusReport.csv
```

### With the MultiGroup Radius Script
1. Copy the function to the end of the multiGroupRadius script
2. Call the function similar to the first example except inputting the various userGroupIDs that were used
```powershell
Get-JCRCertReport -UserGroupIDs "usergroupid1" -ExportFilePath '/Users/USERNAME/RadiusReport.csv
```

[CUT-4602]: https://jumpcloud.atlassian.net/browse/CUT-4602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ