### PR TITLE
Added logic to collect diagnostic information for CertificateService

### DIFF
--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -11,7 +11,7 @@ days=2           # number of days of OS logs to gather
 # do not edit below
 #######
 
-version=1.2.4
+version=1.2.5
 
 ## verify script is running as root.
 if [ $(/usr/bin/id -u) -ne 0 ]
@@ -139,6 +139,10 @@ fi
 collectionLog "Gathering software installation logs"
 log show --last ${days}d --predicate="process CONTAINS[c] 'appstored'" > $baseDir/systemLogs/appstored.log
 cp /var/log/install.log* $baseDir/systemLogs/
+
+## gather CertificateService diagnostic data
+mkdir $baseDir/DiagnosticReports
+cp /Library/Logs/DiagnosticReports/Certificate* $baseDir/DiagnosticReports/
 
 ## list secure tokens and filesystem information
 collectionLog "Gathering filesystem and secure token information"


### PR DESCRIPTION
## Issues
* [<jira-id>](https://jumpcloud.atlassian.net/browse/<jira-id>) - <jira-title>

## What does this solve?
This collects .ips and diagnostic files related to Apple's Certificate Service, which is believed to be crashing & related to the current MDM unenrollment issues. 

## Is there anything particularly tricky?
nope

## How should this be tested?
create a file in /Library/Logs/DiagnosticReports/CertificateService-2025-06-20-085424.ips (this mimics Apple's naming convention for the files) and run the script. 
Run the script via JumpCloud Commands (setting automate=true)
Verify the inclusion of the "DiagnosticReports/<filename>" in the log archive.

## Screenshots
![image](https://github.com/user-attachments/assets/9d64cb1d-bee0-4735-8e6b-dd3c79935c35)
