### PR TITLE
Updated log collection to aid DDM-based policies

### DIFF
--- a/scripts/macos/log_collection.sh
+++ b/scripts/macos/log_collection.sh
@@ -11,7 +11,7 @@ days=2           # number of days of OS logs to gather
 # do not edit below
 #######
 
-version=1.2.8
+version=1.2.9
 
 ## verify script is running as root.
 if [ $(/usr/bin/id -u) -ne 0 ]
@@ -60,7 +60,7 @@ baseDir="${hostDir}JumpCloudLogCollect"
 sysId=$(grep -o '"systemKey": *"[^"]*"' /opt/jc/jcagent.conf | grep -o '"[^"]*"$' | sed 's/\"//g')
 
 ## Create directories for log collection
-mkdir -p {$baseDir/jumpcloud_logs,$baseDir/systemLogs,$baseDir/systemInfo,$baseDir/userLogs,$baseDir/DiagnosticReports}
+mkdir -p {$baseDir/jumpcloud_logs,$baseDir/systemLogs,$baseDir/systemLogs/patchManagement,$baseDir/systemInfo,$baseDir/userLogs,$baseDir/DiagnosticReports}
 
 # Setup Log output for Log Collection Script
 collectionLogFile="${baseDir}/collection.log"
@@ -74,7 +74,6 @@ collectionLog "Log Collection Version: $version"
 
 
 ## Change directory to save log archive depending on active user state
-
 if [[ $(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }') ]]; then
     localuser=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }')
     collectionLog "User $localuser is currently logged in."
@@ -84,8 +83,8 @@ else
     archiveTargetDir="/private/var/tmp/"
 fi
 
-
 collectionLog "Gathering all JumpCloud agent and process Logs..."
+
 
 ## gather JumpCloud system logs (agent, install, patch management)
 for f in /var/log/jc*.log*
@@ -120,17 +119,35 @@ log show --last ${days}d --predicate="eventMessage CONTAINS[c] 'jumpcloud'" > $b
 log show --last ${days}d --debug --info --style compact --predicate 'senderImagePath CONTAINS[c] "JCLoginPlugin"' > $baseDir/systemLogs/SSAP_LoginWindow_events.log
 log show --last ${days}d --predicate="process CONTAINS[c] 'DurtService' || process CONTAINS[c] 'JumpCloudGo'" > $baseDir/systemLogs/JumpCloudGo_events.log
 
+
 ## pull patch management logs
-collectionLog "Gathering profiles & OS Patch Management settings"
-profiles show -o stdout > $baseDir/installedProfiles.txt
+collectionLog "Gathering MDM profiles & OS Patch Management settings"
 
-softwareupdate --list > $baseDir/systemInfo/SoftwareUpdateList.txt 2>&1
+profiles show -o stdout > $baseDir/systemInfo/installedProfiles.txt 2>&1
+softwareupdate --list > $baseDir/systemLogs/patchManagement/SoftwareUpdateList.txt 2>&1
 
-defaults read /Library/Preferences/com.apple.SoftwareUpdate > $baseDir/com.apple.SoftwareUpdate.plist 2>&1
+## pull patch management related log entries from the system logs
+log show --last ${days}d --debug --predicate='eventMessage CONTAINS[c] "SoftwareUpdateMacController"' > $baseDir/systemLogs/patchManagement/SoftwareUpdateMacController.log
+
+
+patchFiles=(
+    "/Library/Preferences/com.apple.SoftwareUpdate.plist"
+    "/var/db/softwareupdate/SoftwareUpdateDDMStatePersistence.plist"
+)
+
+for patchFile in "${patchFiles[@]}"; do
+    if [ -e "$patchFile" ]; then
+        defaults read "$patchFile" > "$baseDir/systemLogs/patchManagement/$(basename $patchFile)" 2>&1
+    else
+        collectionLog "Patch management file $(basename $patchFile) not found; skipping."
+    fi
+done
+
 
 if [ -e /Library/Preferences/com.jumpcloud.Nudge.json ]; then
-    cp /Library/Preferences/com.jumpcloud.Nudge.json $baseDir/systemInfo/com.jumpcloud.Nudge.json
+    cp /Library/Preferences/com.jumpcloud.Nudge.json $baseDir/systemLogs/patchManagement/com.jumpcloud.Nudge.json
 fi
+
 
 ## Only run if a user is actually logged in
 if [[ $localuser ]]; then
@@ -139,13 +156,13 @@ if [[ $localuser ]]; then
     USER_ID=$(id -u "$localuser")
 
     ## pull additional patch management information
-    sudo -u $localuser defaults read com.github.macadmins.Nudge.plist > $baseDir/com.github.macadmins.Nudge.plist 2>&1
+    sudo -u $localuser defaults read com.github.macadmins.Nudge.plist > $baseDir/systemLogs/patchManagement/com.github.macadmins.Nudge.plist 2>&1
 
     ## list jumpcloud services currently running on the system
     sudo -u $localuser launchctl print system | grep -i 'jumpcloud' > $baseDir/systemInfo/activeJumpCloudServices.txt
 
     ## Collect SoftwareUpdateDeviceID relating to DDM / MDM based patch management.
-    sudo launchctl asuser "$USER_ID" /usr/libexec/mdmclient QueryDeviceInformation | grep "SoftwareUpdateDeviceID" | sort -u > $baseDir/systemInfo/SoftwareUpdateDeviceID.txt
+    sudo launchctl asuser "$USER_ID" /usr/libexec/mdmclient QueryDeviceInformation | grep "SoftwareUpdateDeviceID" | sort -u > $baseDir/systemLogs/patchManagement/SoftwareUpdateDeviceID.txt
 
 else
     collectionLog "No user is currently logged in. Skipping user-specific information."


### PR DESCRIPTION

*macOS - Update Patch Management Logging*

Updated patch management logs to collect and function to aid with new DDM-based policies. Along with creating a new directory path to house all related PM logging.


## Issues
* [SUP-1555](https://jumpcloud.atlassian.net/browse/SUP-1555) - SUP-1555

## What does this solve?
Includes logs to assist with troubleshooting DDM-based patch policies.
Improves log collation for improved navigation.

## Is there anything particularly tricky?
N/A

## How should this be tested?
Run the log collection script on a macOS device

## Screenshots

<img width="671" height="487" alt="Screenshot 2026-03-13 at 14 02 02" src="https://github.com/user-attachments/assets/19e39df2-d6df-4ed3-bc94-0bbc586dbfe7" />


<img width="2092" height="1430" alt="Screenshot 2026-03-13 at 10 25 36 AM" src="https://github.com/user-attachments/assets/c8b6e00d-77a4-4c14-8d2e-1c8fcaf79bd8" />

[SUP-1555]: https://jumpcloud.atlassian.net/browse/SUP-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes a root-run support script’s collection commands and output paths, which could affect troubleshooting output or fail on certain macOS versions/filesystems if paths/commands differ.
> 
> **Overview**
> Updates the macOS `log_collection.sh` to better support troubleshooting *DDM-based patch policies* by introducing a dedicated `systemLogs/patchManagement/` output folder and relocating patch-management artifacts into it.
> 
> Adds new patch-management captures (e.g., `SoftwareUpdateMacController` system log entries, DDM state persistence plist reads, and `SoftwareUpdateDeviceID` from `mdmclient` when a user is logged in) and adjusts where profile and `softwareupdate --list` outputs are written. Also bumps the script version to `1.2.9`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f40645f14e71cc070e32c31ce9f7b68fbb16c810. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->