### PR TITLE
sup-1556

### DIFF
--- a/scripts/windows/log_collection.ps1
+++ b/scripts/windows/log_collection.ps1
@@ -174,10 +174,10 @@ function Gather-Logs {
                         $copyLog += "FAILED: Gathering Local Users - $($_.Exception.Message)"
                     }
 
-                    # Gather Credential Providers Information
+                    # Gather Credential Providers Information (With Space between Active and Available)
                     try {
                         $LastUsedGUID = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\LogonUI").LastLoggedOnProvider
-                        Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\Credential Providers" | 
+                        $providers = Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\Credential Providers" | 
                         ForEach-Object {
                             $id = $_.PSChildName
                             $regPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\Credential Providers\$id"
@@ -191,7 +191,16 @@ function Gather-Logs {
                                 GUID         = $id
                                 DLLPath      = $dll
                             }
-                        } | Sort-Object Status | Format-Table -AutoSize | Out-String -Width 4096 | Out-File -FilePath "$tempDir\CredentialProviders.txt"
+                        }
+
+                        $active = $providers | Where-Object { $_.Status -eq "Active (Last Used)" }
+                        $available = $providers | Where-Object { $_.Status -ne "Active (Last Used)" } | Sort-Object ProviderName
+
+                        $credLogContent = $active | Format-Table -AutoSize | Out-String -Width 4096
+                        $credLogContent += "`r`n" # Blank Line
+                        $credLogContent += $available | Format-Table -AutoSize | Out-String -Width 4096
+                        
+                        $credLogContent | Out-File -FilePath "$tempDir\CredentialProviders.txt"
                         $copyLog += "SUCCESS: Gathered Credential Providers to CredentialProviders.txt"
                     } catch {
                         $copyLog += "FAILED: Gathering Credential Providers - $($_.Exception.Message)"
@@ -200,19 +209,23 @@ function Gather-Logs {
                     # Getting per-user logs
                     $allUsers = Get-LocalUser
                     foreach ($user in $allUsers) {
-                        # Getting Jumpcloud TrayApp Log
-                        $trayLog = "C:\ProgramData\JumpCloud\Tray\$($user.Name)\tray*.log"
-                        if (Test-Path $trayLog) {
-                            try {
-                                $destName = "$tempDir\$($user.Name)-tray.log"
-                                Copy-Item -Path $trayLog -Destination $destName -ErrorAction Stop
-                                $copyLog += "SUCCESS: $trayLog -> $destName"
-                            } catch {
-                                $copyLog += "FAILED: $trayLog - $($_.Exception.Message)"
+                        # 1. gETTING Tray Log (Outside Profile Guard)
+                        $trayLogPath = "C:\ProgramData\JumpCloud\Tray\$($user.Name)\tray*.log"
+                        $foundTrayLogs = Get-ChildItem -Path $trayLogPath -ErrorAction SilentlyContinue
+
+                        if ($foundTrayLogs) {
+                            foreach ($logFile in $foundTrayLogs) {
+                                try {
+                                    $destName = "$tempDir\$($user.Name)-$($logFile.Name)"
+                                    Copy-Item -Path $logFile.FullName -Destination $destName -ErrorAction Stop
+                                    $copyLog += "SUCCESS: $($logFile.FullName) -> $destName"
+                                } catch {
+                                    $copyLog += "FAILED: $($logFile.FullName) - $($_.Exception.Message)"
+                                }
                             }
                         }
 
-                        # Getting Profile-Specific Logs
+                        # 2. Getting Profile-Specific Logs
                         if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)" -Name "ProfileImagePath" -ErrorAction SilentlyContinue) {
                             $profilePath = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)" -Name "ProfileImagePath"
                             $profileImagePath = $profilePath.ProfileImagePath
@@ -238,18 +251,15 @@ function Gather-Logs {
                     }
 
                     # Getting JumpCloud Legacy TrayApp logs
-                    $trayLogPath = "C:\ProgramData\JumpCloud\Tray\$($user.Name)\tray*.log"
-                    $foundTrayLogs = Get-ChildItem -Path $trayLogPath -ErrorAction SilentlyContinue
-
-                    if ($foundTrayLogs) {
-                        foreach ($logFile in $foundTrayLogs) {
-                            try {
-                                $destName = "$tempDir\$($user.Name)-$($logFile.Name)"
-                                Copy-Item -Path $logFile.FullName -Destination $destName -ErrorAction Stop
-                                $copyLog += "SUCCESS: $($logFile.FullName) -> $destName"
-                            } catch {
-                                $copyLog += "FAILED: $($logFile.FullName) - $($_.Exception.Message)"
-                            }
+                    $trayAppLogs = Get-ChildItem -Path "C:\ProgramData\JumpCloud\TrayApp\" -Recurse -Filter "jumpcloudtray.log" -ErrorAction SilentlyContinue
+                    foreach ($log in $trayAppLogs) {
+                        try {
+                            $parentFolder = Split-Path $log.DirectoryName -Leaf
+                            $destName = "$tempDir\$parentFolder-jumpcloudtray.log"
+                            Copy-Item -Path $log.FullName -Destination $destName -ErrorAction Stop
+                            $copyLog += "SUCCESS: $($log.FullName) -> $destName"
+                        } catch {
+                            $copyLog += "FAILED: $($log.FullName) - $($_.Exception.Message)"
                         }
                     }
 
@@ -416,4 +426,4 @@ if ($automate) {
         $selectedSections = $selectedIndexes | ForEach-Object { $sections[$_] } -ErrorAction SilentlyContinue
         Gather-Logs -selections $selectedSections
     }
-} 
+}

--- a/scripts/windows/log_collection.ps1
+++ b/scripts/windows/log_collection.ps1
@@ -64,10 +64,10 @@ function Gather-Logs {
         New-Item -ItemType Directory -Path $tempDir > $null
 
         # Gather Windows Version Information
-        $winVersion = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").ProductName
-        $winVersion += " - Version " + (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").ReleaseId
         $winVersionFile = Join-Path $tempDir "WinVersion.txt"
-        $winVersion | Out-File -FilePath $winVersionFile -ErrorAction SilentlyContinue
+        Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" | 
+            Select-Object ProductName, DisplayVersion, CurrentBuild, UBR | 
+            Out-File -FilePath $winVersionFile -ErrorAction SilentlyContinue
 
         # List of Log Files and Event Logs to Gather
         $fileList = @{
@@ -150,7 +150,54 @@ function Gather-Logs {
                     $files += $fileList["AgentLogs"]
                     $eventLogs += $eventLogList["EssentialEvents"]
 
-                    # Getting jc-user-agent.log and jcupdate.log per user
+                    # Gather Local User and Group Membership Information
+                    try {
+                        Get-LocalUser | ForEach-Object {
+                            $user = $_
+                            $userSID = $user.SID
+                            $memberOf = Get-LocalGroup | Where-Object {
+                                try {
+                                    $members = Get-LocalGroupMember -Group $_.Name -ErrorAction SilentlyContinue
+                                    $members.SID -contains $userSID
+                                } catch { $false }
+                            }
+                            [PSCustomObject]@{
+                                UserName    = $user.Name
+                                SID         = $userSID.Value
+                                Description = $user.Description
+                                Groups      = ($memberOf.Name -join ", ")
+                                Enabled     = $user.Enabled
+                            }
+                        } | Sort-Object UserName | Format-Table -AutoSize | Out-String -Width 4096 | Out-File -FilePath "$tempDir\SystemUsers.log"
+                        $copyLog += "SUCCESS: Gathered Local Users to SystemUsers.log"
+                    } catch {
+                        $copyLog += "FAILED: Gathering Local Users - $($_.Exception.Message)"
+                    }
+
+                    # Gather Credential Providers Information
+                    try {
+                        $LastUsedGUID = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\LogonUI").LastLoggedOnProvider
+                        Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\Credential Providers" | 
+                        ForEach-Object {
+                            $id = $_.PSChildName
+                            $regPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\Credential Providers\$id"
+                            $clsidPath = "HKLM:\Software\Classes\CLSID\$id\InprocServer32"
+                            $name = (Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue)."(default)"
+                            $dll = (Get-ItemProperty -Path $clsidPath -ErrorAction SilentlyContinue)."(default)"
+                            $Status = if ($id -eq $LastUsedGUID) { "Active (Last Used)" } else { "Available" }
+                            [PSCustomObject]@{
+                                Status       = $Status
+                                ProviderName = if ($name) { $name } else { "Windows Internal / Generic" }
+                                GUID         = $id
+                                DLLPath      = $dll
+                            }
+                        } | Sort-Object Status -Descending | Format-Table -AutoSize | Out-String -Width 4096 | Out-File -FilePath "$tempDir\CredentialProviders.txt"
+                        $copyLog += "SUCCESS: Gathered Credential Providers to CredentialProviders.txt"
+                    } catch {
+                        $copyLog += "FAILED: Gathering Credential Providers - $($_.Exception.Message)"
+                    }
+
+                    # Getting per-user logs
                     $allUsers = Get-LocalUser
                     foreach ($user in $allUsers) {
                         if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)" -Name "ProfileImagePath" -ErrorAction SilentlyContinue) {
@@ -159,8 +206,10 @@ function Gather-Logs {
 
                             $jcUserAgentLog = "$profileImagePath\AppData\Local\Temp\jc-user-agent.log"
                             $jcUpdateLog = "$profileImagePath\AppData\Local\Temp\jcupdate.log"
+                            $jcNativeMsgLog = "$profileImagePath\AppData\Local\Temp\jc-native-messaging-host.log"
+                            $trayLog = "C:\ProgramData\JumpCloud\Tray\$($user.Name)\tray.log"
 
-                            foreach ($file in @($jcUserAgentLog, $jcUpdateLog)) {
+                            foreach ($file in @($jcUserAgentLog, $jcUpdateLog, $jcNativeMsgLog, $trayLog)) {
                                 if (Test-Path $file) {
                                     try {
                                         $destName = "$tempDir\$($user.Name)-$(Split-Path $file -Leaf)"
@@ -174,6 +223,12 @@ function Gather-Logs {
                                 }
                             }
                         }
+                    }
+
+                    # Fallback for Native Messaging log for Current User
+                    $currentUserNativeLog = Join-Path $env:TEMP "jc-native-messaging-host.log"
+                    if (Test-Path $currentUserNativeLog) {
+                        Copy-Item -Path $currentUserNativeLog -Destination "$tempDir\CurrentUser-jc-native-messaging-host.log" -ErrorAction SilentlyContinue
                     }
 
                     # Getting JumpCloud TrayApp logs
@@ -341,7 +396,7 @@ if ($automate) {
     for ($i = 0; $i -lt $sections.Count; $i++) {
         $selectionPrompt += "$($i + 1). $($sections[$i])`n"
     }
-    $selectionPrompt += "Enter your selection (e.g., 1, 3, 5-7)"
+    $selectionPrompt += "Enter your selection (e.g., 1, 3, 5-7): "
 
     $input = Read-Host -Prompt $selectionPrompt
     $selectedIndexes = $input -split ",|-" | ForEach-Object { $_.Trim() } | Where-Object { $_ -match "^\d+$" } | ForEach-Object { [int]$_ - 1 }

--- a/scripts/windows/log_collection.ps1
+++ b/scripts/windows/log_collection.ps1
@@ -1,4 +1,4 @@
-##################### Do Not Modify Below ######################
+ ##################### Do Not Modify Below ######################
 # set to $true if running via a JumpCloud command (recommended)
 $automate = $false
 
@@ -191,7 +191,7 @@ function Gather-Logs {
                                 GUID         = $id
                                 DLLPath      = $dll
                             }
-                        } | Sort-Object Status -Descending | Format-Table -AutoSize | Out-String -Width 4096 | Out-File -FilePath "$tempDir\CredentialProviders.txt"
+                        } | Sort-Object Status | Format-Table -AutoSize | Out-String -Width 4096 | Out-File -FilePath "$tempDir\CredentialProviders.txt"
                         $copyLog += "SUCCESS: Gathered Credential Providers to CredentialProviders.txt"
                     } catch {
                         $copyLog += "FAILED: Gathering Credential Providers - $($_.Exception.Message)"
@@ -200,6 +200,19 @@ function Gather-Logs {
                     # Getting per-user logs
                     $allUsers = Get-LocalUser
                     foreach ($user in $allUsers) {
+                        # Getting Jumpcloud TrayApp Log
+                        $trayLog = "C:\ProgramData\JumpCloud\Tray\$($user.Name)\tray.log"
+                        if (Test-Path $trayLog) {
+                            try {
+                                $destName = "$tempDir\$($user.Name)-tray.log"
+                                Copy-Item -Path $trayLog -Destination $destName -ErrorAction Stop
+                                $copyLog += "SUCCESS: $trayLog -> $destName"
+                            } catch {
+                                $copyLog += "FAILED: $trayLog - $($_.Exception.Message)"
+                            }
+                        }
+
+                        # Getting Profile-Specific Logs
                         if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)" -Name "ProfileImagePath" -ErrorAction SilentlyContinue) {
                             $profilePath = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)" -Name "ProfileImagePath"
                             $profileImagePath = $profilePath.ProfileImagePath
@@ -207,9 +220,8 @@ function Gather-Logs {
                             $jcUserAgentLog = "$profileImagePath\AppData\Local\Temp\jc-user-agent.log"
                             $jcUpdateLog = "$profileImagePath\AppData\Local\Temp\jcupdate.log"
                             $jcNativeMsgLog = "$profileImagePath\AppData\Local\Temp\jc-native-messaging-host.log"
-                            $trayLog = "C:\ProgramData\JumpCloud\Tray\$($user.Name)\tray.log"
 
-                            foreach ($file in @($jcUserAgentLog, $jcUpdateLog, $jcNativeMsgLog, $trayLog)) {
+                            foreach ($file in @($jcUserAgentLog, $jcUpdateLog, $jcNativeMsgLog)) {
                                 if (Test-Path $file) {
                                     try {
                                         $destName = "$tempDir\$($user.Name)-$(Split-Path $file -Leaf)"
@@ -225,7 +237,7 @@ function Gather-Logs {
                         }
                     }
 
-                    # Getting JumpCloud TrayApp logs
+                    # Getting JumpCloud Legacy TrayApp logs
                     $trayAppLogs = Get-ChildItem -Path "C:\ProgramData\JumpCloud\TrayApp\" -Recurse -Filter "jumpcloudtray.log" -ErrorAction SilentlyContinue
                     foreach ($log in $trayAppLogs) {
                         try {
@@ -311,8 +323,8 @@ function Gather-Logs {
                     if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\Jumpcloud\AD Integration Sync Agent" -ErrorAction SilentlyContinue ) {
                         reg export "HKEY_LOCAL_MACHINE\SOFTWARE\JumpCloud\AD Integration Sync Agent" "$tempDir\ADIntegrationSyncAgent.reg" /y
                     }
-                    Import-Module ActiveDirectory -ErrorAction SilentlyContinue
-                    if (Get-Module -Name ActiveDirectory) {
+                    if (Get-Module -ListAvailable ActiveDirectory) {
+                        Import-Module ActiveDirectory -ErrorAction SilentlyContinue
                         $distinguishedName = (Get-ADDomain).DistinguishedName
                         $distinguishedName | Out-File -FilePath (Join-Path $tempDir "AD_DistinguishedName.txt")
                     }

--- a/scripts/windows/log_collection.ps1
+++ b/scripts/windows/log_collection.ps1
@@ -225,12 +225,6 @@ function Gather-Logs {
                         }
                     }
 
-                    # Fallback for Native Messaging log for Current User
-                    $currentUserNativeLog = Join-Path $env:TEMP "jc-native-messaging-host.log"
-                    if (Test-Path $currentUserNativeLog) {
-                        Copy-Item -Path $currentUserNativeLog -Destination "$tempDir\CurrentUser-jc-native-messaging-host.log" -ErrorAction SilentlyContinue
-                    }
-
                     # Getting JumpCloud TrayApp logs
                     $trayAppLogs = Get-ChildItem -Path "C:\ProgramData\JumpCloud\TrayApp\" -Recurse -Filter "jumpcloudtray.log" -ErrorAction SilentlyContinue
                     foreach ($log in $trayAppLogs) {

--- a/scripts/windows/log_collection.ps1
+++ b/scripts/windows/log_collection.ps1
@@ -174,7 +174,7 @@ function Gather-Logs {
                         $copyLog += "FAILED: Gathering Local Users - $($_.Exception.Message)"
                     }
 
-                    # Gather Credential Providers Information (With Space between Active and Available)
+                    # Gather Credential Providers Information
                     try {
                         $LastUsedGUID = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\LogonUI").LastLoggedOnProvider
                         $providers = Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\Credential Providers" | 
@@ -209,10 +209,9 @@ function Gather-Logs {
                     # Getting per-user logs
                     $allUsers = Get-LocalUser
                     foreach ($user in $allUsers) {
-                        # 1. gETTING Tray Log (Outside Profile Guard)
+                        # 1. Capture Tray Log variants (Outside Profile Guard)
                         $trayLogPath = "C:\ProgramData\JumpCloud\Tray\$($user.Name)\tray*.log"
                         $foundTrayLogs = Get-ChildItem -Path $trayLogPath -ErrorAction SilentlyContinue
-
                         if ($foundTrayLogs) {
                             foreach ($logFile in $foundTrayLogs) {
                                 try {
@@ -225,26 +224,26 @@ function Gather-Logs {
                             }
                         }
 
-                        # 2. Getting Profile-Specific Logs
+                        # Getting Profile-Specific Logs
                         if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)" -Name "ProfileImagePath" -ErrorAction SilentlyContinue) {
-                            $profilePath = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)" -Name "ProfileImagePath"
-                            $profileImagePath = $profilePath.ProfileImagePath
+                            $profilePath = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)").ProfileImagePath
+                            
+                            $logPatterns = @(
+                                "$profilePath\AppData\Local\Temp\jc-user-agent.log",
+                                "$profilePath\AppData\Local\Temp\jcupdate.log",
+                                "$profilePath\AppData\Local\Temp\jc-native-messaging-host*.log"
+                            )
 
-                            $jcUserAgentLog = "$profileImagePath\AppData\Local\Temp\jc-user-agent.log"
-                            $jcUpdateLog = "$profileImagePath\AppData\Local\Temp\jcupdate.log"
-                            $jcNativeMsgLog = "$profileImagePath\AppData\Local\Temp\jc-native-messaging-host.log"
-
-                            foreach ($file in @($jcUserAgentLog, $jcUpdateLog, $jcNativeMsgLog)) {
-                                if (Test-Path $file) {
+                            foreach ($pattern in $logPatterns) {
+                                $matchedFiles = Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue
+                                foreach ($file in $matchedFiles) {
                                     try {
-                                        $destName = "$tempDir\$($user.Name)-$(Split-Path $file -Leaf)"
-                                        Copy-Item -Path $file -Destination $destName -ErrorAction Stop
-                                        $copyLog += "SUCCESS: $file -> $destName"
+                                        $destName = "$tempDir\$($user.Name)-$($file.Name)"
+                                        Copy-Item -Path $file.FullName -Destination $destName -ErrorAction Stop
+                                        $copyLog += "SUCCESS: $($file.FullName) -> $destName"
                                     } catch {
-                                        $copyLog += "FAILED: $file - $($_.Exception.Message)"
+                                        $copyLog += "FAILED: $($file.FullName) - $($_.Exception.Message)"
                                     }
-                                } else {
-                                    $copyLog += "FAILED: $file - File does not exist"
                                 }
                             }
                         }
@@ -278,12 +277,11 @@ function Gather-Logs {
                     $allUsers = Get-LocalUser
                     foreach ($user in $allUsers) {
                         if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)" -Name "ProfileImagePath" -ErrorAction SilentlyContinue) {
-                            $profilePath = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)" -Name "ProfileImagePath"
-                            $profileImagePath = $profilePath.ProfileImagePath
+                            $profilePath = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$($user.SID)").ProfileImagePath
 
                             foreach ($file in @(
-                                    "$profileImagePath\AppData\Roaming\JumpCloud Password Manager\logs\logs-live.log",
-                                    "$profileImagePath\AppData\Roaming\JumpCloud Password Manager\data\daemon\log\*.log"
+                                    "$profilePath\AppData\Roaming\JumpCloud Password Manager\logs\logs-live.log",
+                                    "$profilePath\AppData\Roaming\JumpCloud Password Manager\data\daemon\log\*.log"
                                 )) {
                                 if (Test-Path $file) {
                                     try {
@@ -336,8 +334,8 @@ function Gather-Logs {
                     if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\Jumpcloud\AD Integration Sync Agent" -ErrorAction SilentlyContinue ) {
                         reg export "HKEY_LOCAL_MACHINE\SOFTWARE\JumpCloud\AD Integration Sync Agent" "$tempDir\ADIntegrationSyncAgent.reg" /y
                     }
-                    Import-Module ActiveDirectory -ErrorAction SilentlyContinue
-                    if (Get-Module -Name ActiveDirectory) {
+                    if (Get-Module -ListAvailable ActiveDirectory) {
+                        Import-Module ActiveDirectory -ErrorAction SilentlyContinue
                         $distinguishedName = (Get-ADDomain).DistinguishedName
                         $distinguishedName | Out-File -FilePath (Join-Path $tempDir "AD_DistinguishedName.txt")
                     }
@@ -426,4 +424,4 @@ if ($automate) {
         $selectedSections = $selectedIndexes | ForEach-Object { $sections[$_] } -ErrorAction SilentlyContinue
         Gather-Logs -selections $selectedSections
     }
-}
+} 

--- a/scripts/windows/log_collection.ps1
+++ b/scripts/windows/log_collection.ps1
@@ -201,7 +201,7 @@ function Gather-Logs {
                     $allUsers = Get-LocalUser
                     foreach ($user in $allUsers) {
                         # Getting Jumpcloud TrayApp Log
-                        $trayLog = "C:\ProgramData\JumpCloud\Tray\$($user.Name)\tray.log"
+                        $trayLog = "C:\ProgramData\JumpCloud\Tray\$($user.Name)\tray*.log"
                         if (Test-Path $trayLog) {
                             try {
                                 $destName = "$tempDir\$($user.Name)-tray.log"
@@ -238,15 +238,18 @@ function Gather-Logs {
                     }
 
                     # Getting JumpCloud Legacy TrayApp logs
-                    $trayAppLogs = Get-ChildItem -Path "C:\ProgramData\JumpCloud\TrayApp\" -Recurse -Filter "jumpcloudtray.log" -ErrorAction SilentlyContinue
-                    foreach ($log in $trayAppLogs) {
-                        try {
-                            $parentFolder = Split-Path $log.DirectoryName -Leaf
-                            $destName = "$tempDir\$parentFolder-jumpcloudtray.log"
-                            Copy-Item -Path $log.FullName -Destination $destName -ErrorAction Stop
-                            $copyLog += "SUCCESS: $($log.FullName) -> $destName"
-                        } catch {
-                            $copyLog += "FAILED: $($log.FullName) - $($_.Exception.Message)"
+                    $trayLogPath = "C:\ProgramData\JumpCloud\Tray\$($user.Name)\tray*.log"
+                    $foundTrayLogs = Get-ChildItem -Path $trayLogPath -ErrorAction SilentlyContinue
+
+                    if ($foundTrayLogs) {
+                        foreach ($logFile in $foundTrayLogs) {
+                            try {
+                                $destName = "$tempDir\$($user.Name)-$($logFile.Name)"
+                                Copy-Item -Path $logFile.FullName -Destination $destName -ErrorAction Stop
+                                $copyLog += "SUCCESS: $($logFile.FullName) -> $destName"
+                            } catch {
+                                $copyLog += "FAILED: $($logFile.FullName) - $($_.Exception.Message)"
+                            }
                         }
                     }
 
@@ -323,8 +326,8 @@ function Gather-Logs {
                     if ( Get-ItemProperty -Path "HKLM:\SOFTWARE\Jumpcloud\AD Integration Sync Agent" -ErrorAction SilentlyContinue ) {
                         reg export "HKEY_LOCAL_MACHINE\SOFTWARE\JumpCloud\AD Integration Sync Agent" "$tempDir\ADIntegrationSyncAgent.reg" /y
                     }
-                    if (Get-Module -ListAvailable ActiveDirectory) {
-                        Import-Module ActiveDirectory -ErrorAction SilentlyContinue
+                    Import-Module ActiveDirectory -ErrorAction SilentlyContinue
+                    if (Get-Module -Name ActiveDirectory) {
                         $distinguishedName = (Get-ADDomain).DistinguishedName
                         $distinguishedName | Out-File -FilePath (Join-Path $tempDir "AD_DistinguishedName.txt")
                     }
@@ -413,4 +416,4 @@ if ($automate) {
         $selectedSections = $selectedIndexes | ForEach-Object { $sections[$_] } -ErrorAction SilentlyContinue
         Gather-Logs -selections $selectedSections
     }
-}
+} 


### PR DESCRIPTION
Expanded Log Collection:

- Added jc-native-messaging-host.log to log collection.
- Added tray.log (located in C:\ProgramData\JumpCloud\Tray\%Username%\) to log collection.

New Diagnostic Reports:

- Added CredentialProviders.txt: Generates a report of all registered Windows Credential Providers, identifying their status, DLL paths, and specifically highlighting the Last Logged On Provider to assist with login-related troubleshooting.
- Added SystemUsers.log: Exports a list of local system users, including their SIDs, account status, and full Local Group memberships.
- Improved OS Metadata: Replaced basic Windows version logic with a detailed query capturing ProductName, DisplayVersion, CurrentBuild, and UBR for precise environment identification.

All new features are automatically included when running with the -All switch or when selecting JumpCloud Agent Logs.

## Issues
* [<jira-id>](https://jumpcloud.atlassian.net/browse/SUP-1556) - <jira-title>

## What does this solve?
Gathering logs that have changes locations, and logs that weren't be captured previously.
Added Cred Provider export to troubleshoot issues introduced by the unified credential provider.
Added SystemUsers gathering to give us additional info about the local users on the device to help speed up troubleshooting.
Improved Windows OS version details will make identifying the target system's OS easier.

## Is there anything particularly tricky?
No

## How should this be tested?
Run the script locally and via the admin console and confirm the files SystemUsers.log, credentialProviders.txt are being created and are formatted correctly.
Ensure that, if it they exist locally, the following files are present.

- username-jc-native-messaging-host.log
- username-tray.log

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands data collected (local users/groups and credential provider registry details) and adds more per-user filesystem scanning, which could affect runtime and privacy expectations in support bundles.
> 
> **Overview**
> Enhances `scripts/windows/log_collection.ps1` to collect additional troubleshooting artifacts when gathering **JumpCloud Agent Logs** (and via `-All`): per-user tray logs from `C:\ProgramData\JumpCloud\Tray\%Username%\tray*.log`, `jc-native-messaging-host*.log`, plus new diagnostic reports `SystemUsers.log` (local users + group memberships) and `CredentialProviders.txt` (registered credential providers with last-used highlighted).
> 
> Improves OS metadata capture in `WinVersion.txt` (writes `ProductName`, `DisplayVersion`, `CurrentBuild`, `UBR`), tightens AD module detection to `Get-Module -ListAvailable` before importing, and makes small UX/robustness tweaks to prompt formatting and profile path handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb9d4d63ed01b8469563dc8c1a35776ef7a67c1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->