### PR TITLE
Update Connect-JCOnline to support staging

### DIFF
--- a/PowerShell/JumpCloud Module/JumpCloud.psm1
+++ b/PowerShell/JumpCloud Module/JumpCloud.psm1
@@ -19,15 +19,21 @@ if ($global:JCConfig['JCEnvironment'].Location) {
 switch ($env:JCEnvironment) {
     'STANDARD' {
         $Global:PSDefaultParameterValues['*-JcSdk*:ApiHost'] = 'api'
+        $PSDefaultParameterValues['*-JcSdk*:ApiHost'] = 'api'
         $Global:PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = 'console'
+        $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = 'console'
     }
     'EU' {
         $Global:PSDefaultParameterValues['*-JcSdk*:ApiHost'] = 'api.eu'
+        $PSDefaultParameterValues['*-JcSdk*:ApiHost'] = 'api.eu'
         $Global:PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = 'console.eu'
+        $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = 'console.eu'
     }
     'STAGING' {
         $Global:PSDefaultParameterValues['*-JcSdk*:ApiHost'] = 'api.stg01'
+        $PSDefaultParameterValues['*-JcSdk*:ApiHost'] = 'api.stg01'
         $Global:PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = 'console.stg01'
+        $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = 'console.stg01'
     }
     default {}
 }

--- a/PowerShell/JumpCloud Module/JumpCloud.psm1
+++ b/PowerShell/JumpCloud Module/JumpCloud.psm1
@@ -25,6 +25,10 @@ switch ($env:JCEnvironment) {
         $Global:PSDefaultParameterValues['*-JcSdk*:ApiHost'] = 'api.eu'
         $Global:PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = 'console.eu'
     }
+    'STAGING' {
+        $Global:PSDefaultParameterValues['*-JcSdk*:ApiHost'] = 'api.stg01'
+        $Global:PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = 'console.stg01'
+    }
     default {}
 }
 # set the JCEnvironment from the settings file if it exists

--- a/PowerShell/JumpCloud Module/Public/Authentication/Connect-JCOnline.ps1
+++ b/PowerShell/JumpCloud Module/Public/Authentication/Connect-JCOnline.ps1
@@ -101,8 +101,10 @@ function Connect-JCOnline () {
                     $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console"
                     $env:JCEnvironment = 'STANDARD'
                 }
-                'staging' {
-                    $global:JCUrlBasePath = "https://console.awsstg.jumpcloud.com"
+                'STAGING' {
+                    $global:JCUrlBasePath = "https://console.stg01.jumpcloud.com"
+                    $PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api.stg.01"
+                    $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console.stg.01"
                 }
                 'EU' {
                     $global:JCUrlBasePath = "https://console.eu.jumpcloud.com"

--- a/PowerShell/JumpCloud Module/Public/Authentication/Connect-JCOnline.ps1
+++ b/PowerShell/JumpCloud Module/Public/Authentication/Connect-JCOnline.ps1
@@ -103,8 +103,8 @@ function Connect-JCOnline () {
                 }
                 'STAGING' {
                     $global:JCUrlBasePath = "https://console.stg01.jumpcloud.com"
-                    $PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api.stg.01"
-                    $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console.stg.01"
+                    $PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api.stg01"
+                    $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console.stg01"
                 }
                 'EU' {
                     $global:JCUrlBasePath = "https://console.eu.jumpcloud.com"

--- a/PowerShell/JumpCloud Module/Public/Authentication/Connect-JCOnline.ps1
+++ b/PowerShell/JumpCloud Module/Public/Authentication/Connect-JCOnline.ps1
@@ -97,26 +97,34 @@ function Connect-JCOnline () {
             switch ($env:JCEnvironment) {
                 'STANDARD' {
                     $global:JCUrlBasePath = "https://console.jumpcloud.com"
+                    $Global:PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api"
                     $PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api"
+                    $Global:PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console"
                     $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console"
                     $env:JCEnvironment = 'STANDARD'
                 }
                 'STAGING' {
                     $global:JCUrlBasePath = "https://console.stg01.jumpcloud.com"
+                    $Global:PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api.stg01"
                     $PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api.stg01"
+                    $Global:PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console.stg01"
                     $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console.stg01"
                     $env:JCEnvironment = 'STAGING'
 
                 }
                 'EU' {
                     $global:JCUrlBasePath = "https://console.eu.jumpcloud.com"
+                    $Global:PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api.eu"
                     $PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api.eu"
+                    $Global:PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console.eu"
                     $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console.eu"
                     $env:JCEnvironment = 'EU'
                 }
                 default {
                     $global:JCUrlBasePath = "https://console.jumpcloud.com"
+                    $Global:PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api"
                     $PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api"
+                    $Global:PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console"
                     $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console"
                     $env:JCEnvironment = 'STANDARD'
                 }

--- a/PowerShell/JumpCloud Module/Public/Authentication/Connect-JCOnline.ps1
+++ b/PowerShell/JumpCloud Module/Public/Authentication/Connect-JCOnline.ps1
@@ -32,7 +32,7 @@ function Connect-JCOnline () {
             'ValueFromPipelineByPropertyName' = $true;
             'ValidateNotNullOrEmpty'          = $true;
             'HelpMessage'                     = 'Enter the region for your JumpCloud organization; "EU" or "STANDARD".';
-            'ValidateSet'                     = ('STANDARD', 'staging', 'EU');
+            'ValidateSet'                     = ('STANDARD', 'STAGING', 'EU');
         }
         # If the $env:JCApiKey is not set then make the JumpCloudApiKey mandatory else set the default value to be the env variable
         if ([System.String]::IsNullOrEmpty($env:JCApiKey)) {

--- a/PowerShell/JumpCloud Module/Public/Authentication/Connect-JCOnline.ps1
+++ b/PowerShell/JumpCloud Module/Public/Authentication/Connect-JCOnline.ps1
@@ -105,6 +105,8 @@ function Connect-JCOnline () {
                     $global:JCUrlBasePath = "https://console.stg01.jumpcloud.com"
                     $PSDefaultParameterValues['*-JcSdk*:ApiHost'] = "api.stg01"
                     $PSDefaultParameterValues['*-JcSdk*:ConsoleHost'] = "console.stg01"
+                    $env:JCEnvironment = 'STAGING'
+
                 }
                 'EU' {
                     $global:JCUrlBasePath = "https://console.eu.jumpcloud.com"


### PR DESCRIPTION
## Issues
* [CUT-5129](https://jumpcloud.atlassian.net/browse/CUT-5129) - Update PowerShell Module Staging Authentication

## What does this solve?

The staging address for the JumpCloud PowerShell module is not correct, this branch simply assigns the correct console URL for staging organizations.

## Is there anything particularly tricky?

NO

## How should this be tested?

Import the module, set the $env:JCEnvironment to `STAGING` and connect using a staging API KEY

## Screenshots

<img width="1017" height="116" alt="Screenshot 2026-05-04 at 9 20 42 AM" src="https://github.com/user-attachments/assets/b4ac5061-badb-4e62-8421-59e44a04479a" />


[CUT-5129]: https://jumpcloud.atlassian.net/browse/CUT-5129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `Connect-JCOnline` and module initialization pick API/console hosts, which can affect authentication and all subsequent SDK calls if environment selection is wrong. Scope is small and isolated to environment routing/hostnames.
> 
> **Overview**
> Adds explicit support for a `STAGING` JumpCloud environment in both module initialization (`JumpCloud.psm1`) and `Connect-JCOnline`, including updated `ValidateSet` casing.
> 
> When `JCEnvironment` is `STAGING`, the module now routes SDK calls to `api.stg01` / `console.stg01` and uses `https://console.stg01.jumpcloud.com` as the base console URL; it also mirrors host defaults into both `$Global:PSDefaultParameterValues` and `$PSDefaultParameterValues` for consistency across environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a93cf91504f1224796b4812b9f42ed44b7b9170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->