### PR TITLE
Multi-Culture DateTime Support

### DIFF
--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Get-CertInfo.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Get-CertInfo.ps1
@@ -66,10 +66,12 @@ function Get-CertInfo {
 
                     # Convert notAfter property into datetime format
                     if ($property.notAfter) {
+                        # write-host "TIME: $($property.notAfter)"
                         $date = $property.notAfter
                         # $date = $date.replace('GMT', '').Trim()
                         $date = $date -replace '\s+', ' '
-                        $date = ([datetime]::ParseExact($date , "MMM d HH:mm:ss yyyy GMT", $null)).ToUniversalTime()
+                        # $date = [datetime]::ParseExact($date , "MMM d HH:mm:ss yyyy GMT", $null)
+                        $date = [datetime]::ParseExact($date, "MMM d HH:mm:ss yyyy GMT", [System.Globalization.CultureInfo]::InvariantCulture)
                         $property.notAfter = Get-Date $date.ToUniversalTime() -UFormat '+%Y-%m-%dT%H:%M:%S.000Z'
                     }
 
@@ -89,10 +91,13 @@ function Get-CertInfo {
                         $property = $_ | ConvertFrom-StringData
                         switch ($($property.keys)) {
                             'notAfter' {
+                                # write-host "TIME: $($property.notAfter)"
                                 $date = $property.notAfter
                                 # $date = $date.replace('GMT', '').Trim()
                                 $date = $date -replace '\s+', ' '
-                                $date = [datetime]::ParseExact($date , "MMM d HH:mm:ss yyyy GMT", $null)
+
+                                # $date = [datetime]::ParseExact($date, "MMM d HH:mm:ss yyyy GMT", [System.Globalization.CultureInfo]::InvariantCulture)
+                                # write-host "TIMENOW: $($date)"
                                 $property.notAfter = Get-Date $date.ToUniversalTime() -UFormat '+%Y-%m-%dT%H:%M:%S.000Z'
 
                             }

--- a/scripts/automation/Radius/Functions/Private/CertDeployment/Get-ExpiringCertInfo.ps1
+++ b/scripts/automation/Radius/Functions/Private/CertDeployment/Get-ExpiringCertInfo.ps1
@@ -1,6 +1,5 @@
 function Get-ExpiringCertInfo {
     param (
-        # array of certificates
         [Parameter(Mandatory)]
         [System.Object]
         $certInfo,
@@ -15,9 +14,12 @@ function Get-ExpiringCertInfo {
     process {
         foreach ($cert in $certInfo) {
             $startDate = [datetime]$currentTime
-            $endDate = [datetime]$cert.notAfter
+            if ($cert.notAfter -is [string]) {
+                $endDate = [datetime]::Parse($cert.notAfter, [System.Globalization.CultureInfo]::InvariantCulture)
+            } else {
+                $endDate = [datetime]$cert.notAfter
+            }
             $certTimespan = New-Timespan -Start $startDate -End $endDate
-            # $cert
             if ($certTimespan.days -lt 15) {
                 Write-Debug "$($cert.userName)'s certificate will expire in $($certTimespan.Days) days"
                 $expiringCerts.add($cert) | Out-Null
@@ -26,7 +28,6 @@ function Get-ExpiringCertInfo {
             }
         }
     }
-
     end {
         return $expiringCerts
     }

--- a/scripts/automation/Radius/Functions/Private/Menus/Show-RootCAGenerationMenu.ps1
+++ b/scripts/automation/Radius/Functions/Private/Menus/Show-RootCAGenerationMenu.ps1
@@ -13,7 +13,13 @@ function Show-RootCAGenerationMenu {
         Write-Host $(PadCenter -string "Root CA Expiration: $($rootCAInfo.notAfter)`n" -char ' ') -ForegroundColor Green
 
         # If root CA is expiring within 30 days, display warning
-        $expirationDate = [datetime]$rootCAInfo.notAfter
+        if ($rootCAInfo.notAfter -is [string]) {
+            $expirationDate = [datetime]::Parse($rootCAInfo.notAfter, [System.Globalization.CultureInfo]::InvariantCulture)
+        } else {
+            $expirationDate = [datetime]$rootCAInfo.notAfter
+        }
+        $currentDate = Get-Date
+        $daysRemaining = ($expirationDate - $currentDate).Days
         $currentDate = Get-Date
         $daysRemaining = ($expirationDate - $currentDate).Days
 

--- a/scripts/automation/Radius/Functions/Private/Reports/Get-LatestUserToDeviceReport.ps1
+++ b/scripts/automation/Radius/Functions/Private/Reports/Get-LatestUserToDeviceReport.ps1
@@ -7,7 +7,7 @@ Function Get-LatestUserToDeviceReport {
     )
     begin {
         # get UTC time now:
-        $utcTimeNow = Get-Date ([datetime]::UtcNow) -UFormat "%m/%d/%Y %r"
+        $utcTimeNow = [datetime]::UtcNow
 
         $headers = @{
             "accept"    = "application/json";

--- a/scripts/automation/Radius/Functions/Public/Get-JCRCertReport.ps1
+++ b/scripts/automation/Radius/Functions/Public/Get-JCRCertReport.ps1
@@ -66,7 +66,11 @@ function Get-JCRCertReport {
             }
 
             $reportEntry.certSerialNumber = $certificateSerialNumber
-            $reportEntry.certExpirationDate = $certificateExpirationDate
+            if ($certificateExpirationDate -is [string]) {
+                $reportEntry.certExpirationDate = [datetime]::Parse($certificateExpirationDate, [System.Globalization.CultureInfo]::InvariantCulture)
+            } else {
+                $reportEntry.certExpirationDate = [datetime]$certificateExpirationDate
+            }
             $reportEntry.certInstalled = $certInstalled
 
             $reportData.Add([pscustomobject]$reportEntry) | Out-Null

--- a/scripts/automation/Radius/Tests/Private/CertDeployment/Get-CertInfo.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Private/CertDeployment/Get-CertInfo.Tests.ps1
@@ -1,0 +1,43 @@
+Describe "Date Parsing is Culture Invariant" -Tag "Acceptance" {
+
+    BeforeAll {
+        # Load all functions from private folders
+        $Private = @( Get-ChildItem -Path "$JCRScriptRoot/Functions/Private/*.ps1" -Recurse)
+        Foreach ($Import in $Private) {
+            Try {
+                . $Import.FullName
+            } Catch {
+                Write-Error -Message "Failed to import function $($Import.FullName): $_"
+            }
+        }
+        Start-GenerateRootCert -certKeyPassword "testCertificate123!@#" -generateType "new" -force
+    }
+    Context "Date Parsing" {
+
+        BeforeAll {
+            $originalCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+            $originalUICulture = [System.Threading.Thread]::CurrentThread.CurrentUICulture
+        }
+        AfterAll {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = $originalUICulture
+        }
+
+        It "Parses date string in pt-BR culture" {
+            # Set culture to Brazilian Portuguese
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = 'pt-BR'
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = 'pt-BR'
+
+            $user = $global:JCRRadiusMembers.username | select -First 1
+            # if the user does not have a valid cert, generate one with Start-GenerateUserCerts
+            $userCertExpectedPath = "$($global:JCRConfig.radiusDirectory.value)/UserCerts/$($user)-$($global:JCRConfig.certType.value)-client-signed-cert.crt"
+            if (-not (Test-Path -Path $userCertExpectedPath)) {
+                Start-GenerateUserCerts -username $user -forceReplaceCert -type ByUsername
+            }
+            . "/Users/jworkman/Documents/GitHub/support/scripts/automation/Radius/Functions/Private/CertDeployment/Get-CertInfo.ps1"
+            { Get-CertInfo -UserCerts -username $user } | Should -Not -Throw
+        }
+    }
+
+
+}

--- a/scripts/automation/Radius/Tests/Public/Get-JCRCertReport.Tests.ps1
+++ b/scripts/automation/Radius/Tests/Public/Get-JCRCertReport.Tests.ps1
@@ -34,4 +34,24 @@ Describe 'User Cert Report' -Tag "Reports" {
             { Get-JCRCertReport -ExportFilePath "$JCRScriptRoot/testReport.csv" } | Should -Not -Throw
         }
     }
+    Context "Date Parsing" {
+        BeforeAll {
+            $originalCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+            $originalUICulture = [System.Threading.Thread]::CurrentThread.CurrentUICulture
+        }
+        AfterAll {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = $originalUICulture
+        }
+        It "Generates the report in pt-BR culture" {
+            # Set culture to Brazilian Portuguese
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = 'pt-BR'
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = 'pt-BR'
+
+            # Export the report
+            { Get-JCRCertReport -ExportFilePath "$JCRScriptRoot/testReport.csv" } | Should -Not -Throw
+            $report = Import-Csv -Path "$JCRScriptRoot/testReport.csv"
+            $report | Should -Not -BeNullOrEmpty
+        }
+    }
 }


### PR DESCRIPTION
## Issues
* [CUT-4814](https://jumpcloud.atlassian.net/browse/CUT-4814) - Multi-Culture DateTime Radius Support

## What does this solve?
When the Radius script was first written it was intended to be proof of concept tool. This release adds support for different date time formats to be read into the tool and used while generating and re-generating user certificates

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots
