### PR TITLE
CUT-4711-Nuspec-Path-Bug-Fix

### DIFF
--- a/PowerShell/Deploy/BuildNuspecFromPsd1.ps1
+++ b/PowerShell/Deploy/BuildNuspecFromPsd1.ps1
@@ -8,9 +8,9 @@ param (
 . "$PSScriptRoot/Get-Config.ps1"
 # $nuspecFiles = @{ src = 'en-Us/**;Private/**;Public/**;JumpCloud.psd1;JumpCloud.psm1;LICENSE'; }
 $nuspecFiles = @(
-    @{src = "en-Us/**/*.*"; target = "en-Us" },
-    @{src = "Public/**/*.*"; target = "Public" },
-    @{src = "Private/**/*.*"; target = "Private" },
+    @{src = "en-Us\**\*.*"; target = "en-Us" },
+    @{src = "Public\**\*.*"; target = "Public" },
+    @{src = "Private\**\*.*"; target = "Private" },
     @{src = "JumpCloud.psd1" },
     @{src = "JumpCloud.psm1" },
     @{src = "LICENSE" }

--- a/PowerShell/JumpCloud Module/Docs/JumpCloud.md
+++ b/PowerShell/JumpCloud Module/Docs/JumpCloud.md
@@ -2,7 +2,7 @@
 Module Name: JumpCloud
 Module Guid: 31c023d1-a901-48c4-90a3-082f91b31646
 Download Help Link: https://github.com/TheJumpCloud/support/wiki
-Help Version: 2.18.0
+Help Version: 2.18.1
 Locale: en-Us
 ---
 

--- a/PowerShell/JumpCloud Module/JumpCloud.psd1
+++ b/PowerShell/JumpCloud Module/JumpCloud.psd1
@@ -8,162 +8,162 @@
 
 @{
 
-# Script module or binary module file associated with this manifest.
-RootModule = 'JumpCloud.psm1'
+    # Script module or binary module file associated with this manifest.
+    RootModule        = 'JumpCloud.psm1'
 
-# Version number of this module.
-ModuleVersion = '2.18.0'
+    # Version number of this module.
+    ModuleVersion     = '2.18.1'
 
-# Supported PSEditions
-# CompatiblePSEditions = @()
+    # Supported PSEditions
+    # CompatiblePSEditions = @()
 
-# ID used to uniquely identify this module
-GUID = '31c023d1-a901-48c4-90a3-082f91b31646'
+    # ID used to uniquely identify this module
+    GUID              = '31c023d1-a901-48c4-90a3-082f91b31646'
 
-# Author of this module
-Author = 'JumpCloud Solutions Architect Team'
+    # Author of this module
+    Author            = 'JumpCloud Solutions Architect Team'
 
-# Company or vendor of this module
-CompanyName = 'JumpCloud'
+    # Company or vendor of this module
+    CompanyName       = 'JumpCloud'
 
-# Copyright statement for this module
-Copyright = '(c) JumpCloud. All rights reserved.'
+    # Copyright statement for this module
+    Copyright         = '(c) JumpCloud. All rights reserved.'
 
-# Description of the functionality provided by this module
-Description = 'PowerShell functions to manage a JumpCloud Directory-as-a-Service'
+    # Description of the functionality provided by this module
+    Description       = 'PowerShell functions to manage a JumpCloud Directory-as-a-Service'
 
-# Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '4.0'
+    # Minimum version of the PowerShell engine required by this module
+    PowerShellVersion = '4.0'
 
-# Name of the PowerShell host required by this module
-# PowerShellHostName = ''
+    # Name of the PowerShell host required by this module
+    # PowerShellHostName = ''
 
-# Minimum version of the PowerShell host required by this module
-# PowerShellHostVersion = ''
+    # Minimum version of the PowerShell host required by this module
+    # PowerShellHostVersion = ''
 
-# Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# DotNetFrameworkVersion = ''
+    # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # DotNetFrameworkVersion = ''
 
-# Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# ClrVersion = ''
+    # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # ClrVersion = ''
 
-# Processor architecture (None, X86, Amd64) required by this module
-# ProcessorArchitecture = ''
+    # Processor architecture (None, X86, Amd64) required by this module
+    # ProcessorArchitecture = ''
 
-# Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('JumpCloud.SDK.DirectoryInsights', 
-               'JumpCloud.SDK.V1', 
-               'JumpCloud.SDK.V2')
+    # Modules that must be imported into the global environment prior to importing this module
+    RequiredModules   = @('JumpCloud.SDK.DirectoryInsights',
+        'JumpCloud.SDK.V1',
+        'JumpCloud.SDK.V2')
 
-# Assemblies that must be loaded prior to importing this module
-# RequiredAssemblies = @()
+    # Assemblies that must be loaded prior to importing this module
+    # RequiredAssemblies = @()
 
-# Script files (.ps1) that are run in the caller's environment prior to importing this module.
-# ScriptsToProcess = @()
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+    # ScriptsToProcess = @()
 
-# Type files (.ps1xml) to be loaded when importing this module
-# TypesToProcess = @()
+    # Type files (.ps1xml) to be loaded when importing this module
+    # TypesToProcess = @()
 
-# Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
+    # Format files (.ps1xml) to be loaded when importing this module
+    # FormatsToProcess = @()
 
-# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-# NestedModules = @()
+    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+    # NestedModules = @()
 
-# Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Add-JCAssociation', 'Add-JCCommandTarget', 'Add-JCGsuiteMember', 
-               'Add-JCOffice365Member', 'Add-JCRadiusReplyAttribute', 
-               'Add-JCSystemGroupMember', 'Add-JCSystemUser', 
-               'Add-JCUserGroupMember', 'Backup-JCOrganization', 'Connect-JCOnline', 
-               'Copy-JCAssociation', 'Get-JCAdmin', 'Get-JCAssociation', 
-               'Get-JCBackup', 'Get-JCCloudDirectory', 'Get-JCCommand', 
-               'Get-JCCommandResult', 'Get-JCCommandTarget', 
-               'Get-JCConfiguredTemplatePolicy', 'Get-JCEvent', 'Get-JCEventCount', 
-               'Get-JCGroup', 'Get-JCOrganization', 'Get-JCPolicy', 
-               'Get-JCPolicyGroup', 'Get-JCPolicyGroupMember', 
-               'Get-JCPolicyGroupTemplate', 'Get-JCPolicyGroupTemplateMember', 
-               'Get-JCPolicyResult', 'Get-JCPolicyTargetGroup', 
-               'Get-JCPolicyTargetSystem', 'Get-JCRadiusReplyAttribute', 
-               'Get-JCRadiusServer', 'Get-JCReport', 'Get-JCScheduledUserstate', 
-               'Get-JCSystem', 'Get-JCSystemApp', 'Get-JCSystemGroupMember', 
-               'Get-JCSystemInsights', 'Get-JCSystemKB', 'Get-JCSystemUser', 
-               'Get-JCUser', 'Get-JCUserGroupMember', 'Import-JCCommand', 
-               'Import-JCMSPFromCSV', 'Import-JCUsersFromCSV', 'Invoke-JCCommand', 
-               'Invoke-JCDeployment', 'New-JCCommand', 'New-JCDeploymentTemplate', 
-               'New-JCDeviceUpdateTemplate', 'New-JCImportTemplate', 
-               'New-JCMSPImportTemplate', 'New-JCPolicy', 'New-JCPolicyGroup', 
-               'New-JCRadiusServer', 'New-JCReport', 'New-JCSystemGroup', 'New-JCUser', 
-               'New-JCUserGroup', 'Remove-JCAssociation', 'Remove-JCCommand', 
-               'Remove-JCCommandResult', 'Remove-JCCommandTarget', 
-               'Remove-JCGsuiteMember', 'Remove-JCOffice365Member', 
-               'Remove-JCPolicy', 'Remove-JCPolicyGroup', 
-               'Remove-JCPolicyGroupTemplate', 'Remove-JCRadiusReplyAttribute', 
-               'Remove-JCRadiusServer', 'Remove-JCSystem', 'Remove-JCSystemGroup', 
-               'Remove-JCSystemGroupMember', 'Remove-JCSystemUser', 'Remove-JCUser', 
-               'Remove-JCUserGroup', 'Remove-JCUserGroupMember', 
-               'Send-JCPasswordReset', 'Set-JCCloudDirectory', 'Set-JCCommand', 
-               'Set-JCOrganization', 'Set-JCPolicy', 'Set-JCPolicyGroup', 
-               'Set-JCRadiusReplyAttribute', 'Set-JCRadiusServer', 
-               'Set-JCSettingsFile', 'Set-JCSystem', 'Set-JCSystemUser', 'Set-JCUser', 
-               'Set-JCUserGroupLDAP', 'Update-JCDeviceFromCSV', 'Update-JCModule', 
-               'Update-JCMSPFromCSV', 'Update-JCUsersFromCSV'
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport = 'Add-JCAssociation', 'Add-JCCommandTarget', 'Add-JCGsuiteMember',
+    'Add-JCOffice365Member', 'Add-JCRadiusReplyAttribute',
+    'Add-JCSystemGroupMember', 'Add-JCSystemUser',
+    'Add-JCUserGroupMember', 'Backup-JCOrganization', 'Connect-JCOnline',
+    'Copy-JCAssociation', 'Get-JCAdmin', 'Get-JCAssociation',
+    'Get-JCBackup', 'Get-JCCloudDirectory', 'Get-JCCommand',
+    'Get-JCCommandResult', 'Get-JCCommandTarget',
+    'Get-JCConfiguredTemplatePolicy', 'Get-JCEvent', 'Get-JCEventCount',
+    'Get-JCGroup', 'Get-JCOrganization', 'Get-JCPolicy',
+    'Get-JCPolicyGroup', 'Get-JCPolicyGroupMember',
+    'Get-JCPolicyGroupTemplate', 'Get-JCPolicyGroupTemplateMember',
+    'Get-JCPolicyResult', 'Get-JCPolicyTargetGroup',
+    'Get-JCPolicyTargetSystem', 'Get-JCRadiusReplyAttribute',
+    'Get-JCRadiusServer', 'Get-JCReport', 'Get-JCScheduledUserstate',
+    'Get-JCSystem', 'Get-JCSystemApp', 'Get-JCSystemGroupMember',
+    'Get-JCSystemInsights', 'Get-JCSystemKB', 'Get-JCSystemUser',
+    'Get-JCUser', 'Get-JCUserGroupMember', 'Import-JCCommand',
+    'Import-JCMSPFromCSV', 'Import-JCUsersFromCSV', 'Invoke-JCCommand',
+    'Invoke-JCDeployment', 'New-JCCommand', 'New-JCDeploymentTemplate',
+    'New-JCDeviceUpdateTemplate', 'New-JCImportTemplate',
+    'New-JCMSPImportTemplate', 'New-JCPolicy', 'New-JCPolicyGroup',
+    'New-JCRadiusServer', 'New-JCReport', 'New-JCSystemGroup', 'New-JCUser',
+    'New-JCUserGroup', 'Remove-JCAssociation', 'Remove-JCCommand',
+    'Remove-JCCommandResult', 'Remove-JCCommandTarget',
+    'Remove-JCGsuiteMember', 'Remove-JCOffice365Member',
+    'Remove-JCPolicy', 'Remove-JCPolicyGroup',
+    'Remove-JCPolicyGroupTemplate', 'Remove-JCRadiusReplyAttribute',
+    'Remove-JCRadiusServer', 'Remove-JCSystem', 'Remove-JCSystemGroup',
+    'Remove-JCSystemGroupMember', 'Remove-JCSystemUser', 'Remove-JCUser',
+    'Remove-JCUserGroup', 'Remove-JCUserGroupMember',
+    'Send-JCPasswordReset', 'Set-JCCloudDirectory', 'Set-JCCommand',
+    'Set-JCOrganization', 'Set-JCPolicy', 'Set-JCPolicyGroup',
+    'Set-JCRadiusReplyAttribute', 'Set-JCRadiusServer',
+    'Set-JCSettingsFile', 'Set-JCSystem', 'Set-JCSystemUser', 'Set-JCUser',
+    'Set-JCUserGroupLDAP', 'Update-JCDeviceFromCSV', 'Update-JCModule',
+    'Update-JCMSPFromCSV', 'Update-JCUsersFromCSV'
 
-# Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = @()
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport   = @()
 
-# Variables to export from this module
-VariablesToExport = '*'
+    # Variables to export from this module
+    VariablesToExport = '*'
 
-# Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = 'New-JCAssociation'
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport   = 'New-JCAssociation'
 
-# DSC resources to export from this module
-# DscResourcesToExport = @()
+    # DSC resources to export from this module
+    # DscResourcesToExport = @()
 
-# List of all modules packaged with this module
-# ModuleList = @()
+    # List of all modules packaged with this module
+    # ModuleList = @()
 
-# List of all files packaged with this module
-# FileList = @()
+    # List of all files packaged with this module
+    # FileList = @()
 
-# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
-PrivateData = @{
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData       = @{
 
-    PSData = @{
+        PSData = @{
 
-        # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = 'JumpCloud', 'DaaS', 'Jump', 'Cloud', 'Directory'
+            # Tags applied to this module. These help with module discovery in online galleries.
+            Tags         = 'JumpCloud', 'DaaS', 'Jump', 'Cloud', 'Directory'
 
-        # A URL to the license for this module.
-        LicenseUri = 'https://github.com/TheJumpCloud/support/blob/master/PowerShell/LICENSE'
+            # A URL to the license for this module.
+            LicenseUri   = 'https://github.com/TheJumpCloud/support/blob/master/PowerShell/LICENSE'
 
-        # A URL to the main website for this project.
-        ProjectUri = 'https://github.com/TheJumpCloud/support/wiki'
+            # A URL to the main website for this project.
+            ProjectUri   = 'https://github.com/TheJumpCloud/support/wiki'
 
-        # A URL to an icon representing this module.
-        IconUri = 'https://avatars1.githubusercontent.com/u/4927461?s=200&v=4'
+            # A URL to an icon representing this module.
+            IconUri      = 'https://avatars1.githubusercontent.com/u/4927461?s=200&v=4'
 
-        # ReleaseNotes of this module
-        ReleaseNotes = 'https://git.io/jc-pwsh-releasenotes'
+            # ReleaseNotes of this module
+            ReleaseNotes = 'https://git.io/jc-pwsh-releasenotes'
 
-        # Prerelease string of this module
-        # Prerelease = ''
+            # Prerelease string of this module
+            # Prerelease = ''
 
-        # Flag to indicate whether the module requires explicit user acceptance for install/update/save
-        # RequireLicenseAcceptance = $false
+            # Flag to indicate whether the module requires explicit user acceptance for install/update/save
+            # RequireLicenseAcceptance = $false
 
-        # External dependent modules of this module
-        # ExternalModuleDependencies = @()
+            # External dependent modules of this module
+            # ExternalModuleDependencies = @()
 
-    } # End of PSData hashtable
+        } # End of PSData hashtable
 
-} # End of PrivateData hashtable
+    } # End of PrivateData hashtable
 
-# HelpInfo URI of this module
-HelpInfoURI = 'https://github.com/TheJumpCloud/support/wiki'
+    # HelpInfo URI of this module
+    HelpInfoURI       = 'https://github.com/TheJumpCloud/support/wiki'
 
-# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-# DefaultCommandPrefix = ''
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    # DefaultCommandPrefix = ''
 
 }
 

--- a/PowerShell/ModuleChangelog.md
+++ b/PowerShell/ModuleChangelog.md
@@ -1,3 +1,17 @@
+## 2.18.1
+
+Release Date: April 25, 2025
+
+#### RELEASE NOTES
+
+```
+Implements fix for errors in module directory path resolution
+```
+
+#### BUG FIXES:
+
+Addresses a bug that impacted module directory paths.
+
 ## 2.18.0
 
 Release Date: April 18, 2025


### PR DESCRIPTION
## Issues
* [CUT-4711(https://jumpcloud.atlassian.net/browse/CUT-4711) - CUT-4711-Nuspec-Path-Bug-Fix

## What does this solve?
The latest release of our workflow runner, when transitioning from Linux to Windows for Nuspec builds, has introduced a bug. This bug results in an incorrect directory structure for the `Public`, `Private`, and `en-Us` folders, where extra path information is included ex. `Private\Private\Association` instead of `Private\Association`. The problem is caused by the use of Linux-style forward slashes (`/`) instead of Windows-style backslashes (`\`) in the directory paths. Correcting these path separators resolves the issue.

## How should this be tested?
1. Build nuspec: `. /Users/YOURUSER/Documents/GitHub/support/PowerShell/Deploy/BuildNuspecFromPsd1.ps1`
2. Open the built nuspec file using the Nuget Package Explorer
3. Directory should like this: 
![image](https://github.com/user-attachments/assets/78cb3bf6-a387-43c3-9334-a8ac017fc5f7)


## Screenshots
