### PR TITLE
Sup 1499

### DIFF
--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -113,7 +113,16 @@ fi
 
 ## Only run if a user is actually logged in
 if [[ $localuser ]]; then
+
+    ## pull additional patch management information
     sudo -u $localuser defaults read com.github.macadmins.Nudge.plist > $baseDir/com.github.macadmins.Nudge.plist 2>&1
+
+    ## list jumpcloud services currently running on the system
+    sudo -u $localuser launchctl print system | grep -i 'jumpcloud' > $baseDir/systemInfo/activeJumpCloudServices.txt
+
+    ## list JumpCloud Device Certificate
+    sudo -u $localuser security find-certificate -c "JumpCloud Device Trust Certificate" -p | openssl x509  -text > $baseDir/systemInfo/deviceCert.txt
+
 fi
 
 ## gather relevent system logs for software installs

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -2,7 +2,7 @@
 
 
 
-automate=true   # set to true if running via a JumpCloud command (recommended)
+automate=false   # set to true if running via a JumpCloud command (recommended)
 days=2           # number of days of OS logs to gather
 
 

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -29,9 +29,9 @@ then
 - JumpCloud logging recorded in the macOS system logs for the past ${days} days
 - Currently installed configuration profiles
 - MDM triggered software installations for the past ${days} days (Appstore, VPP and Custom Software)
-- Filevault and secure token information (no passwords or secrets are collected)
+- FileVault and secure token information (no passwords or secrets are collected)
 - Usernames of JumpCloud managed users
-If you agree to this, enter 'Y', or any other key to cancel." -n 1 -r
+If you agree to this, enter 'Y', or any other key to cancel: " -n 1 -r
     echo    # move to a new line
     if [[ ! $REPLY =~ ^[Yy]$ ]]
     then
@@ -126,7 +126,7 @@ if [[ $localuser ]]; then
         echo "JumpCloud Device Trust Certificate found and processed."
     else
     # Certificate not found
-        echo "JumpCloud Device Trust Certificate not found." > $baseDir/systemInfo/deviceCert.txt
+        echo "A JumpCloud Device Trust Certificate was not found - If expected, check and confirm Device Certificates is enabled for the organisation." > $baseDir/systemInfo/deviceCert.txt
     fi
 
 fi

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -122,10 +122,10 @@ if [[ $localuser ]]; then
     sudo -u $localuser launchctl print system | grep -i 'jumpcloud' > $baseDir/systemInfo/activeJumpCloudServices.txt
 
     ## list JumpCloud Device Certificate
-    jcDeviceCert=$(sudo -u "$localuser" security find-certificate -c "JumpCloud Device Trust Certificate" -p)
+    jcDeviceCert=$(sudo -u "$localuser" security find-certificate -c "JumpCloud Device Trust Certificate" -p 2>/dev/null)
     if [ -n "$jcDeviceCert" ]; then
         echo "$jcDeviceCert" | openssl x509 -text > $baseDir/systemInfo/deviceCert.txt
-        echo "JumpCloud Device Trust Certificate found and processed."
+        echo "JumpCloud Device Trust Certificate found and processed"
     else
     # Certificate not found
         echo "A JumpCloud Device Trust Certificate was not found for the user: "$localuser" - If expected, check and confirm Device Certificates is enabled for the organisation." > $baseDir/systemInfo/deviceCert.txt

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -121,12 +121,13 @@ if [[ $localuser ]]; then
     sudo -u $localuser launchctl print system | grep -i 'jumpcloud' > $baseDir/systemInfo/activeJumpCloudServices.txt
 
     ## list JumpCloud Device Certificate
-    if sudo -u "$localuser" security find-certificate -c "JumpCloud Device Trust Certificate" -p > /dev/null 2>&1; then
-        sudo -u $localuser security find-certificate -c "JumpCloud Device Trust Certificate" -p | openssl x509  -text > $baseDir/systemInfo/deviceCert.txt
+    jcDeviceCert="sudo -u \"$localuser\" security find-certificate -c \"JumpCloud Device Trust Certificate\" -p"
+    if $jcDeviceCert > /dev/null 2>&1; then
+        $jcDeviceCert | openssl x509 -text > $baseDir/systemInfo/deviceCert.txt
         echo "JumpCloud Device Trust Certificate found and processed."
     else
     # Certificate not found
-        echo "A JumpCloud Device Trust Certificate was not found - If expected, check and confirm Device Certificates is enabled for the organisation." > $baseDir/systemInfo/deviceCert.txt
+        echo "A JumpCloud Device Trust Certificate was not found for the user: "$localuser" - If expected, check and confirm Device Certificates is enabled for the organisation." > $baseDir/systemInfo/deviceCert.txt
     fi
 
 fi

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -121,7 +121,13 @@ if [[ $localuser ]]; then
     sudo -u $localuser launchctl print system | grep -i 'jumpcloud' > $baseDir/systemInfo/activeJumpCloudServices.txt
 
     ## list JumpCloud Device Certificate
-    sudo -u $localuser security find-certificate -c "JumpCloud Device Trust Certificate" -p | openssl x509  -text > $baseDir/systemInfo/deviceCert.txt
+    if sudo -u "$localuser" security find-certificate -c "JumpCloud Device Trust Certificate" -p > /dev/null 2>&1; then
+        sudo -u $localuser security find-certificate -c "JumpCloud Device Trust Certificate" -p | openssl x509  -text > $baseDir/systemInfo/deviceCert.txt
+        echo "JumpCloud Device Trust Certificate found and processed."
+    else
+    # Certificate not found
+        echo "JumpCloud Device Trust Certificate not found." > $baseDir/systemInfo/deviceCert.txt
+    fi
 
 fi
 
@@ -156,10 +162,12 @@ for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do
         cp -r /Users/$u/Library/Logs/JumpCloud-Remote-Assist $baseDir/userLogs/$u/
     fi
 
+    if [ -d /Users/$u/Library/Logs/JumpCloud ]; then
+        cp -r /Users/$u/Library/Logs/JumpCloud $baseDir/userLogs/$u/
+    fi
+
     # report on any user scope configuration profiles
     sudo -u $u profiles -L -o stdout > $baseDir/userLogs/$u/installedProfiles.txt
-
-    cp -r /Users/$u/Library/Logs/JumpCloud $baseDir/userLogs/$u/
 
 done
 


### PR DESCRIPTION
## Issues
* [SUP-1499](https://jumpcloud.atlassian.net/browse/SUP-1499) - <Log Collection Script Update - macOS>

## What does this solve?
Adds the collection of JumpCloud Device Cert details and a list of active JumpCloud services (agents/daemons) for a logged-in user.

Update to a copy command for JumpCloud users logs to be wrapped in an IF statement, to help avoid cp error in terminal output.

Amended formatting of terminal message when running log collection script locally / non-automatic.

## Is there anything particularly tricky?
No

## How should this be tested?
Run the macOS log collection script from JumpCloud commands and locally on a device.
Run log collection script with JumpCloud Device Certificates turned on as well as with them turned off.

## Screenshots
N/A


[SUP-1499]: https://jumpcloud.atlassian.net/browse/SUP-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ