### PR TITLE
Updated regular expression for improved collection of managed usernames

### DIFF
--- a/scripts/linux/log_collection.sh
+++ b/scripts/linux/log_collection.sh
@@ -16,7 +16,7 @@ automate=false   # set to true if running via a JumpCloud command (recommended)
 # do not edit below
 #######
 
-version=1.0
+version=1.1
 
 ## verify script is running as root.
 if [ $(/usr/bin/id -u) -ne 0 ]
@@ -91,7 +91,7 @@ iptables -L > $baseDir/systemInfo/firewall_rules.txt
 
 # JC Information and Logs
 echo "Collecting managed usernames"
-grep -o '\"username\":\"\w*' /opt/jc/managedUsers.json | cut -d '"' -f 4 > $baseDir/jumpcloudInfo/managedUsers.txt
+grep -o '\"username\":\"[^\"]*' /opt/jc/managedUsers.json | cut -d '"' -f 4 > $baseDir/jumpcloudInfo/managedUsers.txt
 
 cat /opt/jc/policyConf.json | json_pp > $baseDir/jumpcloudInfo/policyConf.json
 

--- a/scripts/linux/log_collection.sh
+++ b/scripts/linux/log_collection.sh
@@ -16,7 +16,7 @@ automate=false   # set to true if running via a JumpCloud command (recommended)
 # do not edit below
 #######
 
-version=1.1
+version=1.0.1
 
 ## verify script is running as root.
 if [ $(/usr/bin/id -u) -ne 0 ]


### PR DESCRIPTION
## Issues
* [SUP-1503] (https://jumpcloud.atlassian.net/browse/SUP-1503) - SUP-1503

## What does this solve?
Improves the capturing of managed usernames during log collection.

The current expression does not handle if a username has a period or such -  For example:

Currently, if a username was set as:

`terry.test`

It would only capture:

`terry`

## Is there anything particularly tricky?
N/A

## How should this be tested?
Run the Linux log collection script on a device that has various usernames and confirm they are printed correctly to the managerUsers file in the log collection:
 
`jumpcloudInfo > managedUsers.txt`

## Screenshots

**Current expression output:**

![Screenshot 2025-03-25 at 14 17 27](https://github.com/user-attachments/assets/3b5738d2-543d-4ebe-b50d-ea55e6d4dc35)


**Updated expression output:**

![Screenshot 2025-03-25 at 14 18 40](https://github.com/user-attachments/assets/f7f2bc14-f304-4a9b-a9ba-99d13a8750a5)



[SUP-1503]: https://jumpcloud.atlassian.net/browse/SUP-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ