### PR TITLE
Update readme.md

### DIFF
--- a/scripts/automation/Radius/readme.md
+++ b/scripts/automation/Radius/readme.md
@@ -77,7 +77,7 @@ To set all of the settings at once, run the `Set-JCRConfig` cmdlet with a hashta
 $settings = @{
     radiusDirectory                   = "/Users/username/RADIUS"
     certType                          = "UsernameCn"
-    certSubjectHeader @{
+    certSubjectHeader = @{
         CountryCode      = "Your_Country_Code"
         StateCode        = "Your_State_Code"
         Locality         = "Your_City"


### PR DESCRIPTION
## Issues
* [CUT-5122](https://jumpcloud.atlassian.net/browse/CUT-5122) - Update Radius Docs 

## What does this solve?
missing "="

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots


[CUT-5122]: https://jumpcloud.atlassian.net/browse/CUT-5122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change fixing a PowerShell hashtable assignment; no runtime or security-impacting code changes.
> 
> **Overview**
> Fixes a typo in `scripts/automation/Radius/readme.md` by adding the missing `=` for `certSubjectHeader` in the `Set-JCRConfig` `$settings` hashtable example, so the copy/paste configuration snippet is valid PowerShell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571ccf8a35bc9d223dd3abd5c7be0533e14760a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->