### PR TITLE
Update log_collection.sh - Correct Home Directory Retrieval for Log Collection

### DIFF
--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -50,7 +50,8 @@ sysId=$(grep -o '"systemKey": *"[^"]*"' /opt/jc/jcagent.conf | grep -o '"[^"]*"$
 if [[ $(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }') ]]; then
     localuser=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }')
     echo "User $localuser is currently logged in."
-    archiveTargetDir="/Users/${localuser}/Documents/"
+    homedir=$(dscl . -read /Users/${localuser} | awk '/NFSHomeDirectory/ {print $2}')
+    archiveTargetDir="${homedir}/Documents/"
 else
     archiveTargetDir="/private/var/tmp/"
 fi
@@ -151,22 +152,24 @@ grep -o '\"username\":\"[^\"]*\"' /opt/jc/managedUsers.json | cut -d '"' -f 4 > 
 ## descend into managed user's homedirs (requires full disk access) and gather JumpCloud logs
 for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do
     echo "pulling logs from user $u"
+    manageduserhomedir=$(dscl . -read /Users/${u} | awk '/NFSHomeDirectory/ {print $2}')
+    echo "user home dir $manageduserhomedir"
     mkdir $baseDir/userLogs/$u
 
-    if [ -d /Users/$u/Library/Logs/JumpCloud\ Password\ Manager ]; then
+    if [ -d $manageduserhomedir/Library/Logs/JumpCloud\ Password\ Manager ]; then
         cp -r /Users/$u/Library/Logs/JumpCloud\ Password\ Manager $baseDir/userLogs/$u/
     fi
 
-    if [ -d /Users/$u/Library/Application\ Support/JumpCloud\ Password\ Manager/data/daemon/log ]; then
-        cp -r /Users/$u/Library/Application\ Support/JumpCloud\ Password\ Manager/data/daemon/log $baseDir/userLogs/$u/PWM_daemon_logs
+    if [ -d $manageduserhomedir/Library/Application\ Support/JumpCloud\ Password\ Manager/data/daemon/log ]; then
+        cp -r $manageduserhomedir/Library/Application\ Support/JumpCloud\ Password\ Manager/data/daemon/log $baseDir/userLogs/$u/PWM_daemon_logs
     fi
 
-    if [ -d /Users/$u/Library/Logs/JumpCloud-Remote-Assist ]; then
-        cp -r /Users/$u/Library/Logs/JumpCloud-Remote-Assist $baseDir/userLogs/$u/
+    if [ -d $manageduserhomedir/Library/Logs/JumpCloud-Remote-Assist ]; then
+        cp -r $manageduserhomedir/Library/Logs/JumpCloud-Remote-Assist $baseDir/userLogs/$u/
     fi
 
-    if [ -d /Users/$u/Library/Logs/JumpCloud ]; then
-        cp -r /Users/$u/Library/Logs/JumpCloud $baseDir/userLogs/$u/
+    if [ -d $manageduserhomedir/Library/Logs/JumpCloud ]; then
+        cp -r $manageduserhomedir/Library/Logs/JumpCloud $baseDir/userLogs/$u/
     fi
 
     # report on any user scope configuration profiles

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -50,8 +50,8 @@ sysId=$(grep -o '"systemKey": *"[^"]*"' /opt/jc/jcagent.conf | grep -o '"[^"]*"$
 if [[ $(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }') ]]; then
     localuser=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }')
     echo "User $localuser is currently logged in."
-    homedir=$(dscl . -read /Users/${localuser} | awk '/NFSHomeDirectory/ {print $2}')
-    archiveTargetDir="${homedir}/Documents/"
+    homeDir=$(dscl . -read /Users/${localuser} | awk '/NFSHomeDirectory/ {print $2}')
+    archiveTargetDir="${homeDir}/Documents/"
 else
     archiveTargetDir="/private/var/tmp/"
 fi
@@ -152,24 +152,24 @@ grep -o '\"username\":\"[^\"]*\"' /opt/jc/managedUsers.json | cut -d '"' -f 4 > 
 ## descend into managed user's homedirs (requires full disk access) and gather JumpCloud logs
 for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do
     echo "pulling logs from user $u"
-    manageduserhomedir=$(dscl . -read /Users/${u} | awk '/NFSHomeDirectory/ {print $2}')
-    echo "user home dir $manageduserhomedir"
+    managedUserDir=$(dscl . -read /Users/${u} | awk '/NFSHomeDirectory/ {print $2}')
+    echo "user home dir $managedUserDir"
     mkdir $baseDir/userLogs/$u
 
-    if [ -d $manageduserhomedir/Library/Logs/JumpCloud\ Password\ Manager ]; then
+    if [ -d $managedUserDir/Library/Logs/JumpCloud\ Password\ Manager ]; then
         cp -r /Users/$u/Library/Logs/JumpCloud\ Password\ Manager $baseDir/userLogs/$u/
     fi
 
-    if [ -d $manageduserhomedir/Library/Application\ Support/JumpCloud\ Password\ Manager/data/daemon/log ]; then
-        cp -r $manageduserhomedir/Library/Application\ Support/JumpCloud\ Password\ Manager/data/daemon/log $baseDir/userLogs/$u/PWM_daemon_logs
+    if [ -d $managedUserDir/Library/Application\ Support/JumpCloud\ Password\ Manager/data/daemon/log ]; then
+        cp -r $managedUserDir/Library/Application\ Support/JumpCloud\ Password\ Manager/data/daemon/log $baseDir/userLogs/$u/PWM_daemon_logs
     fi
 
-    if [ -d $manageduserhomedir/Library/Logs/JumpCloud-Remote-Assist ]; then
-        cp -r $manageduserhomedir/Library/Logs/JumpCloud-Remote-Assist $baseDir/userLogs/$u/
+    if [ -d $managedUserDir/Library/Logs/JumpCloud-Remote-Assist ]; then
+        cp -r $managedUserDir/Library/Logs/JumpCloud-Remote-Assist $baseDir/userLogs/$u/
     fi
 
-    if [ -d $manageduserhomedir/Library/Logs/JumpCloud ]; then
-        cp -r $manageduserhomedir/Library/Logs/JumpCloud $baseDir/userLogs/$u/
+    if [ -d $managedUserDir/Library/Logs/JumpCloud ]; then
+        cp -r $managedUserDir/Library/Logs/JumpCloud $baseDir/userLogs/$u/
     fi
 
     # report on any user scope configuration profiles

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -11,7 +11,7 @@ days=2           # number of days of OS logs to gather
 # do not edit below
 #######
 
-version=1.2.1
+version=1.2.2
 
 ## verify script is running as root.
 if [ $(/usr/bin/id -u) -ne 0 ]


### PR DESCRIPTION
## What does this solve?
On some macOS devices, the user's home directory path differs from their username. This discrepancy caused log collection failures, as the script incorrectly assumed the home directory was directly derived from the username.
This commit resolves the issue by using `dscl` to accurately retrieve the home directory path for both standard and managed users, ensuring reliable log collection regardless of home directory configuration.

## Is there anything particularly tricky?
n/a

## How should this be tested?
use the log collection script on a device with a user having a homedir different than the username:
for example in users & groups:
- user name = ludovic
- home directory = /Users/ludovic_dir

## Screenshots
In this screenshot, the username is ludovic, however the home directorty is /Users/ludovic_dir instead of the standard /Users/ludovic dirrectory:
![image](https://github.com/user-attachments/assets/f3333e10-dc37-4f8a-b2f0-21ab0ffa3dcc)
