### PR TITLE
SUP-1506: Linux - Log Collection Logging

### DIFF
--- a/scripts/linux/log_collection.sh
+++ b/scripts/linux/log_collection.sh
@@ -16,7 +16,7 @@ automate=false   # set to true if running via a JumpCloud command (recommended)
 # do not edit below
 #######
 
-version=1.0.1
+version=1.0.2
 
 ## verify script is running as root.
 if [ $(/usr/bin/id -u) -ne 0 ]


### PR DESCRIPTION
## Issues
* [SUP-1506](https://jumpcloud.atlassian.net/browse/SUP-1506) - Linux - Log Collection Logging

## What does this solve?
Integrate a logging function into the log collection so that any terminal or stdout is also written to a log file, which will then be included in the log collection archive.

This will prevent admins from needing to potentially send a copy of the terminal output along with the log collection. 

Implementing this now can be beneficial for future iterations of the script.

Further to this, Added the checking and capturing JumpCloud Device Certificate details. 

Also include the addition of listing running JumpCloud services & processes on the device.

These additions will bring the Linux log collection in line with matching behaviour to our macOS log collection script.

## Is there anything particularly tricky?
N/A

## How should this be tested?
Run log collection script against a Linux device and confirm collectionLog file is present, along with Device Cert file for users and JumpCloud running services file - See screenshots below for ref.

## Screenshots
![Screenshot 2025-04-01 at 12 07 30](https://github.com/user-attachments/assets/c7444cc9-b75e-4769-b64f-627b79db318f)
![Screenshot 2025-04-01 at 12 09 53](https://github.com/user-attachments/assets/b2148fc5-56ee-4112-a633-6c257ecec9c5)
![Screenshot 2025-04-01 at 12 26 50](https://github.com/user-attachments/assets/aa2de4d5-31c9-4a38-9cba-c5ec632f909f)
![Screenshot 2025-04-01 at 12 26 27](https://github.com/user-attachments/assets/e973d2bc-beb0-4552-a1af-8fe240558ffb)



[SUP-1506]: https://jumpcloud.atlassian.net/browse/SUP-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ