### PR TITLE
Sup 1505

### DIFF
--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -162,7 +162,7 @@ grep -o '\"username\":\"[^\"]*\"' /opt/jc/managedUsers.json | cut -d '"' -f 4 > 
 for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do
     collectionLog "Pulling logs from user $u"
     managedUserDir=$(dscl . -read /Users/${u} | awk '/NFSHomeDirectory/ {print $2}')
-    collectionLog "User Home Directory: $managedUserDir"
+    collectionLog "User "$u" Home Directory: $managedUserDir"
     mkdir $baseDir/userLogs/$u
 
     if [ -d $managedUserDir/Library/Logs/JumpCloud\ Password\ Manager ]; then

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -105,7 +105,7 @@ fi
 chmod -R 777 $baseDir
 
 ## pull jumpcloud log entries from the system logs
-collectionLog "Gathering jumpcloud logs from macOS system logs"
+collectionLog "Gathering Jumpcloud logs from macOS system logs"
 log show --last ${days}d --predicate="eventMessage CONTAINS[c] 'jumpcloud'" > $baseDir/systemLogs/jumpcloud_syslog.log
 log show --last ${days}d --debug --info --style compact --predicate 'senderImagePath CONTAINS[c] "JCLoginPlugin"' > $baseDir/systemLogs/SSAP_LoginWindow_events.log
 log show --last ${days}d --predicate="process CONTAINS[c] 'DurtService' || process CONTAINS[c] 'JumpCloudGo'" > $baseDir/systemLogs/JumpCloudGo_events.log
@@ -155,7 +155,7 @@ fdesetup list > $baseDir/systemInfo/secureTokenList.txt
 diskutil apfs list > $baseDir/systemInfo/diskReport.txt
 
 ## list managed usernames
-collectionLog "finding managed users"
+collectionLog "Finding managed users"
 grep -o '\"username\":\"[^\"]*\"' /opt/jc/managedUsers.json | cut -d '"' -f 4 > $baseDir/systemInfo/managedUsers.txt
 
 ## descend into managed user's homedirs (requires full disk access) and gather JumpCloud logs


### PR DESCRIPTION
## Issues
* [SUP-1505](https://jumpcloud.atlassian.net/browse/SUP-1505) - macOS - Log Collection Logging

## What does this solve?
Setting up a logging function for the log collection script itself.

Currently captures the pre-existing stdout - This could prove helpful to support engineers and sets up good practice for providing logging in the script going forward.

I have added collectionLog function and used this in place of the existing echo lines in places where needed.
I have also re-ordered sections of the script to help with accommodating this.

## Is there anything particularly tricky?
n/a

## How should this be tested?
Run the macOS log collection script from JumpCloud Commands and locally to confirm that stdout is written to both terminal / command results and the collection.log file is created.

## Screenshots
![Screenshot 2025-03-28 at 12 00 35](https://github.com/user-attachments/assets/7b98ad70-68d8-4793-96e7-8555a91ed875)


[SUP-1505]: https://jumpcloud.atlassian.net/browse/SUP-1505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ