### PR TITLE
Add collection of tray logs from c:\programdata\jumpcloud\tray directory

### DIFF
--- a/scripts/windows/log_collection.ps1
+++ b/scripts/windows/log_collection.ps1
@@ -190,11 +190,12 @@ function Gather-Logs {
                     }
 
                     # Getting JumpCloud Tray logs from user-specific directories
-                    $trayUserLogs = Get-ChildItem -Path "C:\ProgramData\JumpCloud\Tray\" -Recurse -Filter "tray.log" -ErrorAction SilentlyContinue
+                    $trayUserLogs = Get-ChildItem -Path "C:\ProgramData\JumpCloud\Tray\" -Recurse -Filter "*.log" -ErrorAction SilentlyContinue
                     foreach ($log in $trayUserLogs) {
                         try {
                             $parentFolder = Split-Path $log.DirectoryName -Leaf
-                            $destName = "$tempDir\$parentFolder-tray.log"
+                            $logFileName = $log.Name
+                            $destName = "$tempDir\$parentFolder-$logFileName"
                             Copy-Item -Path $log.FullName -Destination $destName -ErrorAction Stop
                             $copyLog += "SUCCESS: $($log.FullName) -> $destName"
                         } catch {

--- a/scripts/windows/log_collection.ps1
+++ b/scripts/windows/log_collection.ps1
@@ -189,6 +189,19 @@ function Gather-Logs {
                         }
                     }
 
+                    # Getting JumpCloud Tray logs from user-specific directories
+                    $trayUserLogs = Get-ChildItem -Path "C:\ProgramData\JumpCloud\Tray\" -Recurse -Filter "tray.log" -ErrorAction SilentlyContinue
+                    foreach ($log in $trayUserLogs) {
+                        try {
+                            $parentFolder = Split-Path $log.DirectoryName -Leaf
+                            $destName = "$tempDir\$parentFolder-tray.log"
+                            Copy-Item -Path $log.FullName -Destination $destName -ErrorAction Stop
+                            $copyLog += "SUCCESS: $($log.FullName) -> $destName"
+                        } catch {
+                            $copyLog += "FAILED: $($log.FullName) - $($_.Exception.Message)"
+                        }
+                    }
+
                     # Getting local security policy export
                     try {
                         secedit /export /cfg "$tempDir\secpol_backup.inf"


### PR DESCRIPTION
## Issues
* [BMAD-XXXX](https://jumpcloud.atlassian.net/browse/BMAD-XXXX) - Update log collection script

## What does this solve?

Expands the log collection script to also gather all log files from the new `c:\programdata\jumpcloud\tray\{username}\` directory in addition to the existing `jumpcloudtray.log` collection from `c:\programdata\jumpcloud\trayapp\`.

## Is there anything particularly tricky?

No. The implementation follows the existing pattern used for collecting `jumpcloudtray.log` files, using the same error handling and logging conventions. Now collects all `*.log` files rather than a single file type.

## How should this be tested?

Run the log collection script and select "JumpCloud Agent Logs" to verify:
1. The script correctly discovers all `*.log` files in `c:\programdata\jumpcloud\tray\{username}\`
2. All log files are successfully copied to the output directory with preserved filenames
3. Both jumpcloudtray.log and any tray directory log files are included in the final zip archive
4. The CopiedFiles.log shows successful collection entries for all log files found

## Screenshots

N/A