### PR TITLE
SUP-1514: Amended Device Cert capture

### DIFF
--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -11,7 +11,7 @@ days=2           # number of days of OS logs to gather
 # do not edit below
 #######
 
-version=1.2.3
+version=1.2.4
 
 ## verify script is running as root.
 if [ $(/usr/bin/id -u) -ne 0 ]

--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -131,15 +131,6 @@ if [[ $localuser ]]; then
     ## list jumpcloud services currently running on the system
     sudo -u $localuser launchctl print system | grep -i 'jumpcloud' > $baseDir/systemInfo/activeJumpCloudServices.txt
 
-    ## list JumpCloud Device Certificate
-    jcDeviceCert=$(sudo -u "$localuser" security find-certificate -c "JumpCloud Device Trust Certificate" -p 2>/dev/null)
-    if [ -n "$jcDeviceCert" ]; then
-        echo "$jcDeviceCert" | openssl x509 -text > $baseDir/systemInfo/deviceCert.txt
-        collectionLog "JumpCloud Device Trust Certificate found and processed"
-    else
-    # Certificate not found
-        echo "A JumpCloud Device Trust Certificate was not found for the user: "$localuser" - If expected, check and confirm Device Certificates is enabled for the organisation." > $baseDir/systemInfo/deviceCert.txt
-    fi
 else
     collectionLog "No user is currently logged in. Skipping user-specific information."
 fi
@@ -183,6 +174,16 @@ for u in $(cat $baseDir/SystemInfo/managedUsers.txt); do
 
     # report on any user scope configuration profiles
     sudo -u $u profiles -L -o stdout > $baseDir/userLogs/$u/installedProfiles.txt
+
+    ## list JumpCloud Device Certificate
+    jcDeviceCert=$(sudo -u "$u" security find-certificate -c "JumpCloud Device Trust Certificate" -p 2>/dev/null)
+    if [ -n "$jcDeviceCert" ]; then
+        echo "$jcDeviceCert" | openssl x509 -text > $baseDir/userLogs/$u/deviceCert.txt
+        collectionLog "JumpCloud Device Trust Certificate found and processed for $u"
+    else
+    # Certificate not found
+        echo "A JumpCloud Device Trust Certificate was not found for the user: "$u" - If expected, check and confirm Device Certificates is enabled for the organisation." > $baseDir/userLogs/$u/deviceCert.txt
+    fi
 
 done
 


### PR DESCRIPTION
## Issues
* [SUP-1514](https://jumpcloud.atlassian.net/browse/SUP-1514) - Device Trust Certificate capture update

## What does this solve?
Currently, the function for listing / capturing Device Trust Cert within the script will only capture if and for the currently logged-in user on the device - Though in most cases this will typically not be an issue, if the log collection is run and a non-managed user is logged in, the cert info wouldn’t be checked for any possible managed users on the device, possibly then returning a false negative.

This change is to move the current logic for capturing the device cert info into the FOR loop against managed users.

## Is there anything particularly tricky?
N/A

## How should this be tested?
Run the script from JC commands with no user logged in and confirm the Device Cert info and file are written for the managed users on the device.

## Screenshots
![Screenshot 2025-04-01 at 09 34 54](https://github.com/user-attachments/assets/608dd83f-f8f3-4057-ad66-4368b752da7f)
![Screenshot 2025-04-01 at 09 36 06](https://github.com/user-attachments/assets/536ec882-d030-45aa-9ae1-09701da77b7c)



[SUP-1514]: https://jumpcloud.atlassian.net/browse/SUP-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ