### PR TITLE
case-sensitivity

### DIFF
--- a/scripts/automation/Radius/Functions/Private/Generate-UserCert.ps1
+++ b/scripts/automation/Radius/Functions/Private/Generate-UserCert.ps1
@@ -21,7 +21,7 @@ function Generate-UserCert {
         $user
     )
     begin {
-        . "$JCScriptRoot/config.ps1"
+        . "$JCScriptRoot/Config.ps1"
         if (-Not (Test-Path -Path $rootCAKey)) {
             Throw "RootCAKey could not be found in project directory, have you run Generate-Cert.ps1?"
             exit 1

--- a/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Distribute-UserCerts.ps1
@@ -1,5 +1,5 @@
 # Import Global Config:
-. "$JCScriptRoot/config.ps1"
+. "$JCScriptRoot/Config.ps1"
 Connect-JCOnline $JCAPIKEY -force
 
 ################################################################################

--- a/scripts/automation/Radius/Functions/Public/Generate-UserCerts.ps1
+++ b/scripts/automation/Radius/Functions/Public/Generate-UserCerts.ps1
@@ -1,5 +1,5 @@
 # Import Global Config:
-. "$JCScriptRoot/config.ps1"
+. "$JCScriptRoot/Config.ps1"
 Connect-JCOnline $JCAPIKEY -force
 
 ################################################################################

--- a/scripts/automation/Radius/Functions/Public/Monitor-CertDeployment.ps1
+++ b/scripts/automation/Radius/Functions/Public/Monitor-CertDeployment.ps1
@@ -1,5 +1,5 @@
 # Import Global Config:
-. "$JCScriptRoot/config.ps1"
+. "$JCScriptRoot/Config.ps1"
 Connect-JCOnline $JCAPIKEY -force
 
 ################################################################################

--- a/scripts/automation/Radius/Start-RadiusDeployment.ps1
+++ b/scripts/automation/Radius/Start-RadiusDeployment.ps1
@@ -1,5 +1,5 @@
 # Import Global Config:
-. "$psscriptroot/config.ps1"
+. "$psscriptroot/Config.ps1"
 Connect-JCOnline $JCAPIKEY -force
 
 ################################################################################


### PR DESCRIPTION
## Issues
* error
   ```
   TheJumpCloud/support/scripts/automation/Radius/Functions/Public/Generate-UserCerts.ps1:2:3
   Line |
      2 |  . "$JCScriptRoot/config.ps1"
        |    ~~~~~~~~~~~~~~~~~~~~~~~~~~
        | The term './TheJumpCloud/support/scripts/automation/Radius/config.ps1' is not recognized as a name of a
        | cmdlet, function, script file, or executable program. Check the spelling of the name, or if a path was included, verify that the path is
        | correct and try again.
   ```

## What does this solve?
the error

