### PR TITLE
Added additional log files to the LOGS list to be captured

### DIFF
--- a/scripts/linux/log_collection.sh
+++ b/scripts/linux/log_collection.sh
@@ -42,7 +42,7 @@ then
 - System logs, including syslog or messages, auth.log or secure, and dmsg log files.
 - Usernames of JumpCloud managed users.
 - General system information (distribution, hostname, hardware architecture, kernel version)
-If you agree to this, enter 'Y', or any other key to cancel." -n 1 -r
+If you agree to this, enter 'Y', or any other key to cancel: " -n 1 -r
     echo    # move to a new line
     if [[ ! $REPLY =~ ^[Yy]$ ]]
     then
@@ -74,6 +74,9 @@ LOGS=(
     "dmsg"
     "messages"
     "secure"
+    "apt/term.log"
+    "apt/history.log"
+    "dpkg.log"
 )
 
 echo "Collecting system logs"


### PR DESCRIPTION
## Issues
* [SUP-1501](https://jumpcloud.atlassian.net/browse/SUP-1501) - Linux Log Collection Script - Addition of System Logs Captured

## What does this solve?
Adds additional system logs to be captured, around packages, with the purpose to help with troubleshooting.

## Is there anything particularly tricky?
No

## How should this be tested?
Run Linux Log Collection script locally and via JumpCloud commands against a Linux device.

## Screenshots
![Screenshot 2025-03-13 at 15 00 04](https://github.com/user-attachments/assets/2d997b34-b71d-436a-bf41-d6a2e44ee292)

