### PR TITLE
users.json command names are not being recorded correctly

### DIFF
--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Deploy-UserCertificate.ps1
@@ -550,7 +550,7 @@ fi
                     $workToBeDone.macOSCommandID = $Command.Id
 
                     $CommandTable = [PSCustomObject]@{
-                        commandId            = $command.Id
+                        commandId            = $workToBeDone.macOSCommandID
                         commandName          = $command.name
                         commandPreviouslyRun = $false
                         commandQueued        = $false
@@ -569,7 +569,7 @@ fi
             if (-Not ($workToBeDone.forceGenerateMacOSCommands) -And ($workToBeDone.macOSCommandID)) {
                 $systemIds = (Get-SystemsThatNeedCertWork -userData $user -osType "macOS")
 
-                $Command = Get-JcSdkCommand -Filter @("trigger:eq:$($certInfo.sha1)", "commandType:eq:windows")
+                $Command = Get-JcSdkCommand -Filter @("trigger:eq:$($certInfo.sha1)", "commandType:eq:mac")
                 $CommandTable = [PSCustomObject]@{
                     commandId            = $workToBeDone.macOSCommandID
                     commandName          = $command.name

--- a/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
@@ -582,7 +582,7 @@ Describe 'Distribute User Cert Tests' -Tag 'Distribute' {
             $windowsCommand.Name | Should -Match "RadiusCert-Install:$($user.username):Windows"
 
             # validate that the command names are recorded correctly in the users.json file
-            $userData = Get-UserFromTable -username $user.username
+            $userData = Get-UserFromTable -userId $user.id
             $userData.commandAssociations.commandName | Should -Contain "RadiusCert-Install:$($user.username):MacOSX"
             $userData.commandAssociations.commandName | Should -Contain "RadiusCert-Install:$($user.username):Windows"
         }

--- a/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Start-DeployUserCerts.Tests.ps1
@@ -569,6 +569,23 @@ Describe 'Distribute User Cert Tests' -Tag 'Distribute' {
             $testUserData.commandAssociations.commandId | Should -Contain $windowsCmdAfter.id
             $testUserData.commandAssociations.commandId | Should -Contain $macCmdAfter.id
         }
+        It "When the commands are generated the names of the command should match the predetermined naming structure" {
+            # Run Start Deploy User Certs by username
+            Start-DeployUserCerts -type ByUsername -username $user.username
+
+            $macCommand = Get-JcSdkCommand -Filter @("trigger:eq:$($($certData.sha1))", "commandType:eq:mac")
+            $windowsCommand = Get-JcSdkCommand -Filter @("trigger:eq:$($($certData.sha1))", "commandType:eq:windows")
+
+            # macCommand name should be set correctly
+            $macCommand.Name | Should -Match "RadiusCert-Install:$($user.username):MacOSX"
+            # windowsCommand name should be set correctly
+            $windowsCommand.Name | Should -Match "RadiusCert-Install:$($user.username):Windows"
+
+            # validate that the command names are recorded correctly in the users.json file
+            $userData = Get-UserFromTable -username $user.username
+            $userData.commandAssociations.commandName | Should -Contain "RadiusCert-Install:$($user.username):MacOSX"
+            $userData.commandAssociations.commandName | Should -Contain "RadiusCert-Install:$($user.username):Windows"
+        }
     }
     Context 'Force Generate Certificate Tests' {
         BeforeEach {


### PR DESCRIPTION
## Issues
* [CUT-4540](https://jumpcloud.atlassian.net/browse/CUT-4540) - Users.json command names are not being recorded correctly

## What does this solve?

This issue resolves an issue with the generated command names being recorded incorrectly in the users.json data file. The commandIDs were still being recorded correctly, but the command names were not being updated to match the predetermined naming structure.

## Is there anything particularly tricky?

No, there are automated tests in place to validate that the command names are set correctly.

## How should this be tested?

## Screenshots


[CUT-4540]: https://jumpcloud.atlassian.net/browse/CUT-4540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ