### PR TITLE
Account for package changes in recent Debian and Ubuntu releases.

### DIFF
--- a/scripts/linux/log_collection.sh
+++ b/scripts/linux/log_collection.sh
@@ -16,7 +16,7 @@ automate=false   # set to true if running via a JumpCloud command (recommended)
 # do not edit below
 #######
 
-version=1.0.2
+version=1.0.3
 
 ## verify script is running as root.
 if [ $(/usr/bin/id -u) -ne 0 ]
@@ -56,7 +56,7 @@ fi
 datestamp=$(date "+%Y%m%d")
 hostDir="/var/tmp/"
 baseDir="${hostDir}JumpCloudLogCollect"
-mkdir -p {$baseDir/jumpcloudLogs,$baseDir/jumpcloudInfo,$baseDir/systemLogs,$baseDir/systemInfo,$baseDir/userLogs}
+mkdir -p "$baseDir"/{jumpcloudLogs,jumpcloudInfo,systemLogs,systemInfo,userLogs}
 sysId=$(grep -o '"systemKey": *"[^"]*"' /opt/jc/jcagent.conf | grep -o '"[^"]*"$' | sed 's/\"//g')
 
 # Setup Log output for Log Collection Script
@@ -65,19 +65,47 @@ collectionLog() {
     echo "$1" | tee -a "$collectionLogFile"
 }
 
+
 # Also redirect standard errors to the collectionLog file
 exec 2> >(tee -a "$collectionLogFile" >&2)
+
+# Check whether a command is available on this system
+commandExists() {
+    command -v "$1" &> /dev/null
+}
 
 
 ## Collect logs and information
 
+collectionLog "Log Collection Version: $version"
+
 # system information and logs
 collectionLog "Gathering system information."
-hostnamectl 2>&1 > $baseDir/systemInfo/sysInfo.txt
-/opt/jc/bin/jcosqueryi --line "select * from users" > $baseDir/systemInfo/osq_usersList.txt
-last > $baseDir/systemInfo/last.txt
+if commandExists hostnamectl; then
+    hostnamectl >  $baseDir/systemInfo/sysInfo.txt 2>&1 
+else
+    collectionLog "hostnamectl not found; skipping system info collection."
+fi
 
-LOGS=(
+/opt/jc/bin/jcosqueryi --line "select * from users" > $baseDir/systemInfo/osq_usersList.txt
+
+if commandExists wtmpdb; then
+    wtmpdb last > $baseDir/systemInfo/last.txt
+elif commandExists last; then
+    last > $baseDir/systemInfo/last.txt
+else
+    collectionLog "Neither 'wtmpdb' nor 'last' found; skipping login history collection."
+fi
+
+jcOptLogs=(
+    "version.txt"
+    "policyConf.json"
+    "managedUsers.json"
+    "packageUpgradeBackup.json"
+
+)
+
+sysLogs=(
     "syslog"
     "auth.log"
     "dmsg"
@@ -89,14 +117,18 @@ LOGS=(
 )
 
 collectionLog "Collecting system logs"
-for LOG in "${LOGS[@]}"; do
+for LOG in "${sysLogs[@]}"; do
     if [ -f /var/log/${LOG} ]; then
         cp /var/log/$LOG $baseDir/systemLogs/
         collectionLog "Collected /var/log/$LOG"
     fi
 done
 
-iptables -L > $baseDir/systemInfo/firewall_rules.txt
+if commandExists iptables; then
+    iptables -L > $baseDir/systemInfo/firewall_rules.txt
+else
+    collectionLog "iptables not found; skipping firewall rules collection."
+fi
 
 # List JumpCloud services currently running using systemd
 collectionLog "Checking running JumpCloud services"
@@ -113,12 +145,29 @@ ps -aufx | grep -i 'jumpcloud' | grep -v grep >> $jumpcloudServices
 collectionLog "Collecting managed usernames"
 grep -o '\"username\":\"[^\"]*' /opt/jc/managedUsers.json | cut -d '"' -f 4 > $baseDir/jumpcloudInfo/managedUsers.txt
 
-cat /opt/jc/policyConf.json | json_pp > $baseDir/jumpcloudInfo/policyConf.json
+if commandExists json_pp; then
+    cat /opt/jc/policyConf.json | json_pp > $baseDir/jumpcloudInfo/policyConf.json
+else
+    collectionLog "json_pp not found; copying policyConf.json without formatting."
+    cp /opt/jc/policyConf.json $baseDir/jumpcloudInfo/policyConf.json
+fi
 
 collectionLog "Collecting JumpCloud Logs"
 cp /var/log/jc* $baseDir/jumpcloudLogs/
 cp -R /var/log/jumpcloud $baseDir/jumpcloudLogs/
+
 cp /opt/jc/jcagentInstall.log $baseDir/jumpcloudLogs/
+
+for logFile in "${jcOptLogs[@]}"; do
+    if [ -f "/opt/jc/$logFile" ]; then
+        cp "/opt/jc/$logFile" $baseDir/jumpcloudInfo/
+        collectionLog "Collected $logFile"
+    else
+        collectionLog "File $logFile not found; skipping."
+    fi
+done
+
+
 cp /opt/jc/version.txt $baseDir/jumpcloudInfo/
 cp -R /opt/jc/policies $baseDir/jumpcloudInfo/
 
@@ -127,30 +176,34 @@ if [ -f /etc/jcagent-proxy.conf ]; then
     collectionLog "Proxy configuration file detected; collecting /etc/jcagent-proxy.conf"
     cp /etc/jcagent-proxy.conf $baseDir/jumpcloudLogs/
 else
-    collectionLog "No proxy configuration file (/etc/jcagent-proxy.conf) found"
+    collectionLog "No proxy configuration file (/etc/jcagent-proxy.conf) found; skipping."
 fi
 
-# Password Manager logs
-for USER in $(ls /home/); do
-    homeDir="/home/$USER"
-    mkdir $baseDir/userLogs/$USER
+
+# User level logs
+for homeDir in /home/*; do
+    [ -d "$homeDir" ] || continue
+    USER=$(basename "$homeDir")
+
+    mkdir -p $baseDir/userLogs/$USER
 
     # Password Manager logs
-    if [ -d /home/$USER/.config/JumpCloud\ Password\ Manager/logs ]; then
-        cp -R /home/$USER/.config/JumpCloud\ Password\ Manager/logs $baseDir/userLogs/$USER/PWM
+    if [ -d "$homeDir/.config/JumpCloud Password Manager/logs" ]; then
+        cp -R "$homeDir/.config/JumpCloud Password Manager/logs" $baseDir/userLogs/$USER/PWM
     fi
 
-    if [ -d /home/$USER/.config/JumpCloud\ Password\ Manager/data/daemon/log ]; then
-        cp -R /home/$USER/.config/JumpCloud\ Password\ Manager/data/daemon/log $baseDir/userLogs/$USER/PWM_Daemon
+    if [ -d "$homeDir/.config/JumpCloud Password Manager/data/daemon/log" ]; then
+        cp -R "$homeDir/.config/JumpCloud Password Manager/data/daemon/log" $baseDir/userLogs/$USER/PWM_Daemon
     fi
 
     # Remote Assist logs
-    if [ -d $homeDir/.config/JumpCloud-Remote-Assist/logs ]; then 
-        cp -R $homeDir/.config/JumpCloud-Remote-Assist/logs/* $baseDir/jumpcloudLogs/RemoteAssist
+    if [ -d "$homeDir/.config/JumpCloud-Remote-Assist/logs" ]; then 
+        mkdir -p $baseDir/jumpcloudLogs/RemoteAssist
+        cp -R "$homeDir/.config/JumpCloud-Remote-Assist/logs/"* $baseDir/jumpcloudLogs/RemoteAssist
     fi
 
     # list JumpCloud Device Certificate
-    if command -v certutil &> /dev/null; then
+    if commandExists certutil; then
         jcDeviceCert=$(certutil -d "sql:$homeDir/.pki/nssdb" -L 2>/dev/null | grep "JumpCloud Device Trust Certificate" | sed 's/ \+u,u,u$//' | sed 's/ \+CTu,CTu,CTu$//')
         if [ -n "$jcDeviceCert" ]; then
             certutil -d "sql:$homeDir/.pki/nssdb" -L -n "$jcDeviceCert" > "$baseDir/userLogs/$USER/deviceCert.txt"
@@ -164,6 +217,7 @@ for USER in $(ls /home/); do
     fi
 
 done
+
 
 ## Package up the archive - execute bit for owner appears to be required for readability on macOS
 

--- a/scripts/linux/log_collection.sh
+++ b/scripts/linux/log_collection.sh
@@ -99,7 +99,6 @@ fi
 
 jcOptLogs=(
     "version.txt"
-    "policyConf.json"
     "managedUsers.json"
     "packageUpgradeBackup.json"
 
@@ -168,8 +167,8 @@ for logFile in "${jcOptLogs[@]}"; do
 done
 
 
-cp /opt/jc/version.txt $baseDir/jumpcloudInfo/
 cp -R /opt/jc/policies $baseDir/jumpcloudInfo/
+
 
 ## gather proxy configuration if present
 if [ -f /etc/jcagent-proxy.conf ]; then


### PR DESCRIPTION
This update to the log collection script primarily accounts for package changes in recent Debian and Ubuntu releases.

Have added a **commandExists** function for command checks, as package installs vary between distros and releases.

Additionally, have updated other checks and loops within the script to improve reliability and ensure relevant logs are collected from the device.

## Issues
* [SUP-1712](https://jumpcloud.atlassian.net/browse/SUP-1712) - Linux - Log Collection Script: last command check

## What does this solve?

Ensure a successful / clean exit Log collection from JC-supported Linux distros 

## Is there anything particularly tricky?
N/A

## How should this be tested?
Run the Linux Log Collection script on any supported Linux distro.

## Screenshots
<img width="774" height="547" alt="Screenshot 2026-07-31 at 11 44 33" src="https://github.com/user-attachments/assets/e13c2186-ab9e-476a-8c83-079c5a71f7f3" />


[SUP-1712]: https://jumpcloud.atlassian.net/browse/SUP-1712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Support-only diagnostic script changes with no auth or agent behavior impact; main risk is omitting a log slice when a command is missing, which is logged explicitly.
> 
> **Overview**
> Bumps **`scripts/linux/log_collection.sh`** to **1.0.3** and makes collection steps **optional when tools or files are missing**, so the script can finish cleanly on varied JumpCloud-supported Linux releases.
> 
> Adds a **`commandExists`** helper and uses it (and similar guards) for **`hostnamectl`**, login history (**`wtmpdb last`** with fallback to **`last`**), **`iptables`**, **`json_pp`**, and **`certutil`**. Optional **`/opt/jc`** artifacts are copied via a **`jcOptLogs`** loop with per-file skip logging. **User home iteration**, **`mkdir`**, and Remote Assist copy paths are quoted and use **`mkdir -p`** where needed; **`policyConf.json`** falls back to a plain copy when **`json_pp`** is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b7e3e10f52dc4f67a4fa66684bd86a27cfe5b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->